### PR TITLE
Sort recovered sessions in the recovery view to show the most recent first

### DIFF
--- a/src/app/crash/session.cpp
+++ b/src/app/crash/session.cpp
@@ -71,6 +71,11 @@ std::string Session::name() const
     return name;
 }
 
+std::string Session::path() const
+{
+  return m_path;
+}
+
 const Session::Backups& Session::backups()
 {
   if (m_backups.empty()) {

--- a/src/app/crash/session.h
+++ b/src/app/crash/session.h
@@ -40,6 +40,7 @@ namespace crash {
     ~Session();
 
     std::string name() const;
+    std::string path() const;
     const Backups& backups();
 
     bool isRunning();

--- a/src/app/ui/data_recovery_view.cpp
+++ b/src/app/ui/data_recovery_view.cpp
@@ -19,6 +19,7 @@
 #include "app/ui/skin/skin_theme.h"
 #include "app/ui/workspace.h"
 #include "base/bind.h"
+#include "base/path.h"
 #include "ui/alert.h"
 #include "ui/button.h"
 #include "ui/entry.h"
@@ -159,7 +160,15 @@ void DataRecoveryView::fillList()
     child->deferDelete();
   }
 
-  for (auto& session : m_dataRecovery->sessions()) {
+  auto sessions = m_dataRecovery->sessions();
+  // Sort sessions to show the most recent one first
+  std::sort(sessions.begin(), sessions.end(),
+    [](const crash::SessionPtr& s1, const crash::SessionPtr& s2) {
+      return base::get_file_name(s1->path()) > base::get_file_name(s2->path());
+    }
+  );
+
+  for (auto& session : sessions) {
     if (session->isEmpty())
       continue;
 


### PR DESCRIPTION
When I open the recovered session view (which I do a bit too often because of a crash in curl-related crash with longjmp...) I am interested in the latest session, therefore listing the most recent session first instead of having to find it in the list is nicer for me.

I considered sorting the session list in app::crash::DataRecovery, but I felt this was a UI concern so it was more appropriate to do the sort before populating the list. Doing it in DataRecovery would avoid the need for adding the `path()` getter to app::crash::Session though. I am happy to redo it that way if you prefer.