### PR TITLE
Fixing underlinking for gcc 4.9

### DIFF
--- a/src/she/CMakeLists.txt
+++ b/src/she/CMakeLists.txt
@@ -242,7 +242,8 @@ if(USE_ALLEG4_BACKEND)
   target_link_libraries(she
     ${LOADPNG_LIBRARY}
     ${LIBALLEGRO4_LINK_FLAGS}
-    ${DXGUID_LIBRARIES})
+    ${DXGUID_LIBRARIES}
+    ${X11_LIBRARIES})
 endif()
 
 if(USE_SKIA_BACKEND)


### PR DESCRIPTION
Allegro4 backend uses XGrabPointer() from libX11.
Added ${X11_LIBRARIES} for she to resolve underlinking.