### PR TITLE
Don't send a signal when setting a hex color is typed into the popup

### DIFF
--- a/src/app/ui/color_popup.cpp
+++ b/src/app/ui/color_popup.cpp
@@ -384,7 +384,7 @@ void ColorPopup::onColorHexEntryChange(const app::Color& color)
   // is writting in the text field.
   m_disableHexUpdate = true;
 
-  setColorWithSignal(color, ChangeType);
+  setColor(color, ChangeType);
   findBestfitIndex(color);
 
   m_disableHexUpdate = false;


### PR DESCRIPTION
This fixes the #1636 by preventing the color change signal from being sent while the hex color is typed in.