### PR TITLE
Timeline thumbnails 1

### DIFF
--- a/src/app/thumbnails.cpp
+++ b/src/app/thumbnails.cpp
@@ -23,7 +23,8 @@
 namespace app {
   namespace thumb {
 
-    she::Surface* get_cel_thumbnail(const doc::Cel* cel, const gfx::Rect& bounds)
+    she::Surface* get_cel_thumbnail(const doc::Cel* cel, gfx::Size thumb_size,
+      gfx::Rect cel_image_on_thumb)
     {
       app::Document* document = static_cast<app::Document*>(cel->sprite()->document());
       doc::frame_t frame = cel->frame();
@@ -36,18 +37,19 @@ namespace app {
       doc::algorithm::ResizeMethod resize_method = docPref.thumbnails.quality();
 
       gfx::Size image_size = image->size();
-      gfx::Size thumb_size = bounds.size();
 
-      double zw = thumb_size.w / (double)image_size.w;
-      double zh = thumb_size.h / (double)image_size.h;
-      double zoom = MIN(1, MIN(zw, zh));
+      if (cel_image_on_thumb.isEmpty()) {
+        double zw = thumb_size.w / (double)image_size.w;
+        double zh = thumb_size.h / (double)image_size.h;
+        double zoom = MIN(1, MIN(zw, zh));
 
-      gfx::Rect cel_image_on_thumb(
-        (int)(thumb_size.w * 0.5 - image_size.w  * zoom * 0.5),
-        (int)(thumb_size.h * 0.5 - image_size.h * zoom * 0.5),
-        (int)(image_size.w  * zoom),
-        (int)(image_size.h * zoom)
-      );
+        cel_image_on_thumb = gfx::Rect(
+          (int)(thumb_size.w * 0.5 - image_size.w  * zoom * 0.5),
+          (int)(thumb_size.h * 0.5 - image_size.h * zoom * 0.5),
+          (int)(image_size.w  * zoom),
+          (int)(image_size.h * zoom)
+        );
+      }
 
       const doc::Sprite* sprite = document->sprite();
       base::UniquePtr<doc::Image> thumb_img(doc::Image::create(
@@ -58,7 +60,7 @@ namespace app {
       base::UniquePtr<doc::Image> scale_img;
       const doc::Image* source = image;
 
-      if (zoom != 1) {
+      if (cel_image_on_thumb.w != image_size.w || cel_image_on_thumb.h != image_size.h) {
         scale_img.reset(doc::Image::create(
           image->pixelFormat(), cel_image_on_thumb.w, cel_image_on_thumb.h));
 

--- a/src/app/thumbnails.h
+++ b/src/app/thumbnails.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "gfx/rect.h"
+#include "gfx/size.h"
 
 namespace doc {
   class Cel;
@@ -22,7 +23,8 @@ namespace she {
 namespace app {
   namespace thumb {
 
-    she::Surface* get_cel_thumbnail(const doc::Cel* cel, const gfx::Rect& bounds);
+    she::Surface* get_cel_thumbnail(const doc::Cel* cel, gfx::Size thumb_size,
+      gfx::Rect cel_image_on_thumb = gfx::Rect());
 
   } // thumb
 } // app

--- a/src/app/ui/timeline.cpp
+++ b/src/app/ui/timeline.cpp
@@ -206,6 +206,12 @@ void Timeline::updateUsingEditor(Editor* editor)
 
   site.document()->addObserver(this);
 
+  app::Document* app_document = static_cast<app::Document*>(site.document());
+  DocumentPreferences& docPref = Preferences::instance().document(app_document);
+
+  m_thumbnailsPrefConn = docPref.thumbnails.AfterChange.connect(
+    base::Bind<void>(&Timeline::onThumbnailsPrefChange, this));
+
   // If we are already in the same position as the "editor", we don't
   // need to update the at all timeline.
   if (m_document == site.document() &&
@@ -222,10 +228,6 @@ void Timeline::updateUsingEditor(Editor* editor)
   m_hot.part = PART_NOTHING;
   m_clk.part = PART_NOTHING;
 
-  m_thumbnailsPrefConn.disconnect();
-  m_thumbnailsPrefConn = docPref().thumbnails.AfterChange.connect(
-    base::Bind<void>(&Timeline::onThumbnailsPrefChange, this));
-
   setFocusStop(true);
   regenerateLayers();
   setViewScroll(viewScroll());
@@ -235,6 +237,7 @@ void Timeline::updateUsingEditor(Editor* editor)
 void Timeline::detachDocument()
 {
   if (m_document) {
+    m_thumbnailsPrefConn.disconnect();
     m_document->removeObserver(this);
     m_document = NULL;
   }
@@ -1090,7 +1093,6 @@ void Timeline::onAfterCommandExecution(CommandExecutionEvent& ev)
 void Timeline::onRemoveDocument(doc::Document* document)
 {
   if (document == m_document) {
-    m_thumbnailsPrefConn.disconnect();
     detachDocument();
   }
 }

--- a/src/app/ui/timeline.cpp
+++ b/src/app/ui/timeline.cpp
@@ -1548,7 +1548,7 @@ void Timeline::drawCel(ui::Graphics* g, LayerIndex layerIndex, frame_t frame, Ce
   if (docPref().thumbnails.enabled() && image) {
     gfx::Rect thumb_bounds = gfx::Rect(bounds).offset(1,1).inflate(-1,-1);
 
-    she::Surface* thumb_surf = thumb::get_cel_thumbnail(cel, thumb_bounds);
+    she::Surface* thumb_surf = thumb::get_cel_thumbnail(cel, thumb_bounds.size());
 
     g->drawRgbaSurface(thumb_surf, thumb_bounds.x, thumb_bounds.y);
 
@@ -1635,35 +1635,28 @@ void Timeline::drawCelOverlay(ui::Graphics* g)
   if (!clip)
     return;
 
-  base::UniquePtr<Image> overlay_img(
-    Image::create(image->pixelFormat(),
-                  m_thumbnailsOverlayInner.w,
-                  m_thumbnailsOverlayInner.h));
-
   double scale = (
     m_sprite->width() > m_sprite->height() ?
     m_thumbnailsOverlayInner.w / (double)m_sprite->width() :
     m_thumbnailsOverlayInner.h / (double)m_sprite->height()
   );
 
-  clear_image(overlay_img, 0);
-  algorithm::scale_image(overlay_img, image,
-                         (int)(cel->x() * scale),
-                         (int)(cel->y() * scale),
-                         (int)(image->width() * scale),
-                         (int)(image->height() * scale),
-                         0, 0, image->width(), image->height());
+  gfx::Size overlay_size(
+    m_thumbnailsOverlayInner.w,
+    m_thumbnailsOverlayInner.h
+  );
 
-  she::Surface* overlay_surf = she::instance()->createRgbaSurface(
-    overlay_img->width(),
-    overlay_img->height());
+  gfx::Rect cel_image_on_overlay(
+    (int)(cel->x() * scale),
+    (int)(cel->y() * scale),
+    (int)(image->width() * scale),
+    (int)(image->height() * scale)
+  );
 
-  convert_image_to_surface(overlay_img, m_sprite->palette(m_frame), overlay_surf,
-    0, 0, 0, 0, overlay_img->width(), overlay_img->height());
+  she::Surface* overlay_surf = thumb::get_cel_thumbnail(cel, overlay_size, cel_image_on_overlay);
 
   gfx::Color background = color_utils::color_for_ui(docPref().thumbnails.background());
   gfx::Color border = color_utils::blackandwhite_neg(background);
-  g->fillRect(background, m_thumbnailsOverlayInner);
   g->drawRgbaSurface(overlay_surf,
     m_thumbnailsOverlayInner.x, m_thumbnailsOverlayInner.y);
   g->drawRect(border, m_thumbnailsOverlayOuter);


### PR DESCRIPTION
Continuing #152 and addressing the issues at #1187 and #1208.

For now there are only two commits:

* fixed crash on docPref disconnect at doc remove
* timeline overlay using the thumbs scaler

The next things I could commit:

* connection from the preferences to the conf popup so the cmd keypress would change the checkbox
* improve the quality
   * remove the quality option (hardcode the bilinear scaler)
   * replace the bilinear scaler with a custom box sampling
* provide a better feedback about how the overlay would look with the selected settings
   * separate the preferences of the overlay and the thumbnails
   * connection with the overlay prefs to display it's looks while they the settings are changed 
* thumbnail cache
   * cache structures
   * hooks to cache clear 
