### PR TITLE
Update arne32.gpl to v20e5

### DIFF
--- a/data/extensions/arne-palettes/arne32.gpl
+++ b/data/extensions/arne-palettes/arne32.gpl
@@ -3,34 +3,35 @@ GIMP Palette
 # by Arne Niklas Jansson
 # http://androidarts.com/palette/16pal.htm
 #
+  0   0   0	Untitled
+157 157 157	Untitled
+255 255 255	Untitled
 190  38  51	Untitled
-115  41  48	Untitled
-203  92 207	Untitled
 224 111 139	Untitled
-150  75 168	Untitled
-158 115 235	Untitled
- 52  42 151	Untitled
- 36  90 239	Untitled
- 27  38  50	Untitled
- 49 162 242	Untitled
-  0  87 132	Untitled
-105 113 117	Untitled
-178 220 239	Untitled
- 47  72  78	Untitled
- 20 128 126	Untitled
- 39 193 167	Untitled
- 33  92  46	Untitled
- 68 137  26	Untitled
-163 206  39	Untitled
- 71  81  32	Untitled
-188 179  48	Untitled
-247 226 107	Untitled
-238 182  47	Untitled
  73  60  43	Untitled
 164 100  34	Untitled
 235 137  49	Untitled
-247 176 128	Untitled
-218  66   0	Untitled
-255 255 255	Untitled
+247 226 107	Untitled
+ 47  72  78	Untitled
+ 68 137  26	Untitled
+163 206  39	Untitled
+ 27  38  50	Untitled
+  0  87 132	Untitled
+ 49 162 242	Untitled
+178 220 239	Untitled
+ 52  42 151	Untitled
+101 109 113	Untitled
 204 204 204	Untitled
-157 157 157	Untitled
+115  41  48	Untitled
+203  67 167	Untitled
+ 82  79  64	Untitled
+173 157  51	Untitled
+236  71   0	Untitled
+250 180  11	Untitled
+ 17  94  51	Untitled
+ 20 128 126	Untitled
+ 21 194 165	Untitled
+ 34  90 246	Untitled
+153 100 249	Untitled
+247 142 214	Untitled
+244 185 144	Untitled


### PR DESCRIPTION
Fixed missing black, reordered colors according to http://androidarts.com/palette/16pal_v20-Expanded_v5.gif , few RGB values slightly changed to match v5 palette.