### PR TITLE
Fix compilation on MSVC for 32bit profile.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,14 +25,6 @@ if(MSVC)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /NODEFAULTLIB:LIBCMT")
   endif()
 
-  if (CMAKE_CL_64)
-    # 64 bits
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /MACHINE:X64")
-  else()
-    # Add support for Windows XP with 5.01 subsystem
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /MACHINE:X86 /SUBSYSTEM:WINDOWS,5.01")
-  endif()
-
   add_definitions(-D_SCL_SECURE_NO_WARNINGS)
 endif(MSVC)
 


### PR DESCRIPTION
Option "/SUBSYSTEM:WINDOWS,5.01" cause failing compilation checkings.
It is near to impossible compile current cmake-project on Windows XP,
and since this statement doing nothing else than CMake can do
themself, let's just delete them.

Tested on Windows 10 / MSVC 2015 on 32 and 64 bit profiles. Fixes
issue #1086.