### PR TITLE
Added PCC as PCX variation

### DIFF
--- a/src/docio/detect_format.cpp
+++ b/src/docio/detect_format.cpp
@@ -119,7 +119,8 @@ FileFormat detect_format_by_file_extension(const std::string& filename)
   if (ext == "pal")
     return FileFormat::PAL_PALETTE;
 
-  if (ext == "pcx")
+  if (ext == "pcx" ||
+      ext == "pcc")
     return FileFormat::PCX_IMAGE;
 
   if (ext == "anim")


### PR DESCRIPTION
PCC is old PCX-compatible format, which is still occurs.

See http://www.fileformat.info/format/pcx/egff.htm for reference.