### PR TITLE
Fixed error: 'O_BINARY' was not declared in this scope

### DIFF
--- a/src/base/file_handle.cpp
+++ b/src/base/file_handle.cpp
@@ -21,6 +21,11 @@
 #include <fcntl.h>
 #endif
 
+#ifndef O_BINARY
+#define O_BINARY  0
+#define O_TEXT    0
+#endif
+
 using namespace std;
 
 namespace base {


### PR DESCRIPTION
as described in #461.
