### PR TITLE
Fix clickable pivot pos in StandbyState (fix #1608)

### DIFF
--- a/src/app/ui/editor/moving_pixels_state.cpp
+++ b/src/app/ui/editor/moving_pixels_state.cpp
@@ -657,7 +657,12 @@ void MovingPixelsState::dropPixels()
 
 Transformation MovingPixelsState::getTransformation(Editor* editor)
 {
-  return m_pixelsMovement->getTransformation();
+  // m_pixelsMovement can be null in the final onMouseDown(), after we
+  // called dropPixels() and we're just going to the previous state.
+  if (m_pixelsMovement)
+    return m_pixelsMovement->getTransformation();
+  else
+    return StandbyState::getTransformation(editor);
 }
 
 bool MovingPixelsState::isActiveDocument() const

--- a/src/app/ui/editor/standby_state.cpp
+++ b/src/app/ui/editor/standby_state.cpp
@@ -257,7 +257,7 @@ bool StandbyState::onMouseDown(Editor* editor, MouseMessage* msg)
       // Get the handle covered by the mouse.
       HandleType handle = transfHandles->getHandleAtPoint(editor,
         msg->position(),
-        document->getTransformation());
+        getTransformation(editor));
 
       if (handle != NoHandle) {
         int x, y, opacity;


### PR DESCRIPTION
Also reported in https://community.aseprite.org/t/pivot-point-doesnt-recalibrate-when-setting-its-direction/1228