### PR TITLE
Add padding support for --sheet-pack

### DIFF
--- a/src/app/doc_exporter.cpp
+++ b/src/app/doc_exporter.cpp
@@ -356,9 +356,7 @@ class DocExporter::BestFitLayoutSamples :
     public DocExporter::LayoutSamples {
 public:
   void layoutSamples(Samples& samples, int borderPadding, int shapePadding, int& width, int& height) override {
-    gfx::PackingRects pr;
-
-    // TODO Add support for shape paddings
+    gfx::PackingRects pr(borderPadding, shapePadding);
 
     for (auto& sample : samples) {
       if (sample.isDuplicated() ||


### PR DESCRIPTION
Combined with aseprite/laf#8, this tries to address #1240. Below is the output with the example attached in that issue.

![player](https://user-images.githubusercontent.com/45892908/55132653-13a70780-515e-11e9-883a-0c09e12f019c.png)

Hope it helps!