### PR TITLE
Fix sheet size extrude export

### DIFF
--- a/src/app/commands/cmd_export_sprite_sheet.cpp
+++ b/src/app/commands/cmd_export_sprite_sheet.cpp
@@ -659,6 +659,7 @@ void ExportSpriteSheetCommand::onExecute(Context* context)
       if (!params.shapePadding.isSet())     params.shapePadding(    docPref.spriteSheet.shapePadding());
       if (!params.innerPadding.isSet())     params.innerPadding(    docPref.spriteSheet.innerPadding());
       if (!params.trim.isSet())             params.trim(            docPref.spriteSheet.trim());
+      if (!params.extrude.isSet())          params.extrude(         docPref.spriteSheet.extrude());
       if (!params.openGenerated.isSet())    params.openGenerated(   docPref.spriteSheet.openGenerated());
       if (!params.layer.isSet())            params.layer(           docPref.spriteSheet.layer());
       if (!params.tag.isSet())              params.tag(             docPref.spriteSheet.frameTag());

--- a/src/app/commands/cmd_export_sprite_sheet.cpp
+++ b/src/app/commands/cmd_export_sprite_sheet.cpp
@@ -118,7 +118,7 @@ namespace {
 
   Fit calculate_sheet_size(Sprite* sprite, int nframes,
                            int columns, int rows,
-                           int borderPadding, int shapePadding, int innerPadding) {
+                           int borderPadding, int shapePadding, int innerPadding, bool extrude) {
     if (columns == 0) {
       rows = MID(1, rows, nframes);
       columns = ((nframes/rows) + ((nframes%rows) > 0 ? 1: 0));
@@ -128,9 +128,15 @@ namespace {
       rows = ((nframes/columns) + ((nframes%columns) > 0 ? 1: 0));
     }
 
+    int extrudeColumns = 0;
+    int extrudeRows = 0;
+    if (extrude) {
+      extrudeColumns = columns*2;
+      extrudeRows = rows*2;
+    }
     return Fit(
-      2*borderPadding + (sprite->width()+2*innerPadding)*columns + (columns-1)*shapePadding,
-      2*borderPadding + (sprite->height()+2*innerPadding)*rows + (rows-1)*shapePadding,
+      2*borderPadding + (sprite->width()+2*innerPadding)*columns + (columns-1)*shapePadding + extrudeColumns,
+      2*borderPadding + (sprite->height()+2*innerPadding)*rows + (rows-1)*shapePadding + extrudeRows,
       columns, rows, 0);
   }
 
@@ -588,7 +594,8 @@ private:
         rowsValue(),
         borderPaddingValue(),
         shapePaddingValue(),
-        innerPaddingValue());
+        innerPaddingValue(),
+        extrudeValue());
     }
 
     columns()->setTextf("%d", fit.columns);
@@ -771,24 +778,14 @@ void ExportSpriteSheetCommand::onExecute(Context* context)
   int sheet_w = 0;
   int sheet_h = 0;
 
-  int extrude_w = 0;
-  int extrude_h = 0;
   switch (type) {
     case app::SpriteSheetType::Horizontal:
       columns = sprite->totalFrames();
       rows = 1;
-      if (extrude) {
-        extrude_w = sprite->totalFrames()*2;
-        extrude_h = 2;
-      }
       break;
     case app::SpriteSheetType::Vertical:
       columns = 1;
       rows = nframes;
-      if (extrude) {
-        extrude_w = 2;
-        extrude_h = sprite->totalFrames()*2;
-      }
       break;
     case app::SpriteSheetType::Rows:
     case app::SpriteSheetType::Columns:
@@ -800,9 +797,9 @@ void ExportSpriteSheetCommand::onExecute(Context* context)
   Fit fit = calculate_sheet_size(
     sprite, nframes,
     columns, rows,
-    borderPadding, shapePadding, innerPadding);
-  if (sheet_w == 0) sheet_w = fit.width + extrude_w;
-  if (sheet_h == 0) sheet_h = fit.height + extrude_h;
+    borderPadding, shapePadding, innerPadding, extrude);
+  if (sheet_w == 0) sheet_w = fit.width ;
+  if (sheet_h == 0) sheet_h = fit.height;
 
   DocExporter exporter;
   if (!filename.empty())

--- a/src/app/commands/cmd_export_sprite_sheet.cpp
+++ b/src/app/commands/cmd_export_sprite_sheet.cpp
@@ -771,14 +771,24 @@ void ExportSpriteSheetCommand::onExecute(Context* context)
   int sheet_w = 0;
   int sheet_h = 0;
 
+  int extrude_w = 0;
+  int extrude_h = 0;
   switch (type) {
     case app::SpriteSheetType::Horizontal:
       columns = sprite->totalFrames();
       rows = 1;
+      if (extrude) {
+        extrude_w = sprite->totalFrames()*2;
+        extrude_h = 2;
+      }
       break;
     case app::SpriteSheetType::Vertical:
       columns = 1;
       rows = nframes;
+      if (extrude) {
+        extrude_w = 2;
+        extrude_h = sprite->totalFrames()*2;
+      }
       break;
     case app::SpriteSheetType::Rows:
     case app::SpriteSheetType::Columns:
@@ -791,8 +801,8 @@ void ExportSpriteSheetCommand::onExecute(Context* context)
     sprite, nframes,
     columns, rows,
     borderPadding, shapePadding, innerPadding);
-  if (sheet_w == 0) sheet_w = fit.width;
-  if (sheet_h == 0) sheet_h = fit.height;
+  if (sheet_w == 0) sheet_w = fit.width + extrude_w;
+  if (sheet_h == 0) sheet_h = fit.height + extrude_h;
 
   DocExporter exporter;
   if (!filename.empty())

--- a/src/app/doc_exporter.cpp
+++ b/src/app/doc_exporter.cpp
@@ -286,7 +286,7 @@ public:
       gfx::Size size = sample.requiredSize();
 
       if (oldSprite) {
-        if (m_type == SpriteSheetType::Columns || m_type == SpriteSheetType::Horizontal) {
+        if (m_type == SpriteSheetType::Columns) {
           // If the user didn't specify a height for the texture, we
           // put each sprite/layer in a different column.
           if (height == 0) {
@@ -331,21 +331,11 @@ public:
       sample.setInTextureBounds(gfx::Rect(framePt, size));
 
       // Next frame position.
-      switch (m_type) {
-        case SpriteSheetType::Columns:
-          framePt.y += size.h + shapePadding;
-          break;
-        case SpriteSheetType::Vertical:
-          framePt.y += shapePadding;
-          break;
-        case SpriteSheetType::Rows:
-          framePt.x += size.w + shapePadding;
-        case SpriteSheetType::Horizontal:
-          framePt.x += shapePadding;
-        default:
-          framePt.x += shapePadding;
-          framePt.y += shapePadding;
-          break;
+      if (m_type == SpriteSheetType::Columns) {
+        framePt.y += size.h + shapePadding;
+      }
+      else {
+        framePt.x += size.w + shapePadding;
       }
 
       rowSize = rowSize.createUnion(size);
@@ -640,7 +630,6 @@ void DocExporter::layoutSamples(Samples& samples)
 gfx::Size DocExporter::calculateSheetSize(const Samples& samples) const
 {
   gfx::Rect fullTextureBounds(0, 0, m_textureWidth, m_textureHeight);
-
   for (const auto& sample : samples) {
     if (sample.isDuplicated() ||
         sample.isEmpty())

--- a/src/app/doc_exporter.cpp
+++ b/src/app/doc_exporter.cpp
@@ -281,13 +281,12 @@ public:
         sample.setInTextureBounds(gfx::Rect(0, 0, 0, 0));
         continue;
       }
-
       const Sprite* sprite = sample.sprite();
       const Layer* layer = sample.layer();
       gfx::Size size = sample.requiredSize();
 
       if (oldSprite) {
-        if (m_type == SpriteSheetType::Columns) {
+        if (m_type == SpriteSheetType::Columns || m_type == SpriteSheetType::Horizontal) {
           // If the user didn't specify a height for the texture, we
           // put each sprite/layer in a different column.
           if (height == 0) {
@@ -332,11 +331,21 @@ public:
       sample.setInTextureBounds(gfx::Rect(framePt, size));
 
       // Next frame position.
-      if (m_type == SpriteSheetType::Columns) {
-        framePt.y += size.h + shapePadding;
-      }
-      else {
-        framePt.x += size.w + shapePadding;
+      switch (m_type) {
+        case SpriteSheetType::Columns:
+          framePt.y += size.h + shapePadding;
+          break;
+        case SpriteSheetType::Vertical:
+          framePt.y += shapePadding;
+          break;
+        case SpriteSheetType::Rows:
+          framePt.x += size.w + shapePadding;
+        case SpriteSheetType::Horizontal:
+          framePt.x += shapePadding;
+        default:
+          framePt.x += shapePadding;
+          framePt.y += shapePadding;
+          break;
       }
 
       rowSize = rowSize.createUnion(size);


### PR DESCRIPTION
It fix the problem of exporting a horizontal spriteSheet when it has a lot of frames and using extruding option.
Example:
![too-many-frames-for-horizontal-sheet](https://user-images.githubusercontent.com/6051497/51716864-dd0a1f00-203e-11e9-8c74-caf79efd1890.png)

