### PR TITLE
Correct usage of variable arguments

### DIFF
--- a/src/app/log.cpp
+++ b/src/app/log.cpp
@@ -68,6 +68,7 @@ void verbose_log(const char* format, ...)
     fflush(app::log_fileptr);
 
 #ifdef _DEBUG
+    va_start(ap, format);
     vfprintf(stderr, format, ap);
     fflush(stderr);
 #endif


### PR DESCRIPTION
This fix the crash while running aseprite with -v argument. (I only test this on GNU/Linux but I believe this would crash others platforms as well)

We should call va_start() before calling vfprintf() again.