### PR TITLE
Add support for open_folder on Linux

### DIFF
--- a/src/app/launcher.cpp
+++ b/src/app/launcher.cpp
@@ -31,12 +31,8 @@ void open_file(const std::string& file)
 
 void open_folder(const std::string& file)
 {
-  if (base::launcher::support_open_folder()) {
-    if (!base::launcher::open_folder(file))
-      ui::Alert::show("Problem<<Cannot open folder:<<%s||&Close", file.c_str());
-  }
-  else
-    ui::Alert::show("Problem<<This command is not supported on your platform||&Close");
+  if (!base::launcher::open_folder(file))
+    ui::Alert::show("Problem<<Cannot open folder:<<%s||&Close", file.c_str());
 }
 
 } // namespace launcher

--- a/src/base/launcher.cpp
+++ b/src/base/launcher.cpp
@@ -116,17 +116,10 @@ bool open_folder(const std::string& file)
 
 #else
 
-  return false;
+  int ret;
+  ret = system(("xdg-open \"" + file + "\"").c_str());
+  return (ret == 0);
 
-#endif
-}
-
-bool support_open_folder()
-{
-#if defined(_WIN32) || defined(__APPLE__)
-  return true;
-#else
-  return false;
 #endif
 }
 

--- a/src/base/launcher.h
+++ b/src/base/launcher.h
@@ -17,8 +17,6 @@ namespace base {
     bool open_file(const std::string& file);
     bool open_folder(const std::string& file);
 
-    bool support_open_folder();
-
   } // namespace launcher
 } // namespace base
 


### PR DESCRIPTION
Removed base::launcher::support_open_folder() as it would always return true.