### PR TITLE
Fix error when decoding GPL file

### DIFF
--- a/src/doc/file/gpl_file.cpp
+++ b/src/doc/file/gpl_file.cpp
@@ -53,8 +53,11 @@ Palette* load_gpl_file(const char *filename)
     std::istringstream lineIn(line);
     // TODO add support to read the color name
     lineIn >> r >> g >> b;
-    if (lineIn.good())
-      pal->addEntry(rgba(r, g, b, 255));
+
+    if (lineIn.fail())
+        continue;
+
+    pal->addEntry(rgba(r, g, b, 255));
   }
 
   return pal.release();


### PR DESCRIPTION
Color without name are not added to the palette.

`fstream::good()` method should not be used to test stream, use `fstream::fail()` method instead ([reference](http://www.cplusplus.com/reference/ios/ios/good/)).