### PR TITLE
Small fixes needed to build on Linux

### DIFF
--- a/src/app/pref/option.h
+++ b/src/app/pref/option.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "base/signal.h"
+#include <string>
 
 namespace app {
 

--- a/src/base/recent_items.h
+++ b/src/base/recent_items.h
@@ -29,8 +29,8 @@ public:
   std::size_t size() const { return m_items.size(); }
   std::size_t limit() const { return m_limit; }
 
-  template<typename T, typename Predicate>
-  void addItem(const T& item, Predicate p) {
+  template<typename T2, typename Predicate>
+  void addItem(const T2& item, Predicate p) {
     iterator it = std::find_if(m_items.begin(), m_items.end(), p);
 
     // If the item already exist in the list...
@@ -50,8 +50,8 @@ public:
     m_items.insert(m_items.begin(), item);
   }
 
-  template<typename T, typename Predicate>
-  void removeItem(const T& item, Predicate p) {
+  template<typename T2, typename Predicate>
+  void removeItem(const T2& item, Predicate p) {
     iterator it = std::find_if(m_items.begin(), m_items.end(), p);
     if (it != m_items.end())
       m_items.erase(it);

--- a/src/doc/frame_tags.h
+++ b/src/doc/frame_tags.h
@@ -12,6 +12,7 @@
 #include "doc/object_id.h"
 
 #include <vector>
+#include <string>
 
 namespace doc {
 


### PR DESCRIPTION
First of all—wonderful piece of software!

In compiling from source on a Linux machine, there were a few small issues—two files missing `#include<string>` and one that failed to compile because of shadowed template names. All this PR does is fix those.

I've confirmed that this builds on my reasonably up-to-date installs of Fedora, Arch Linux, and Void Linux, and also that the current repo clone did not successfully build on any of them before these changes.