### PR TITLE
Avoid dirent.d_type since it is not POSIX compatible.

### DIFF
--- a/src/app/file_system.cpp
+++ b/src/app/file_system.cpp
@@ -37,6 +37,7 @@
   #define MYPC_CSLID  "::{20D04FE0-3AEA-1069-A2D8-08002B30309D}"
 #else
   #include <dirent.h>
+  #include <sys/stat.h>
 #endif
 
 //////////////////////////////////////////////////////////////////////
@@ -456,11 +457,15 @@ const FileItemList& FileItem::children()
             child = new FileItem(this);
 
             bool is_folder;
-            if (entry->d_type == DT_LNK) {
+            struct stat fileStat;
+
+            stat(fullfn.c_str(), &fileStat);
+
+            if ((fileStat.st_mode & S_IFMT) == S_IFLNK) {
               is_folder = base::is_directory(fullfn);
             }
             else {
-              is_folder = (entry->d_type == DT_DIR);
+              is_folder = ((fileStat.st_mode & S_IFMT) == S_IFDIR);
             }
 
             child->m_filename = fullfn;


### PR DESCRIPTION
This fixes the empty file dialog bug on XFS/JFS/... from issue #951