### PR TITLE
Do not list hidden files in file lists

### DIFF
--- a/src/app/file_system.cpp
+++ b/src/app/file_system.cpp
@@ -84,6 +84,7 @@ public:
 
   bool isFolder() const;
   bool isBrowsable() const;
+  bool isHidden() const;
 
   std::string getKeyName() const;
   std::string getFileName() const;
@@ -311,6 +312,17 @@ bool FileItem::isBrowsable() const
   ASSERT(this->filename != NOTINITIALIZED);
 
   return is_folder;
+}
+
+bool FileItem::isHidden() const
+{
+  ASSERT(this->displayname != NOTINITIALIZED);
+
+#ifdef _WIN32
+  return false;
+#else
+  return this->displayname[0] == '.';
+#endif
 }
 
 std::string FileItem::getKeyName() const

--- a/src/app/file_system.h
+++ b/src/app/file_system.h
@@ -68,6 +68,7 @@ namespace app {
 
     virtual bool isFolder() const = 0;
     virtual bool isBrowsable() const = 0;
+    virtual bool isHidden() const = 0;
 
     virtual std::string getKeyName() const = 0;
     virtual std::string getFileName() const = 0;

--- a/src/app/ui/file_list.cpp
+++ b/src/app/ui/file_list.cpp
@@ -497,7 +497,9 @@ void FileList::regenerateList()
            it=m_list.begin();
          it!=m_list.end(); ) {
       IFileItem* fileitem = *it;
-      if (!fileitem->isFolder() &&
+      if (fileitem->isHidden())
+        it = m_list.erase(it);
+      else if (!fileitem->isFolder() &&
           !fileitem->hasExtension(m_exts.c_str())) {
         it = m_list.erase(it);
       }


### PR DESCRIPTION
This makes browsing $HOME a lot less cluttered.

In the unlikely event where one needs to go inside an hidden folder, it is still possible to do so by typing its name in the entry at the bottom of the file selector.

I did not provide a WIN32 implementation because a) I don't have a Windows machine and b) I don't think hidden files are as annoying on Windows than they are on Unix systems.