### PR TITLE
Fixed crash upon destroying PreviewEditor

### DIFF
--- a/src/app/ui/document_view.cpp
+++ b/src/app/ui/document_view.cpp
@@ -162,7 +162,7 @@ public:
 
   ~PreviewEditor()
   {
-	  setCustomizationDelegate(NULL);
+	setCustomizationDelegate(NULL);
   }
 
   // EditorCustomizationDelegate implementation

--- a/src/app/ui/document_view.cpp
+++ b/src/app/ui/document_view.cpp
@@ -160,6 +160,11 @@ public:
     setCustomizationDelegate(this);
   }
 
+  ~PreviewEditor()
+  {
+	  setCustomizationDelegate(NULL);
+  }
+
   // EditorCustomizationDelegate implementation
   void dispose() override {
     // Do nothing

--- a/src/app/ui/document_view.cpp
+++ b/src/app/ui/document_view.cpp
@@ -162,7 +162,7 @@ public:
 
   ~PreviewEditor()
   {
-	setCustomizationDelegate(NULL);
+    setCustomizationDelegate(NULL);
   }
 
   // EditorCustomizationDelegate implementation


### PR DESCRIPTION
On my end there was a crash when creating a new file. I investigated it and found out that when destroying PreviewEditor a call to m_customizationDelegate->dispose(); was making aseprite crash.

This is probably because the virtual table is unloaded before dispose is called.

So I added a setCustomizationDelegate(NULL); directly in a new destructor for PreviewEditor which makes the call to dispose correctly before the destructor of Editor is called.