### PR TITLE
Fixing bug #1644: Combination of parameters results in jumbled layer …

### DIFF
--- a/src/app/cli/cli_processor.cpp
+++ b/src/app/cli/cli_processor.cpp
@@ -540,7 +540,7 @@ bool CliProcessor::openFile(Context* ctx, CliOpenFile& cof)
         filter_layers(doc->sprite()->allLayers(), cof, filteredLayers);
 
         if (cof.splitLayers) {
-          for (Layer* layer : filteredLayers) {
+          for (Layer* layer : filteredLayers.toAllLayersList()) {
             SelectedLayers oneLayer;
             oneLayer.insert(layer);
 

--- a/src/doc/selected_layers.cpp
+++ b/src/doc/selected_layers.cpp
@@ -58,6 +58,26 @@ bool SelectedLayers::hasSameParent() const
   return true;
 }
 
+LayerList SelectedLayers::toAllLayersList() const
+{
+  LayerList output;
+
+  if (empty())
+    return output;
+
+  ASSERT(*begin());
+  ASSERT((*begin())->sprite());
+
+  for (Layer* layer = (*begin())->sprite()->firstLayer();
+       layer != nullptr;
+       layer = layer->getNext()) {
+    if (contains(layer))
+      output.push_back(layer);
+  }
+
+  return output;
+}
+
 LayerList SelectedLayers::toLayerList() const
 {
   LayerList output;

--- a/src/doc/selected_layers.h
+++ b/src/doc/selected_layers.h
@@ -39,6 +39,7 @@ namespace doc {
     bool contains(Layer* layer) const;
     bool hasSameParent() const;
     LayerList toLayerList() const;
+    LayerList toAllLayersList() const;
 
     void removeChildrenIfParentIsSelected();
     void expandCollapsedGroups();

--- a/src/doc/sprite.cpp
+++ b/src/doc/sprite.cpp
@@ -215,6 +215,14 @@ LayerImage* Sprite::backgroundLayer() const
   return NULL;
 }
 
+Layer* Sprite::firstLayer() const
+{
+  Layer* layer = root()->firstLayer();
+  while (layer->isGroup())
+    layer = static_cast<LayerGroup*>(layer)->firstLayer();
+  return layer;
+}
+
 Layer* Sprite::firstBrowsableLayer() const
 {
   Layer* layer = root()->firstLayer();

--- a/src/doc/sprite.h
+++ b/src/doc/sprite.h
@@ -104,6 +104,7 @@ namespace doc {
     LayerGroup* root() const { return m_root; }
     LayerImage* backgroundLayer() const;
     Layer* firstBrowsableLayer() const;
+    Layer* firstLayer() const;
     layer_t allLayersCount() const;
     bool hasVisibleReferenceLayers() const;
 


### PR DESCRIPTION
…order.

This fix iterates over layers, no matter if are visible or not