### PR TITLE
Fix bug when closing Undo History with a keyboard shortcut

### DIFF
--- a/src/app/commands/cmd_undo_history.cpp
+++ b/src/app/commands/cmd_undo_history.cpp
@@ -246,7 +246,7 @@ void UndoHistoryCommand::onExecute(Context* ctx)
     g_window = new UndoHistoryWindow(ctx);
 
   if (g_window->isVisible())
-    g_window->setVisible(false);
+    g_window->closeWindow(nullptr);
   else
     g_window->openWindow();
 }


### PR DESCRIPTION
Closes #1423

Apparently the bug was happening because when the Undo History window was closed using the keyboard shortcut, the message kCloseMessage was never being sent to the window. This is probably not the only cause, but making UndoHistoryCommand close the window instead of just hiding it solves the problem.

I tested it several times, including switching files while the undo history window was open. Everything seems to work as expected.