### PR TITLE
Build fixes

### DIFF
--- a/src/doc/test_context.h
+++ b/src/doc/test_context.h
@@ -36,12 +36,12 @@ namespace doc {
     }
 
     void onAddDocument(Document* doc) override {
-      notifyActiveDocumentChanged(m_activeDoc = doc);
+      this->notifyActiveDocumentChanged(m_activeDoc = doc);
     }
 
     void onRemoveDocument(Document* doc) override {
       if (m_activeDoc == doc)
-        notifyActiveDocumentChanged(m_activeDoc = nullptr);
+        this->notifyActiveDocumentChanged(m_activeDoc = nullptr);
     }
 
   private:

--- a/src/updater/CMakeLists.txt
+++ b/src/updater/CMakeLists.txt
@@ -12,3 +12,4 @@ elseif(APPLE)
 endif()
 
 add_library(updater-lib ${UPDATER_LIB_SOURCES})
+target_link_libraries(updater-lib net-lib)


### PR DESCRIPTION
I needed to make those two changes to get Aseprite master to build on my system (Ubuntu 14.10, gcc 4.9.1).

I am not entirely sure why prefixing calls to `notifyActiveDocumentChanged()` with `this->` was necessary, but this is what gcc error suggested, so who am I to argue :)