### PR TITLE
Add key mapping commands for symmetry

### DIFF
--- a/data/gui.xml
+++ b/data/gui.xml
@@ -473,6 +473,12 @@
       <key command="ChangeBrush">
         <param name="change" value="decrement-angle" />
       </key>
+      <key command="SymmetryMode">
+        <param name="orientation" value="vertical" />
+      </key>
+      <key command="SymmetryMode">
+        <param name="orientation" value="horizontal" />
+      </key>
     </commands>
 
     <!-- Keyboard shortcuts to select tools -->

--- a/data/strings/en.ini
+++ b/data/strings/en.ini
@@ -1342,3 +1342,8 @@ image_preset_photo = Photo
 image_preset_drawing = Drawing
 image_preset_icon = Icon
 image_preset_text = Text
+
+[symmetry]
+toggle = Toggle Symmetry
+toggle_horizontal = Toggle Horizontal Symmetry
+toggle_vertical = Toggle Vertical Symmetry

--- a/src/app/commands/cmd_symmetry_mode.cpp
+++ b/src/app/commands/cmd_symmetry_mode.cpp
@@ -12,7 +12,12 @@
 #include "app/commands/command.h"
 #include "app/commands/params.h"
 #include "app/context.h"
+#include "app/doc.h"
+#include "app/i18n/strings.h"
 #include "app/pref/preferences.h"
+#include "app/ui_context.h"
+#include "app/ui/context_bar.h"
+#include "app/modules/gui.h"
 
 namespace app {
 
@@ -22,14 +27,39 @@ public:
   Command* clone() const override { return new SymmetryModeCommand(*this); }
 
 protected:
+  void onLoadParams(const Params& params) override;
   bool onEnabled(Context* context) override;
   bool onChecked(Context* context) override;
   void onExecute(Context* context) override;
+  std::string onGetFriendlyName() const override;
+
+private:
+    app::gen::SymmetryMode m_mode = app::gen::SymmetryMode::NONE;
 };
 
 SymmetryModeCommand::SymmetryModeCommand()
   : Command(CommandId::SymmetryMode(), CmdUIOnlyFlag)
 {
+}
+
+std::string SymmetryModeCommand::onGetFriendlyName() const
+{
+  switch (m_mode) {
+    case app::gen::SymmetryMode::HORIZONTAL:
+      return Strings::symmetry_toggle_horizontal();
+    case app::gen::SymmetryMode::VERTICAL:
+      return Strings::symmetry_toggle_vertical();
+    default:
+      return Strings::symmetry_toggle();
+  }
+}
+
+void SymmetryModeCommand::onLoadParams(const Params& params)
+{
+  std::string mode = params.get("orientation");
+  if (mode == "vertical") m_mode = app::gen::SymmetryMode::VERTICAL;
+  else if (mode == "horizontal") m_mode = app::gen::SymmetryMode::HORIZONTAL;
+  else m_mode = app::gen::SymmetryMode::NONE;
 }
 
 bool SymmetryModeCommand::onEnabled(Context* ctx)
@@ -46,7 +76,18 @@ bool SymmetryModeCommand::onChecked(Context* ctx)
 void SymmetryModeCommand::onExecute(Context* ctx)
 {
   auto& enabled = Preferences::instance().symmetryMode.enabled;
-  enabled(!enabled());
+  if (m_mode == app::gen::SymmetryMode::NONE) {
+    enabled(!enabled());
+  }
+  else {
+    Doc* document = ctx->activeDocument();
+    DocumentPreferences& docPref = Preferences::instance().document(ctx->activeDocument());
+    app::gen::SymmetryMode actual = docPref.symmetry.mode();
+    docPref.symmetry.mode(app::gen::SymmetryMode(int(m_mode) ^ int(actual)));
+    enabled(true);
+    document->notifyGeneralUpdate();
+    App::instance()->contextBar()->updateForActiveTool();
+  }
 }
 
 Command* CommandFactory::createSymmetryModeCommand()


### PR DESCRIPTION
Now it is possible to associate symmetry with a selected shortcut.