### PR TITLE
Add support for ACT palettes (#1501)

### DIFF
--- a/src/app/file/palette_file.cpp
+++ b/src/app/file/palette_file.cpp
@@ -18,6 +18,7 @@
 #include "base/string.h"
 #include "dio/detect_format.h"
 #include "doc/cel.h"
+#include "doc/file/act_file.h"
 #include "doc/file/col_file.h"
 #include "doc/file/gpl_file.h"
 #include "doc/file/hex_file.h"
@@ -33,7 +34,7 @@ namespace app {
 
 using namespace doc;
 
-static const char* palExts[] = { "col", "gpl", "hex", "pal" };
+static const char* palExts[] = { "act", "col", "gpl", "hex", "pal" };
 
 base::paths get_readable_palette_extensions()
 {
@@ -57,6 +58,10 @@ Palette* load_palette(const char* filename)
   Palette* pal = nullptr;
 
   switch (dioFormat) {
+
+    case dio::FileFormat::ACT_PALETTE:
+      pal = doc::file::load_act_file(filename);
+      break;
 
     case dio::FileFormat::COL_PALETTE:
       pal = doc::file::load_col_file(filename);
@@ -115,6 +120,10 @@ bool save_palette(const char* filename, const Palette* pal, int columns)
   bool success = false;
 
   switch (dioFormat) {
+
+    case dio::FileFormat::ACT_PALETTE:
+      success = doc::file::save_act_file(pal, filename);
+      break;
 
     case dio::FileFormat::COL_PALETTE:
       success = doc::file::save_col_file(pal, filename);

--- a/src/dio/detect_format.cpp
+++ b/src/dio/detect_format.cpp
@@ -96,6 +96,9 @@ FileFormat detect_format_by_file_extension(const std::string& filename)
       ext == "aseprite")
     return FileFormat::ASE_ANIMATION;
 
+  if (ext == "act")
+    return FileFormat::ACT_PALETTE;
+
   if (ext == "bmp")
     return FileFormat::BMP_IMAGE;
 

--- a/src/dio/file_format.h
+++ b/src/dio/file_format.h
@@ -16,6 +16,7 @@ enum class FileFormat {
 
   ASE_ANIMATION,                // Aseprite File Format
   ASE_PALETTE,                  // Adobe Swatch Exchange
+  ACT_PALETTE,
   BMP_IMAGE,
   COL_PALETTE,
   FLIC_ANIMATION,

--- a/src/doc/CMakeLists.txt
+++ b/src/doc/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(doc-lib
   compressed_image.cpp
   conversion_to_surface.cpp
   document.cpp
+  file/act_file.cpp
   file/col_file.cpp
   file/gpl_file.cpp
   file/hex_file.cpp

--- a/src/doc/file/act_file.cpp
+++ b/src/doc/file/act_file.cpp
@@ -1,0 +1,83 @@
+// Aseprite Document Library
+// Copyright (c) 2001-2018 David Capello
+//
+// This file is released under the terms of the MIT license.
+// Read LICENSE.txt for more information.
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "base/fstream_path.h"
+#include "base/serialization.h"
+#include "doc/palette.h"
+
+#include <cctype>
+#include <fstream>
+#include <memory>
+
+namespace doc {
+namespace file {
+
+using namespace base::serialization::big_endian;
+
+const int ActMaxColors = 256;
+
+Palette* load_act_file(const char *filename)
+{
+  std::ifstream f(FSTREAM_PATH(filename), std::ios::binary);
+  if (f.bad())
+    return nullptr;
+
+  // Each color is a 24-bit RGB value
+  uint8_t rgb[ActMaxColors * 3] = { 0 };
+  f.read(reinterpret_cast<char*>(&rgb), sizeof(rgb));
+
+  int colors = ActMaxColors;
+  // If there's extra bytes, it's the number of colors to use
+  if (!f.eof()) {
+    colors = MIN(read16(f), ActMaxColors);
+  }
+
+  std::unique_ptr<Palette> pal(new Palette(frame_t(0), colors));
+
+  uint8_t *c = rgb;
+  for (int i = 0; i < colors; ++i) {
+    uint8_t r = *(c++);
+    uint8_t g = *(c++);
+    uint8_t b = *(c++);
+
+    pal->setEntry(i, rgba(r, g, b, 255));
+  }
+
+  return pal.release();
+}
+
+bool save_act_file(const Palette *pal, const char *filename)
+{
+  std::ofstream f(FSTREAM_PATH(filename), std::ios::binary);
+  if (f.bad())
+    return false;
+
+  // Need to write 256 colors even if the palette is smaller
+  uint8_t rgb[ActMaxColors * 3] = { 0 };
+  uint8_t *c = rgb;
+
+  int colors = MIN(pal->size(), ActMaxColors);
+  for (int i = 0; i < colors; ++i) {
+    uint32_t col = pal->getEntry(i);
+
+    *(c++) = rgba_getr(col);
+    *(c++) = rgba_getg(col);
+    *(c++) = rgba_getb(col);
+  }
+  f.write(reinterpret_cast<char*>(&rgb), sizeof(rgb));
+
+  write16(f, colors);
+  write16(f, 0);
+
+  return true;
+}
+
+} // namespace file
+} // namespace doc

--- a/src/doc/file/act_file.h
+++ b/src/doc/file/act_file.h
@@ -1,0 +1,23 @@
+// Aseprite Document Library
+// Copyright (c) 2001-2015 David Capello
+//
+// This file is released under the terms of the MIT license.
+// Read LICENSE.txt for more information.
+
+#ifndef DOC_FILE_ACT_FILE_H_INCLUDED
+#define DOC_FILE_ACT_FILE_H_INCLUDED
+#pragma once
+
+namespace doc {
+
+  class Palette;
+
+  namespace file {
+
+    Palette* load_act_file(const char* filename);
+    bool save_act_file(const Palette* pal, const char* filename);
+
+  } // namespace file
+} // namespace doc
+
+#endif


### PR DESCRIPTION
Adds loading/saving Adobe palettes per issue #1501 
ACT palettes only support up to 256 colors so extra colors will be ignored on save.

There was already an [Adobe enum](https://github.com/SupSuper/aseprite/blob/de0f356ed1928d512d55ace55fd95edef7908545/src/dio/file_format.h#L18) in code but it's not used anywhere so might be worth removing to avoid confusion.