### PR TITLE
OS X: fix clang compile error over non-existent simpleini lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,7 +270,6 @@ endif()
 include_directories(${LIBCURL_INCLUDE_DIR})
 
 # simpleini
-set(SIMPLEINI_LIBRARY simpleini)
 include_directories(${SIMPLEINI_DIR})
 
 ######################################################################

--- a/src/cfg/CMakeLists.txt
+++ b/src/cfg/CMakeLists.txt
@@ -2,6 +2,3 @@
 # Copyright (c) 2014, 2015 David Capello
 
 add_library(cfg-lib cfg.cpp)
-
-target_link_libraries(cfg-lib
-  ${SIMPLEINI_LIBRARY})


### PR DESCRIPTION
I was getting the following build error on OS X 10.11.3:
[ 94%] Linking CXX executable ../bin/aseprite
ld: library not found for -lsimpleini
clang: error: linker command failed with exit code 1 (use -v to see invocation)

Since simpleini appears to only be a header-only library I removed the target_link_libraries command from the CMakeLists.txt. Asesprite now builds fine for me.