### PR TITLE
Fix app menu may become disabled on macOS

### DIFF
--- a/src/app/app_menus.cpp
+++ b/src/app/app_menus.cpp
@@ -728,6 +728,7 @@ void AppMenus::createNativeMenus()
         UIContext::instance()->executeCommand(cmd);
       }
     };
+    about.validate = [](os::MenuItem* item){ item->setEnabled(true); };
 
     os::MenuItemInfo preferences("Preferences...");
     native = get_native_shortcut_for_command(CommandId::Options());
@@ -738,6 +739,7 @@ void AppMenus::createNativeMenus()
         UIContext::instance()->executeCommand(cmd);
       }
     };
+    preferences.validate = [](os::MenuItem* item){ item->setEnabled(true); };
 
     os::MenuItemInfo hide("Hide " PACKAGE, os::MenuItemInfo::Hide);
     hide.shortcut = os::Shortcut('h', os::kKeyCmdModifier);

--- a/src/app/app_menus.cpp
+++ b/src/app/app_menus.cpp
@@ -728,7 +728,9 @@ void AppMenus::createNativeMenus()
         UIContext::instance()->executeCommand(cmd);
       }
     };
-    about.validate = [](os::MenuItem* item){ item->setEnabled(true); };
+    about.validate = [native](os::MenuItem* item){
+      item->setEnabled(can_call_global_shortcut(&native));
+    };
 
     os::MenuItemInfo preferences("Preferences...");
     native = get_native_shortcut_for_command(CommandId::Options());
@@ -739,7 +741,9 @@ void AppMenus::createNativeMenus()
         UIContext::instance()->executeCommand(cmd);
       }
     };
-    preferences.validate = [](os::MenuItem* item){ item->setEnabled(true); };
+    preferences.validate = [native](os::MenuItem* item){
+      item->setEnabled(can_call_global_shortcut(&native));
+    };
 
     os::MenuItemInfo hide("Hide " PACKAGE, os::MenuItemInfo::Hide);
     hide.shortcut = os::Shortcut('h', os::kKeyCmdModifier);


### PR DESCRIPTION
Hi! I think here is a valid fix for #1974. Please refer to aseprite/laf#7 — both changes need to be applied for the fix.

The reason for the changes in this repo is that according to the automatic validation policy, modal dialogs somehow disable these menu items, and they need to be re-enabled with a `validate` routine. (Btw, I'd love to hear if there is a better approach ^ ^)

Thanks for the effort and time!