### PR TITLE
Fixed an unnecessary quotation mark in the OSX building instructions.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -165,7 +165,7 @@ the following parameters and then `ninja`:
       -DUSE_ALLEG4_BACKEND=OFF \
       -DUSE_SKIA_BACKEND=ON \
       -DSKIA_DIR=$HOME/deps/skia \
-      -DWITH_HarfBuzz=OFF" \
+      -DWITH_HarfBuzz=OFF \
       -G Ninja \
       ..
     ninja aseprite


### PR DESCRIPTION
In line 168, there was a quotation mark at the end of the line that was causing Bash to expect the user to finish the string, not letting it finish reading the command and compile. It works fine without it, and seems to be a typo.