### PR TITLE
Ignore cmake build dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 *.exe.manifest
 *.log
 *.res
+
+# CMake output
+build


### PR DESCRIPTION
Prevent build dir from being tracked in git. Common practice / mentioned within INSTALL.md to ``mkdir build`` and ``cmake ..``.