### PR TITLE
Stop mnenomic processing from truncating multibyte characters

### DIFF
--- a/src/ui/widget.cpp
+++ b/src/ui/widget.cpp
@@ -1368,7 +1368,7 @@ void Widget::processMnemonicFromText(int escapeChar)
   if (!hasText())
     return;
 
-  std::string newText;
+  std::wstring newText; // for utf8 support during push_back()
   if (!m_text.empty())
     newText.reserve(m_text.size());
 
@@ -1387,7 +1387,7 @@ void Widget::processMnemonicFromText(int escapeChar)
     newText.push_back(*it);
   }
 
-  setText(newText);
+  setText(base::to_utf8(newText));
 }
 
 bool Widget::isMnemonicPressed(const KeyMessage* keyMsg) const

--- a/src/ui/widget.cpp
+++ b/src/ui/widget.cpp
@@ -1368,7 +1368,7 @@ void Widget::processMnemonicFromText(int escapeChar)
   if (!hasText())
     return;
 
-  std::wstring newText; // for utf8 support during push_back()
+  std::wstring newText; // wstring is used to properly push_back() multibyte chars
   if (!m_text.empty())
     newText.reserve(m_text.size());
 


### PR DESCRIPTION
Addresses #1660 though I'm not sure if it's the cleanest/most obvious way...

`newText.push_back(*it)` used to push each subsequent symbol casted to a `char` even if it was multibyte. This is avoided by initializing `newText` as a `std::wstring` and converting to `std::string` when setting widget text.

Looks like this on my machine now:
![image](https://user-images.githubusercontent.com/9067601/36135864-97978eb0-105b-11e8-81b8-52c8f47826d0.png)
Not sure what might be a good way to make a little sharper. Would an extension to pixel fonts for other character sets be a reasonable idea? (or was this behaviour intentional so that widgets only have ASCII text?)

Thanks for the awesome software by the way :)