### PR TITLE
Added missing includes: stdio.h for rename(2) and limits.h for PATH_MAX

### DIFF
--- a/src/base/fs_unix.h
+++ b/src/base/fs_unix.h
@@ -8,6 +8,8 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <stdio.h>
+#include <limits.h>
 
 #include <cstdlib>
 #include <ctime>


### PR DESCRIPTION
Spotted on FreeBSD 9.2 while compiled with gcc.