### PR TITLE
Timeline thumbnails 2: removing preferences

### DIFF
--- a/data/pref.xml
+++ b/data/pref.xml
@@ -260,7 +260,6 @@
       <option id="enabled" type="bool" default="false" />
       <option id="overlay_enabled" type="bool" default="false" />
       <option id="overlay_size" type="int" default="5" />
-      <option id="quality" type="doc::algorithm::ResizeMethod" default="doc::algorithm::RESIZE_METHOD_NEAREST_NEIGHBOR" />
       <option id="opacity" type="int" default="255" />
       <option id="background" type="app::Color" default="app::Color::fromRgb(180, 180, 180, 220)" />
     </section>

--- a/data/pref.xml
+++ b/data/pref.xml
@@ -261,7 +261,6 @@
       <option id="overlay_enabled" type="bool" default="false" />
       <option id="overlay_size" type="int" default="5" />
       <option id="opacity" type="int" default="255" />
-      <option id="background" type="app::Color" default="app::Color::fromRgb(180, 180, 180, 220)" />
     </section>
     <section id="onionskin">
       <option id="active" type="bool" default="false" migrate="Onionskin.Enabled" />

--- a/data/widgets/timeline_conf.xml
+++ b/data/widgets/timeline_conf.xml
@@ -12,9 +12,6 @@
     <label text="Size:" />
     <slider min="2" max="10" id="thumb_overlay_size" cell_align="horizontal" width="128" />
 
-    <label text="Quality:" />
-    <combobox id="thumb_quality" expansive="true" cell_hspan="2" />
-
     <label text="Background:" />
     <colorpicker id="thumb_background" expansive="true" cell_hspan="2" />
 

--- a/data/widgets/timeline_conf.xml
+++ b/data/widgets/timeline_conf.xml
@@ -11,10 +11,6 @@
     <check id="thumb_overlay_enabled" text="Overlay"/>
     <label text="Size:" />
     <slider min="2" max="10" id="thumb_overlay_size" cell_align="horizontal" width="128" />
-
-    <label text="Background:" />
-    <colorpicker id="thumb_background" expansive="true" cell_hspan="2" />
-
   </grid>
   <separator cell_hspan="2" text="Onion Skin:" left="true" horizontal="true" />
   <grid columns="2">

--- a/src/app/thumbnails.cpp
+++ b/src/app/thumbnails.cpp
@@ -46,8 +46,8 @@ namespace app {
         cel_image_on_thumb = gfx::Rect(
           (int)(thumb_size.w * 0.5 - image_size.w * zoom * 0.5),
           (int)(thumb_size.h * 0.5 - image_size.h * zoom * 0.5),
-          (int)(image_size.w * zoom),
-          (int)(image_size.h * zoom)
+          MAX(1, (int)(image_size.w * zoom)),
+          MAX(1, (int)(image_size.h * zoom))
         );
       }
 

--- a/src/app/thumbnails.cpp
+++ b/src/app/thumbnails.cpp
@@ -34,7 +34,6 @@ namespace app {
 
       int opacity = docPref.thumbnails.opacity();
       gfx::Color background = color_utils::color_for_ui(docPref.thumbnails.background());
-      doc::algorithm::ResizeMethod resize_method = docPref.thumbnails.quality();
 
       gfx::Size image_size = image->size();
 
@@ -66,7 +65,7 @@ namespace app {
 
         doc::algorithm::resize_image(
           image, scale_img,
-          resize_method,
+          doc::algorithm::ResizeMethod::RESIZE_METHOD_NEAREST_NEIGHBOR,
           sprite->palette(frame),
           sprite->rgbMap(frame),
           sprite->transparentColor());

--- a/src/app/thumbnails.cpp
+++ b/src/app/thumbnails.cpp
@@ -41,12 +41,12 @@ namespace app {
       if (cel_image_on_thumb.isEmpty()) {
         double zw = thumb_size.w / (double)image_size.w;
         double zh = thumb_size.h / (double)image_size.h;
-        double zoom = MIN(1, MIN(zw, zh));
+        double zoom = MIN(1.0, MIN(zw, zh));
 
         cel_image_on_thumb = gfx::Rect(
-          (int)(thumb_size.w * 0.5 - image_size.w  * zoom * 0.5),
+          (int)(thumb_size.w * 0.5 - image_size.w * zoom * 0.5),
           (int)(thumb_size.h * 0.5 - image_size.h * zoom * 0.5),
-          (int)(image_size.w  * zoom),
+          (int)(image_size.w * zoom),
           (int)(image_size.h * zoom)
         );
       }

--- a/src/app/ui/configure_timeline_popup.cpp
+++ b/src/app/ui/configure_timeline_popup.cpp
@@ -63,7 +63,6 @@ ConfigureTimelinePopup::ConfigureTimelinePopup()
   m_box->infront()->Click.connect(base::Bind<void>(&ConfigureTimelinePopup::onPositionChange, this));
 
   m_box->thumbOpacity()->Change.connect(base::Bind<void>(&ConfigureTimelinePopup::onThumbOpacityChange, this));
-  m_box->thumbBackground()->Change.connect(&ConfigureTimelinePopup::onThumbBackgroundChange, this);
   m_box->thumbEnabled()->Click.connect(base::Bind<void>(&ConfigureTimelinePopup::onThumbEnabledChange, this));
   m_box->thumbOverlayEnabled()->Click.connect(base::Bind<void>(&ConfigureTimelinePopup::onThumbOverlayEnabledChange, this));
   m_box->thumbOverlaySize()->Change.connect(base::Bind<void>(&ConfigureTimelinePopup::onThumbOverlaySizeChange, this));
@@ -116,7 +115,6 @@ void ConfigureTimelinePopup::updateWidgetsFromCurrentSettings()
   }
 
   m_box->thumbOpacity()->setValue(docPref.thumbnails.opacity());
-  m_box->thumbBackground()->setColor(docPref.thumbnails.background());
   m_box->thumbEnabled()->setSelected(docPref.thumbnails.enabled());
   m_box->thumbOverlayEnabled()->setSelected(docPref.thumbnails.overlayEnabled());
   m_box->thumbOverlaySize()->setValue(docPref.thumbnails.overlaySize());
@@ -194,11 +192,6 @@ void ConfigureTimelinePopup::onPositionChange()
 void ConfigureTimelinePopup::onThumbOpacityChange()
 {
   docPref().thumbnails.opacity(m_box->thumbOpacity()->getValue());
-}
-
-void ConfigureTimelinePopup::onThumbBackgroundChange(const app::Color& color)
-{
-  docPref().thumbnails.background(color);
 }
 
 void ConfigureTimelinePopup::onThumbEnabledChange()

--- a/src/app/ui/configure_timeline_popup.cpp
+++ b/src/app/ui/configure_timeline_popup.cpp
@@ -67,11 +67,6 @@ ConfigureTimelinePopup::ConfigureTimelinePopup()
   m_box->thumbEnabled()->Click.connect(base::Bind<void>(&ConfigureTimelinePopup::onThumbEnabledChange, this));
   m_box->thumbOverlayEnabled()->Click.connect(base::Bind<void>(&ConfigureTimelinePopup::onThumbOverlayEnabledChange, this));
   m_box->thumbOverlaySize()->Change.connect(base::Bind<void>(&ConfigureTimelinePopup::onThumbOverlaySizeChange, this));
-
-  m_box->thumbQuality()->addItem("Nearest-neighbor");
-  m_box->thumbQuality()->addItem("Bilinear");
-//  m_box->thumbQuality()->addItem("RotSprite");
-  m_box->thumbQuality()->Change.connect(&ConfigureTimelinePopup::onThumbQualityChange, this);
 }
 
 app::Document* ConfigureTimelinePopup::doc()
@@ -117,19 +112,6 @@ void ConfigureTimelinePopup::updateWidgetsFromCurrentSettings()
       break;
     case render::OnionskinPosition::INFRONT:
       m_box->infront()->setSelected(true);
-      break;
-  }
-
-  switch (docPref.thumbnails.quality()) {
-    case doc::algorithm::RESIZE_METHOD_NEAREST_NEIGHBOR:
-      m_box->thumbQuality()->setSelectedItemIndex(0);
-      break;
-    case doc::algorithm::RESIZE_METHOD_BILINEAR:
-      m_box->thumbQuality()->setSelectedItemIndex(1);
-      break;
-    default:
-      docPref.thumbnails.quality(doc::algorithm::RESIZE_METHOD_NEAREST_NEIGHBOR);
-      m_box->thumbQuality()->setSelectedItemIndex(0);
       break;
   }
 
@@ -212,22 +194,6 @@ void ConfigureTimelinePopup::onPositionChange()
 void ConfigureTimelinePopup::onThumbOpacityChange()
 {
   docPref().thumbnails.opacity(m_box->thumbOpacity()->getValue());
-}
-
-void ConfigureTimelinePopup::onThumbQualityChange()
-{
-  switch (m_box->thumbQuality()->getSelectedItemIndex()) {
-    case 0:
-      docPref().thumbnails.quality(doc::algorithm::RESIZE_METHOD_NEAREST_NEIGHBOR);
-      break;
-    case 1:
-      docPref().thumbnails.quality(doc::algorithm::RESIZE_METHOD_BILINEAR);
-      break;
-    default:
-      docPref().thumbnails.quality(doc::algorithm::RESIZE_METHOD_NEAREST_NEIGHBOR);
-      m_box->thumbQuality()->setSelectedItemIndex(0);
-      break;
-  }
 }
 
 void ConfigureTimelinePopup::onThumbBackgroundChange(const app::Color& color)

--- a/src/app/ui/configure_timeline_popup.h
+++ b/src/app/ui/configure_timeline_popup.h
@@ -42,7 +42,6 @@ namespace app {
     void onPositionChange();
 
     void onThumbOpacityChange();
-    void onThumbQualityChange();
     void onThumbBackgroundChange(const app::Color& color);
     void onThumbEnabledChange();
     void onThumbOverlayEnabledChange();

--- a/src/app/ui/configure_timeline_popup.h
+++ b/src/app/ui/configure_timeline_popup.h
@@ -42,7 +42,6 @@ namespace app {
     void onPositionChange();
 
     void onThumbOpacityChange();
-    void onThumbBackgroundChange(const app::Color& color);
     void onThumbEnabledChange();
     void onThumbOverlayEnabledChange();
     void onThumbOverlaySizeChange();

--- a/src/app/ui/timeline.cpp
+++ b/src/app/ui/timeline.cpp
@@ -1638,11 +1638,9 @@ void Timeline::drawCelOverlay(ui::Graphics* g)
 
   she::Surface* overlay_surf = thumb::get_cel_thumbnail(cel, overlay_size, cel_image_on_overlay);
 
-  gfx::Color background = color_utils::color_for_ui(docPref().thumbnails.background());
-  gfx::Color border = color_utils::blackandwhite_neg(background);
   g->drawRgbaSurface(overlay_surf,
     m_thumbnailsOverlayInner.x, m_thumbnailsOverlayInner.y);
-  g->drawRect(border, m_thumbnailsOverlayOuter);
+  g->drawRect(gfx::rgba(0,0,0,255), m_thumbnailsOverlayOuter);
 
   overlay_surf->dispose();
 }


### PR DESCRIPTION
Continuing #152.

I tried to use the `AppRender` to draw it properly, I got entangled on a weird bug that I couldn't pin point yet, I were using a code like this on the thumbnails.cpp:

```cpp
AppRender render;
render.setupBackground(document, image->pixelFormat());
render.setBgCheckedSize(gfx::Size(4,4)); // FIXME hardcoded
render.renderBackground(thumb_img, gfx::Rect(thumb_size), render::Zoom(1, 1));

render.renderImage(
  thumb_img.get(),
  image,
  sprite->palette(frame),
  cel_image_on_thumb.x,
  cel_image_on_thumb.y,
  render::Zoom(cel_image_on_thumb.w, image_size.w),
  opacity, BlendMode::NORMAL);
```

There is at least one design problem using this code, I can't have images that are out of aspect (i.e., force the cel representation on the thumbnail to have at least 1 pixel wide); another problem is that if I use `algorithm::resize_image` I can't use alpha blending; but besides that I am having some other problem that are causing ASSERT failures (on render.cpp: composite_image_scale_down(): `ASSERT(dst_it >= dstBits.begin() && dst_it < dst_end)`), crashes, skews, like the rows of the image are being interpreted with the wrong width:

![downscale-skew](https://cloud.githubusercontent.com/assets/7734/17460665/17d95bdc-5c47-11e6-9869-eaba9d5ded49.png)

I ended up doing did a simple checkered background render, respecting the docPref color.