### PR TITLE
Added missing cmath header include.

### DIFF
--- a/src/app/ui/animated_widget.h
+++ b/src/app/ui/animated_widget.h
@@ -12,6 +12,8 @@
 #include "base/connection.h"
 #include "ui/timer.h"
 
+#include <cmath>
+
 namespace app {
 
   class AnimatedWidget {


### PR DESCRIPTION
Before this change compilation failed on OSX 10.10.2 with latest toolchain.

```
/Users/msiedlarek/Projects/aseprite/src/./app/ui/animated_widget.h:65:21: error: no member named 'pow' in namespace 'std'; did you mean simply 'pow'?
      return (1.0 - std::pow(1.0 - t, 2));
                    ^~~~~~~~
                    pow
/SDKs/MacOSX10.4u.sdk/usr/include/architecture/i386/math.h:347:15: note: 'pow' declared here
extern double pow ( double, double );
              ^
1 error generated.
```