### PR TITLE
Fix ScrollingState crash (fix #2115)

### DIFF
--- a/src/app/ui/editor/scrolling_state.h
+++ b/src/app/ui/editor/scrolling_state.h
@@ -24,7 +24,8 @@ namespace app {
     virtual bool onKeyDown(Editor* editor, ui::KeyMessage* msg) override;
     virtual bool onKeyUp(Editor* editor, ui::KeyMessage* msg) override;
     virtual bool onUpdateStatusBar(Editor* editor) override;
-
+    virtual LeaveAction onLeaveState(Editor* editor, EditorState* newState) override { return DiscardState; }
+  
   private:
     gfx::Point m_oldPos;
   };


### PR DESCRIPTION
Before this fix Aseprite was crashing, when we kept holding the mouse middle button down, then pasting and finally pressing undo.