### PR TITLE
Improve build instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -55,24 +55,30 @@ the repository clone in a directory called `aseprite-source`):
 
    If you have nmake (MSVC compilers):
 
-        C:\...\aseprite-source\build>cmake .. -G "NMake Makefiles"
+        C:\...\aseprite-source\build>cmake -G "NMake Makefiles" ..
 
    If you have Visual Studio you can generate a solution:
 
-        C:\...\aseprite-source\build>cmake .. -G "Visual Studio 12 2013"
+        C:\...\aseprite-source\build>cmake -G "Visual Studio 12 2013" ..
 
    If you are on Linux:
 
-        /.../aseprite-source/build$ cmake .. -G "Unix Makefiles"
+        /.../aseprite-source/build$ cmake -G "Unix Makefiles" ..
 
    For more information in [CMake wiki](http://www.vtk.org/Wiki/CMake_Generator_Specific_Information).
+   
+   Additionally you can change build settings by passing them on the command line, like so:
 
-3. After you have executed one of the `cmake .. -G <generator>`
+        /.../aseprite-source/build$ cmake -DCMAKE_INSTALL_PREFIX=~/software ..
+
+   or later on with a tool like `ccmake`.
+
+3. After you have executed one of the `cmake -G <generator> ..`
    commands, you have to compile the project executing make, nmake,
    opening the solution, etc.
 
 4. When the project is compiled, you can find the executable file
-   inside `build/bin/aseprite.exe`.
+   inside `build/bin/aseprite.exe`. If you invoked `make install` it will be copied to an appropriate location (e.g. `/usr/local/bin/aseprite` on Linux).
 
 ## Mac OS X details
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -71,7 +71,7 @@ the repository clone in a directory called `aseprite-source`):
 
         /.../aseprite-source/build$ cmake -DCMAKE_INSTALL_PREFIX=~/software ..
 
-   or later on with a tool like `ccmake`.
+   or later on with a tool like [`ccmake`](https://cmake.org/cmake/help/latest/manual/ccmake.1.html) or [`cmake-gui`](https://cmake.org/cmake/help/latest/manual/cmake-gui.1.html).
 
 3. After you have executed one of the `cmake -G <generator> ..`
    commands, you have to compile the project executing make, nmake,


### PR DESCRIPTION
i changed all the commands from `cmake .. <options>` to `cmake <options> ..` - this is the standard order and on BSD systems the C library requires options to precede other arguments (although i don't know if this affects CMake).

also i was confused by the instructions, i thought i have to use `build/bin/aseprite` and shouldn't run `make install`. maybe it's just me but i still clarified that part.