### PR TITLE
Issue #1134 copy/move existing cels before duplicating

### DIFF
--- a/src/app/commands/cmd_new_frame.cpp
+++ b/src/app/commands/cmd_new_frame.cpp
@@ -124,6 +124,14 @@ void NewFrameCommand::onExecute(Context* context)
           for (LayerIndex layer = layerBegin; layer <= layerEnd; ++layer) {
             Layer* layerPtr = writer.sprite()->indexToLayer(layer);
             if (layerPtr->isImage()) {
+              LayerImage* layerImagePtr = static_cast<LayerImage*>(layerPtr);
+              int celsCount = layerImagePtr->getCelsCount();
+              if (range.frameEnd() < (celsCount-1)) {
+                for (frame_t frame = (celsCount-1); frame > range.frameEnd(); --frame) {
+                  api.moveCel(layerImagePtr, frame, layerImagePtr, frame+(1 + range.frameEnd() - range.frameBegin()));
+                }
+              }
+
               for (frame_t frame = range.frameEnd(); frame >= range.frameBegin(); --frame) {
                 frame_t srcFrame = frame;
                 frame_t dstFrame = frame+range.frames();


### PR DESCRIPTION
Hi, 

Been a loooong time since I did any C or C++ coding, but decided to start learning again. So chose my favorite tools like aseprite, krita and inkscape to start practicing by reading the code.

Yesterday I wanted to duplicate a cel, but it was replacing another existing cel. The issue has been reported in #1134, and this pull request is a first tentative at fixing it :-)

Started learning about aseprite's code base yesterday, so I may have missed something. I'm copying one cel each time, but not sure if that performs well when you have lots of cels. Also still learning about continuous cels.

Thanks for aseprite! And for blogging about C++
Bruno