### PR TITLE
Allow Esc key to close Cel and Layer Properties windows

### DIFF
--- a/src/app/commands/cmd_cel_properties.cpp
+++ b/src/app/commands/cmd_cel_properties.cpp
@@ -126,7 +126,9 @@ private:
 
       case kKeyDownMessage:
         if (opacity()->hasFocus()) {
-          if (static_cast<KeyMessage*>(msg)->scancode() == kKeyEnter) {
+          KeyScancode scancode = static_cast<KeyMessage*>(msg)->scancode();
+          if (scancode == kKeyEnter ||
+              scancode == kKeyEsc) {
             onCommitChange();
             closeWindow(this);
             return true;

--- a/src/app/commands/cmd_layer_properties.cpp
+++ b/src/app/commands/cmd_layer_properties.cpp
@@ -139,7 +139,9 @@ private:
         if (name()->hasFocus() ||
             opacity()->hasFocus() ||
             mode()->hasFocus()) {
-          if (static_cast<KeyMessage*>(msg)->scancode() == kKeyEnter) {
+          KeyScancode scancode = static_cast<KeyMessage*>(msg)->scancode();
+          if (scancode == kKeyEnter ||
+              scancode == kKeyEsc) {
             onCommitChange();
             closeWindow(this);
             return true;


### PR DESCRIPTION
Addresses #964, and does the same for the _Layer Properties_ window.

~~This mostly follows the key handling style used in [menu.cpp](https://github.com/aseprite/aseprite/blob/master/src/ui/menu.cpp#L475-L659).~~