### PR TITLE
Add new color wheel for normal maps

### DIFF
--- a/data/gui.xml
+++ b/data/gui.xml
@@ -925,6 +925,9 @@
       <item command="SetColorSelector" text="RYB Color Wheel">
         <param name="type" value="ryb-wheel" />
       </item>
+      <item command="SetColorSelector" text="Normal Map Color Wheel">
+        <param name="type" value="normal-map-wheel" />
+      </item>
       <separator />
       <item command="LoadPalette" text="L&amp;oad Palette" />
       <item command="SavePalette" text="S&amp;ave Palette" />

--- a/src/app/commands/cmd_set_color_selector.cpp
+++ b/src/app/commands/cmd_set_color_selector.cpp
@@ -55,6 +55,9 @@ void SetColorSelectorCommand::onLoadParams(const Params& params)
   else if (type == "ryb-wheel") {
     m_type = ColorBar::ColorSelector::RYB_WHEEL;
   }
+  else if (type == "normal-map-wheel") {
+    m_type = ColorBar::ColorSelector::NORMAL_MAP_WHEEL;
+  }
 }
 
 bool SetColorSelectorCommand::onChecked(Context* context)
@@ -83,6 +86,9 @@ std::string SetColorSelectorCommand::onGetFriendlyName() const
       break;
     case ColorBar::ColorSelector::RYB_WHEEL:
       result += "RYB Color Wheel";
+      break;
+    case ColorBar::ColorSelector::NORMAL_MAP_WHEEL:
+      result += "Normal Map Color Wheel";
       break;
     default:
       result += "Unknown";

--- a/src/app/ui/color_bar.cpp
+++ b/src/app/ui/color_bar.cpp
@@ -341,6 +341,7 @@ void ColorBar::setColorSelector(ColorSelector selector)
 
     case ColorSelector::RGB_WHEEL:
     case ColorSelector::RYB_WHEEL:
+    case ColorSelector::NORMAL_MAP_WHEEL:
       if (!m_wheel) {
         m_wheel = new ColorWheel;
         m_wheel->setExpansive(true);
@@ -348,10 +349,15 @@ void ColorBar::setColorSelector(ColorSelector selector)
         m_wheel->ColorChange.connect(&ColorBar::onPickSpectrum, this);
         m_selectorPlaceholder.addChild(m_wheel);
       }
-      m_wheel->setColorModel(
-        (m_selector == ColorSelector::RGB_WHEEL ?
-         ColorWheel::ColorModel::RGB:
-         ColorWheel::ColorModel::RYB));
+      if (m_selector == ColorSelector::RGB_WHEEL) {
+        m_wheel->setColorModel(ColorWheel::ColorModel::RGB);
+      }
+      else if (m_selector == ColorSelector::RYB_WHEEL) {
+        m_wheel->setColorModel(ColorWheel::ColorModel::RYB);
+      }
+      else if (m_selector == ColorSelector::NORMAL_MAP_WHEEL) {
+        m_wheel->setColorModel(ColorWheel::ColorModel::NORMAL_MAP);
+      }
       m_wheel->setVisible(true);
       break;
 

--- a/src/app/ui/color_bar.h
+++ b/src/app/ui/color_bar.h
@@ -50,6 +50,7 @@ namespace app {
       SPECTRUM,
       RGB_WHEEL,
       RYB_WHEEL,
+      NORMAL_MAP_WHEEL,
       TINT_SHADE_TONE,
     };
 

--- a/src/app/ui/color_wheel.cpp
+++ b/src/app/ui/color_wheel.cpp
@@ -84,6 +84,22 @@ app::Color ColorWheel::getColorInClientPos(const gfx::Point& pos)
   int v = (pos.y - (m_wheelBounds.y+m_wheelBounds.h/2));
   double d = std::sqrt(u*u + v*v);
 
+  if (m_colorModel == ColorModel::NORMAL_MAP) {
+    float x = float(u) / float(m_wheelBounds.w / 2);
+    float y = -float(v) / float(m_wheelBounds.h / 2);
+    float z = std::sqrt(1 - x*x - y*y);
+    if (z <= 1.f) {
+      return app::Color::fromRgb(
+        int(std::round((x + 1) * 127.5)),
+        int(std::round((y + 1) * 127.5)),
+        int(std::round((z + 1) * 127.5))
+      );
+    }
+    else {
+      return app::Color::fromRgb(128, 128, 255);
+    }
+  }
+
   // Pick from the wheel
   if (d < m_wheelRadius+2*guiscale()) {
     double a = std::atan2(-v, u);
@@ -231,7 +247,7 @@ void ColorWheel::onPaint(ui::PaintEvent& ev)
     }
   }
 
-  if (m_color.getAlpha() > 0) {
+  if (m_color.getAlpha() > 0 && m_colorModel != ColorModel::NORMAL_MAP) {
     int n = getHarmonies();
     int boxsize = MIN(rc.w/10, rc.h/10);
 
@@ -336,16 +352,32 @@ void ColorWheel::onOptions()
   menu.addChild(&tetradic);
   menu.addChild(&square);
 
-  if (isDiscrete()) discrete.setSelected(true);
-  switch (m_harmony) {
-    case Harmony::NONE: none.setSelected(true); break;
-    case Harmony::COMPLEMENTARY: complementary.setSelected(true); break;
-    case Harmony::MONOCHROMATIC: monochromatic.setSelected(true); break;
-    case Harmony::ANALOGOUS: analogous.setSelected(true); break;
-    case Harmony::SPLIT: split.setSelected(true); break;
-    case Harmony::TRIADIC: triadic.setSelected(true); break;
-    case Harmony::TETRADIC: tetradic.setSelected(true); break;
-    case Harmony::SQUARE: square.setSelected(true); break;
+  if (m_colorModel == ColorModel::NORMAL_MAP) {
+    discrete.setSelected(false);
+    discrete.setEnabled(false);
+
+    none.setSelected(true);
+    none.setEnabled(false);
+    complementary.setEnabled(false);
+    monochromatic.setEnabled(false);
+    analogous.setEnabled(false);
+    split.setEnabled(false);
+    triadic.setEnabled(false);
+    tetradic.setEnabled(false);
+    square.setEnabled(false);
+  }
+  else {
+    if (isDiscrete()) discrete.setSelected(true);
+    switch (m_harmony) {
+      case Harmony::NONE: none.setSelected(true); break;
+      case Harmony::COMPLEMENTARY: complementary.setSelected(true); break;
+      case Harmony::MONOCHROMATIC: monochromatic.setSelected(true); break;
+      case Harmony::ANALOGOUS: analogous.setSelected(true); break;
+      case Harmony::SPLIT: split.setSelected(true); break;
+      case Harmony::TRIADIC: triadic.setSelected(true); break;
+      case Harmony::TETRADIC: tetradic.setSelected(true); break;
+      case Harmony::SQUARE: square.setSelected(true); break;
+    }
   }
 
   discrete.Click.connect(base::Bind<void>(&ColorWheel::setDiscrete, this, !isDiscrete()));

--- a/src/app/ui/color_wheel.h
+++ b/src/app/ui/color_wheel.h
@@ -18,6 +18,7 @@ namespace app {
     enum class ColorModel {
       RGB,
       RYB,
+      NORMAL_MAP,
     };
 
     enum class Harmony {


### PR DESCRIPTION
This PR adds a new type of colour wheel for creating/editing tangent-space normal maps (similar to the Angle brush in [SpriteIlluminator](https://www.codeandweb.com/spriteilluminator)).

I realise this is a bit of a niche feature, but I figured I'd open this PR anyway in case this is useful to anyone else.

This could be expanded upon by adding a lighting preview to the preview window, which would allow the user to test out their hand-drawn normal map from within Aseprite rather than having to export it first.

## Screenshot

<img width="864" alt="screen shot 2017-01-03 at 12 48 58" src="https://cloud.githubusercontent.com/assets/657807/21608217/1be2c89e-d1b3-11e6-82a0-3b4bae063bd4.png">