### PR TITLE
Invalidate editor after background setting changed

### DIFF
--- a/src/app/ui/editor/editor.cpp
+++ b/src/app/ui/editor/editor.cpp
@@ -195,6 +195,7 @@ Editor::Editor(Document* document, EditorFlags flags)
   m_tiledConn = docPref.tiled.AfterChange.connect(base::Bind<void>(&Editor::invalidate, this));
   m_gridConn = docPref.grid.AfterChange.connect(base::Bind<void>(&Editor::invalidate, this));
   m_pixelGridConn = docPref.pixelGrid.AfterChange.connect(base::Bind<void>(&Editor::invalidate, this));
+  m_bgConn = docPref.bg.AfterChange.connect(base::Bind<void>(&Editor::invalidate, this));
   m_onionskinConn = docPref.onionskin.AfterChange.connect(base::Bind<void>(&Editor::invalidate, this));
 
   m_document->addObserver(this);

--- a/src/app/ui/editor/editor.h
+++ b/src/app/ui/editor/editor.h
@@ -296,6 +296,7 @@ namespace app {
     base::ScopedConnection m_tiledConn;
     base::ScopedConnection m_gridConn;
     base::ScopedConnection m_pixelGridConn;
+    base::ScopedConnection m_bgConn;
     base::ScopedConnection m_onionskinConn;
 
     EditorObservers m_observers;


### PR DESCRIPTION
This should fix #898.

Use the same way, `afterChange` signal. as grid settings and onionSkin settings.