### PR TITLE
Add TGA v2.0 footer in TGA type file on export

### DIFF
--- a/src/app/file/tga_format.cpp
+++ b/src/app/file/tga_format.cpp
@@ -463,6 +463,9 @@ bool TgaFormat::onSave(FileOp* fop)
       break;
   }
 
+  const char* tga2_footer = "\0\0\0\0\0\0\0\0TRUEVISION-XFILE.\0";
+  fwrite(tga2_footer, 1, 26, f);
+
   if (ferror(f)) {
     fop->setError("Error writing file.\n");
     return false;


### PR DESCRIPTION
Save exported TGA file as v2.0 TGA file by appending TGA v2.0 footer at the end of the file as recommended by following:

1. http://www.dca.fee.unicamp.br/~martino/disciplinas/ea978/tgaffs.pdf
2. http://netghost.narod.ru/gff/graphics/summary/tga.htm

This was causing issue (https://github.com/bjorn/tiled/issues/2013) when trying to load .TGA file exported from Aseprite into Tiled Map Editor (https://www.mapeditor.org/) because it uses QT library to load images, and QT doesn't support non-TrueVision 2.0 files (https://code.woboq.org/qt5/qtimageformats/src/plugins/imageformats/tga/qtgafile.cpp.html#186)

TGA v2.0 format is backward compatible and it doesn't affect applications that expect original TGA format file.

I have tested the fix myself, it fixes the issue (https://github.com/bjorn/tiled/issues/2013) and everything else is working as expected.