### PR TITLE
Fix timeline scroll clipping under layer 0

### DIFF
--- a/src/app/ui/timeline/timeline.cpp
+++ b/src/app/ui/timeline/timeline.cpp
@@ -3721,9 +3721,9 @@ void Timeline::setViewScroll(const gfx::Point& pt)
 
   if (newScroll.y != oldScroll.y) {
     gfx::Rect rc;
-    rc |= getPartBounds(Hit(PART_ROW, 0));
-    rc |= getPartBounds(Hit(PART_ROW, lastLayer()));
-    rc.offset(origin());
+    rc = getLayerHeadersBounds();
+    rc.x += bounds().x;
+    rc.y += bounds().y;
     invalidateRect(rc);
   }
 


### PR DESCRIPTION
Fix clipping under layer 0 when we go down with the scroll slider.