### PR TITLE
Fix compilation with shared libraries (BUILD_SHARED_LIBS=ON)

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -66,7 +66,7 @@ if(WIN32)
 endif()
 
 add_library(base-lib ${BASE_SOURCES})
-target_link_libraries(base-lib modp_b64)
+target_link_libraries(base-lib modp_b64 ${CMAKE_THREAD_LIBS_INIT})
 
 if(WIN32)
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)

--- a/src/doc/context_tests.cpp
+++ b/src/doc/context_tests.cpp
@@ -87,7 +87,7 @@ TEST(Context, SwitchContext)
   EXPECT_EQ(&ctx2, doc2->context());
 }
 
-int main(int argc, char** argv)
+int app_main(int argc, char** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/src/doc/image_tests.cpp
+++ b/src/doc/image_tests.cpp
@@ -178,7 +178,7 @@ TYPED_TEST(ImageAllTypes, DrawHLine)
   }
 }
 
-int main(int argc, char** argv)
+int app_main(int argc, char** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/src/doc/remap_tests.cpp
+++ b/src/doc/remap_tests.cpp
@@ -215,7 +215,7 @@ TEST(Remap, BetweenPalettesNonInvertible)
   EXPECT_FALSE(map.isInvertible(all));
 }
 
-int main(int argc, char** argv)
+int app_main(int argc, char** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/src/doc/resize_image_tests.cpp
+++ b/src/doc/resize_image_tests.cpp
@@ -90,7 +90,7 @@ TEST(ResizeImage, BilinearInterpRGBType)
 }
 #endif
 
-int main(int argc, char** argv)
+int app_main(int argc, char** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/src/doc/sprite_tests.cpp
+++ b/src/doc/sprite_tests.cpp
@@ -101,7 +101,7 @@ TEST(Sprite, CelsRange)
   EXPECT_EQ(2, i);
 }
 
-int main(int argc, char** argv)
+int app_main(int argc, char** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/src/render/ordered_dither_tests.cpp
+++ b/src/render/ordered_dither_tests.cpp
@@ -57,7 +57,7 @@ TEST(BayerMatrix, CheckD8)
     EXPECT_EQ(expected[i], matrix[i]);
 }
 
-int main(int argc, char** argv)
+int app_main(int argc, char** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/src/render/render_tests.cpp
+++ b/src/render/render_tests.cpp
@@ -214,7 +214,7 @@ TEST(Render, ZoomAndDstBounds)
     0, 0, 0, 0);
 }
 
-int main(int argc, char** argv)
+int app_main(int argc, char** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();


### PR DESCRIPTION
There should be app_main() instead main() as defined in libshe.
Seems, this issue somehow related to #698.

(I know this case is uncommon, but enabling KDE/Qt thumbnailer automatically enables BUILD_SHARED_LIBS to ON).