### PR TITLE
Selection of a range in color pallet now scrolls.

### DIFF
--- a/src/app/ui/palette_view.cpp
+++ b/src/app/ui/palette_view.cpp
@@ -538,6 +538,9 @@ void PaletteView::onPaint(ui::PaintEvent& ev)
   if (dragging) {
     dragPicks.resize(m_hot.color+picksCount);
     std::fill(dragPicks.begin()+m_hot.color, dragPicks.end(), true);
+    
+    update_scroll(dragPicks.firstPick());
+    invalidate();
   }
   PalettePicks& picks = (dragging ? dragPicks: m_selectedEntries);
 


### PR DESCRIPTION
Fixes #1796
Simply added an update_scroll call after the mouse dragging is processed.