### PR TITLE
Repaint animated sprite only when frame changed

### DIFF
--- a/src/app/ui/editor/play_state.cpp
+++ b/src/app/ui/editor/play_state.cpp
@@ -141,10 +141,10 @@ void PlayState::onPlaybackTick()
 
     m_editor->setFrame(frame);
     m_nextFrameTime += getNextFrameTime();
+    m_editor->invalidate();
   }
 
   m_curFrameTick = ui::clock();
-  m_editor->invalidate();
 }
 
 // Before executing any command, we stop the animation


### PR DESCRIPTION
I found CPU bursts crazily while playing animation, and I found this unnecessary repainting.