### PR TITLE
Remove input param in Timeline::getDrawable functions

### DIFF
--- a/src/app/ui/timeline/timeline.cpp
+++ b/src/app/ui/timeline/timeline.cpp
@@ -1491,8 +1491,8 @@ void Timeline::onPaint(ui::PaintEvent& ev)
     layer_t layer, firstLayer, lastLayer;
     frame_t frame, firstFrame, lastFrame;
 
-    getDrawableLayers(g, &firstLayer, &lastLayer);
-    getDrawableFrames(g, &firstFrame, &lastFrame);
+    getDrawableLayers(&firstLayer, &lastLayer);
+    getDrawableFrames(&firstFrame, &lastFrame);
 
     drawTop(g);
 
@@ -1829,7 +1829,7 @@ void Timeline::setCursor(ui::Message* msg, const Hit& hit)
   }
 }
 
-void Timeline::getDrawableLayers(ui::Graphics* g, layer_t* firstLayer, layer_t* lastLayer)
+void Timeline::getDrawableLayers(layer_t* firstLayer, layer_t* lastLayer)
 {
   int hpx = (clientBounds().h - headerBoxHeight() - topHeight());
   layer_t i = this->lastLayer() - ((viewScroll().y+hpx) / layerBoxHeight());
@@ -1845,7 +1845,7 @@ void Timeline::getDrawableLayers(ui::Graphics* g, layer_t* firstLayer, layer_t* 
   *lastLayer = j;
 }
 
-void Timeline::getDrawableFrames(ui::Graphics* g, frame_t* firstFrame, frame_t* lastFrame)
+void Timeline::getDrawableFrames(frame_t* firstFrame, frame_t* lastFrame)
 {
   int availW = (clientBounds().w - m_separator_x);
 

--- a/src/app/ui/timeline/timeline.h
+++ b/src/app/ui/timeline/timeline.h
@@ -251,8 +251,8 @@ namespace app {
     bool allLayersDiscontinuous();
     void detachDocument();
     void setCursor(ui::Message* msg, const Hit& hit);
-    void getDrawableLayers(ui::Graphics* g, layer_t* firstLayer, layer_t* lastLayer);
-    void getDrawableFrames(ui::Graphics* g, frame_t* firstFrame, frame_t* lastFrame);
+    void getDrawableLayers(layer_t* firstLayer, layer_t* lastLayer);
+    void getDrawableFrames(frame_t* firstFrame, frame_t* lastFrame);
     void drawPart(ui::Graphics* g, const gfx::Rect& bounds,
                   const std::string* text,
                   ui::Style* style,


### PR DESCRIPTION
Removed unnecesary input argument in functions getDrawableLayers(...) and getDrawableFrames(...) from timeline.cpp and timeline.h