### PR TITLE
clear_rect.cpp: PVS-Studio: CWE-476 NULL Pointer Dereference.

### DIFF
--- a/src/app/cmd/clear_rect.cpp
+++ b/src/app/cmd/clear_rect.cpp
@@ -23,11 +23,14 @@ using namespace doc;
 
 ClearRect::ClearRect(Cel* cel, const gfx::Rect& bounds)
 {
-  app::Document* doc = static_cast<app::Document*>(cel->document());
+  if (!cel)
+    return;
 
-  Image* image = (cel ? cel->image(): NULL);
+  Image* image = cel->image();
   if (!image)
     return;
+
+  app::Document* doc = static_cast<app::Document*>(cel->document());
 
   m_offsetX = bounds.x - cel->x();
   m_offsetY = bounds.y - cel->y();


### PR DESCRIPTION
We have found and fixed a weakness using PVS-Studio tool. PVS-Studio is a static code analyzer for C, C++ and C#: https://www.viva64.com/en/pvs-studio/

We suggests having a look at the emails, sent from @pvs-studio.com.

Analyzer warning: [V595](https://www.viva64.com/en/w/V595/) The 'cel' pointer was utilized before it was verified against nullptr. Check lines: 26, 28. clear_rect.cpp 26
