### PR TITLE
Show preview correctly when moving multiple cels

### DIFF
--- a/src/app/ui/editor/moving_cel_state.h
+++ b/src/app/ui/editor/moving_cel_state.h
@@ -11,6 +11,10 @@
 
 #include "app/ui/editor/standby_state.h"
 
+#include "doc/cel_list.h"
+
+#include <vector>
+
 namespace doc {
   class Cel;
 }
@@ -30,10 +34,10 @@ namespace app {
     virtual bool requireBrushPreview() override { return false; }
 
   private:
-    Cel* m_cel;
-    gfx::Point m_celStart;
-    gfx::Point m_mouseStart;
-    gfx::Point m_celNew;
+    CelList m_celList;
+    std::vector<gfx::Point> m_celStarts;
+    gfx::Point m_celOffset;
+    gfx::Point m_cursorStart;
     bool m_canceled;
     bool m_maskVisible;
   };


### PR DESCRIPTION
This should fix #731

I've make sure it works when:
0. selecting single cel
1. selecting multiple cels
2. selecting no cel (range is not enabled)
3. selecting single layer/frame
4. selecting multiple layers/frames
5. moving with axis locked
6. the auto-select-layer is on and we select only one cel, then the layer we pointed was selected and moved

The only thing which not very clear to me is the behaviour of item 6. What should moving tool do when auto-select-layer is on and we have multiple cels selected?