### PR TITLE
Fixed undefined reference to symbol 'XGrabPointer' 

### DIFF
--- a/src/she/CMakeLists.txt
+++ b/src/she/CMakeLists.txt
@@ -170,6 +170,7 @@ if(APPLE)
 endif()
 
 add_library(she ${SHE_SOURCES})
+target_link_libraries(she ${PLATFORM_LIBS})
 
 target_link_libraries(she
   gfx-lib


### PR DESCRIPTION
as described in #625. The previous commit linked there made me think this was already fixed in your main tree, but that doesn't seem to be the case. This is essentially the patch from @winterheart but rebased.