### PR TITLE
Beta

### DIFF
--- a/data/skins/default/skin.xml
+++ b/data/skins/default/skin.xml
@@ -18,6 +18,7 @@
     <dim id="timeline_outline_width" value="2" />
     <dim id="palette_outline_width" value="3" />
     <dim id="color_slider_height" value="14" />
+    <dim id="timeline_base_size" value="12" />
   </dimensions>
 
   <colors>

--- a/src/app/ui/timeline.cpp
+++ b/src/app/ui/timeline.cpp
@@ -1063,17 +1063,24 @@ bool Timeline::onProcessMessage(Message* msg)
 
         dx += static_cast<MouseMessage*>(msg)->wheelDelta().x;
 
-        if (msg->ctrlPressed())
-          dx = dz * base_size;
-        else
-          dy = dz * base_size;
-
-        if (msg->shiftPressed()) {
-          dx *= frameBoxWidth() / base_size;
-          dy *= layerBoxHeight() / base_size;
+        if (msg->altPressed()) {
+          double next_zoom = m_zoom + (dz < 0 ? -1 : 1);
+          setZoom(next_zoom);
+          invalidate();
         }
+        else {
+          if (msg->ctrlPressed())
+            dx = dz * base_size;
+          else
+            dy = dz * base_size;
 
-        setViewScroll(viewScroll() + gfx::Point(dx, dy));
+          if (msg->shiftPressed()) {
+            dx *= frameBoxWidth() / base_size;
+            dy *= layerBoxHeight() / base_size;
+          }
+
+          setViewScroll(viewScroll() + gfx::Point(dx, dy));
+        }
       }
       break;
 

--- a/src/app/ui/timeline.cpp
+++ b/src/app/ui/timeline.cpp
@@ -1065,23 +1065,27 @@ bool Timeline::onProcessMessage(Message* msg)
 
     case kMouseWheelMessage:
       if (m_document) {
-        int dz = static_cast<MouseMessage*>(msg)->wheelDelta().y;
-        int dx = 0;
-        int dy = 0;
-
-        dx += static_cast<MouseMessage*>(msg)->wheelDelta().x;
+        int base_size = skinTheme()->dimensions.timelineBaseSize();
+        int dz = static_cast<MouseMessage*>(msg)->wheelDelta().y  * base_size;
 
         if (msg->altPressed()) {
-          double next_zoom = m_zoom + (dz < 0 ? 1 : -1);
-          setZoomAndUpdate(next_zoom);
+          if (dz != 0) {
+            double next_zoom = m_zoom + (dz < 0 ? 1 : -1);
+            setZoomAndUpdate(next_zoom);
+          }
         }
         else {
-          int base_size = skinTheme()->dimensions.timelineBaseSize();
+          int dx;
+          int dy;
 
-          if (msg->ctrlPressed())
-            dx = dz * base_size;
-          else
-            dy = dz * base_size;
+          if (msg->ctrlPressed()) {
+            dx = dz;
+            dy = 0;
+          }
+          else {
+            dx = static_cast<MouseMessage*>(msg)->wheelDelta().x  * base_size;
+            dy = dz;
+          }
 
           if (msg->shiftPressed()) {
             dx *= frameBoxWidth() / base_size;

--- a/src/app/ui/timeline.cpp
+++ b/src/app/ui/timeline.cpp
@@ -185,6 +185,12 @@ void Timeline::setZoom(double zoom)
   m_zoom = MID(1.0, zoom, 10.0);
 }
 
+void Timeline::setZoomAndSavePref(double zoom)
+{
+  setZoom(zoom);
+  docPref().thumbnails.zoom(zoom);
+}
+
 void Timeline::onThumbnailsPrefChange()
 {
   setZoom(docPref().thumbnails.zoom());
@@ -1065,7 +1071,7 @@ bool Timeline::onProcessMessage(Message* msg)
 
         if (msg->altPressed()) {
           double next_zoom = m_zoom + (dz < 0 ? -1 : 1);
-          setZoom(next_zoom);
+          setZoomAndSavePref(next_zoom);
           invalidate();
         }
         else {
@@ -1092,7 +1098,7 @@ bool Timeline::onProcessMessage(Message* msg)
       break;
 
     case kTouchMagnifyMessage:
-      setZoom(m_zoom + m_zoom * static_cast<ui::TouchMessage*>(msg)->magnification());
+      setZoomAndSavePref(m_zoom + m_zoom * static_cast<ui::TouchMessage*>(msg)->magnification());
       invalidate();
       break;
   }

--- a/src/app/ui/timeline.cpp
+++ b/src/app/ui/timeline.cpp
@@ -88,6 +88,8 @@ enum {
   PART_FRAME_TAG,
 };
 
+static const int base_size = 12;
+
 struct Timeline::DrawCelData {
   CelIterator begin;
   CelIterator end;
@@ -1062,13 +1064,13 @@ bool Timeline::onProcessMessage(Message* msg)
         dx += static_cast<MouseMessage*>(msg)->wheelDelta().x;
 
         if (msg->ctrlPressed())
-          dx = dz * frameBoxWidth();
+          dx = dz * base_size;
         else
-          dy = dz * layerBoxHeight();
+          dy = dz * base_size;
 
         if (msg->shiftPressed()) {
-          dx *= 3;
-          dy *= 3;
+          dx *= frameBoxWidth() / base_size;
+          dy *= layerBoxHeight() / base_size;
         }
 
         setViewScroll(viewScroll() + gfx::Point(dx, dy));
@@ -3020,22 +3022,22 @@ gfx::Size Timeline::celBoxSize() const
 
 int Timeline::headerBoxWidth() const
 {
-  return int(12 * guiscale());
+  return int(base_size * guiscale());
 }
 
 int Timeline::headerBoxHeight() const
 {
-  return int(12 * guiscale());
+  return int(base_size * guiscale());
 }
 
 int Timeline::layerBoxHeight() const
 {
-  return int(m_zoom*12*guiscale() + (int)(m_zoom > 1) * headerBoxHeight());
+  return int(m_zoom*base_size*guiscale() + (int)(m_zoom > 1) * headerBoxHeight());
 }
 
 int Timeline::frameBoxWidth() const
 {
-  return int(m_zoom*12*guiscale());
+  return int(m_zoom*base_size*guiscale());
 }
 
 int Timeline::outlineWidth() const

--- a/src/app/ui/timeline.cpp
+++ b/src/app/ui/timeline.cpp
@@ -88,8 +88,6 @@ enum {
   PART_FRAME_TAG,
 };
 
-static const int base_size = 12;
-
 struct Timeline::DrawCelData {
   CelIterator begin;
   CelIterator end;
@@ -1078,6 +1076,8 @@ bool Timeline::onProcessMessage(Message* msg)
           setZoomAndUpdate(next_zoom);
         }
         else {
+          int base_size = skinTheme()->dimensions.timelineBaseSize();
+
           if (msg->ctrlPressed())
             dx = dz * base_size;
           else
@@ -3037,22 +3037,22 @@ gfx::Size Timeline::celBoxSize() const
 
 int Timeline::headerBoxWidth() const
 {
-  return int(base_size * guiscale());
+  return int(skinTheme()->dimensions.timelineBaseSize() * guiscale());
 }
 
 int Timeline::headerBoxHeight() const
 {
-  return int(base_size * guiscale());
+  return int(skinTheme()->dimensions.timelineBaseSize() * guiscale());
 }
 
 int Timeline::layerBoxHeight() const
 {
-  return int(m_zoom*base_size*guiscale() + (int)(m_zoom > 1) * headerBoxHeight());
+  return int(m_zoom*skinTheme()->dimensions.timelineBaseSize()*guiscale() + (int)(m_zoom > 1) * headerBoxHeight());
 }
 
 int Timeline::frameBoxWidth() const
 {
-  return int(m_zoom*base_size*guiscale());
+  return int(m_zoom*skinTheme()->dimensions.timelineBaseSize()*guiscale());
 }
 
 int Timeline::outlineWidth() const

--- a/src/app/ui/timeline.cpp
+++ b/src/app/ui/timeline.cpp
@@ -1072,7 +1072,7 @@ bool Timeline::onProcessMessage(Message* msg)
         dx += static_cast<MouseMessage*>(msg)->wheelDelta().x;
 
         if (msg->altPressed()) {
-          double next_zoom = m_zoom + (dz < 0 ? -1 : 1);
+          double next_zoom = m_zoom + (dz < 0 ? 1 : -1);
           setZoomAndUpdate(next_zoom);
         }
         else {

--- a/src/app/ui/timeline.h
+++ b/src/app/ui/timeline.h
@@ -311,7 +311,7 @@ namespace app {
     void drawCelOverlay(ui::Graphics* g);
     void onThumbnailsPrefChange();
     void setZoom(double zoom);
-    void setZoomAndSavePref(double zoom);
+    void setZoomAndUpdate(double zoom);
 
     ui::ScrollBar m_hbar;
     ui::ScrollBar m_vbar;

--- a/src/app/ui/timeline.h
+++ b/src/app/ui/timeline.h
@@ -311,6 +311,7 @@ namespace app {
     void drawCelOverlay(ui::Graphics* g);
     void onThumbnailsPrefChange();
     void setZoom(double zoom);
+    void setZoomAndSavePref(double zoom);
 
     ui::ScrollBar m_hbar;
     ui::ScrollBar m_vbar;


### PR DESCRIPTION
Points from #1271:
- vertical scroll jumps in big chunks when we have a big zoom (e.g. Zoom = 10)
- add zoom with ctrl+mouse wheel (using alt actually, ctrl is used)
- zoom is reset each time after we paint (e.g. on OS X we can change zoom with mouse wheel, after doing that, if we paint, the zoom is reset to the configured zoom level in preferences)
-  when we change zoom with mouse wheel we must update the scroll area
