### PR TITLE
Patch for timeline

### DIFF
--- a/src/app/ui/editor/editor.cpp
+++ b/src/app/ui/editor/editor.cpp
@@ -38,6 +38,7 @@
 #include "app/ui/main_window.h"
 #include "app/ui/skin/skin_theme.h"
 #include "app/ui/status_bar.h"
+#include "app/ui/timeline.h"
 #include "app/ui/toolbar.h"
 #include "app/ui_context.h"
 #include "app/util/boundary.h"
@@ -253,8 +254,9 @@ void Editor::setLayer(const Layer* layer)
   m_observers.notifyBeforeLayerChanged(this);
   m_layer = const_cast<Layer*>(layer);
   m_observers.notifyAfterLayerChanged(this);
-
-  updateStatusBar();
+  
+  if(App::instance()->getMainWindow()->getTimeline()->getState() != Timeline::STATE_SELECTING_CELS)
+    updateStatusBar();
 }
 
 void Editor::setFrame(frame_t frame)
@@ -265,7 +267,9 @@ void Editor::setFrame(frame_t frame)
     m_observers.notifyAfterFrameChanged(this);
 
     invalidate();
-    updateStatusBar();
+    
+    if(App::instance()->getMainWindow()->getTimeline()->getState() != Timeline::STATE_SELECTING_CELS)
+      updateStatusBar();
   }
 }
 

--- a/src/app/ui/timeline.cpp
+++ b/src/app/ui/timeline.cpp
@@ -390,6 +390,12 @@ bool Timeline::onProcessMessage(Message* msg)
           bool selectCel = (mouseMsg->left()
             || !isLayerActive(m_clk_layer)
             || !isFrameActive(m_clk_frame));
+            
+          if (selectCel) {
+            m_state = STATE_SELECTING_CELS;
+            m_range.startRange(m_clk_layer, m_clk_frame, Range::kCels);
+          }
+            
           frame_t old_frame = m_frame;
 
           // Select the new clicked-part.
@@ -403,10 +409,6 @@ bool Timeline::onProcessMessage(Message* msg)
           // Change the scroll to show the new selected cel.
           showCel(m_clk_layer, m_frame);
 
-          if (selectCel) {
-            m_state = STATE_SELECTING_CELS;
-            m_range.startRange(m_clk_layer, m_clk_frame, Range::kCels);
-          }
           invalidate();
           break;
         }


### PR DESCRIPTION
Status bar will show the editor info but not the timeline info when you select new frame in timeline.
![image](https://cloud.githubusercontent.com/assets/5674588/6371058/b65df048-bd32-11e4-9258-a08011ee753d.png)
This patch aims to fix this issue.

