### PR TITLE
Prevent CLI render of hidden layers in group when exporting

### DIFF
--- a/src/app/cli/cli_processor.cpp
+++ b/src/app/cli/cli_processor.cpp
@@ -102,6 +102,16 @@ void filter_layers(const LayerList& layers,
         (!cof.includeLayers.empty() && !filter_layer(layer, layer_path, cof.includeLayers, true)))
       continue;
 
+    if (!cof.includeLayers.empty() && !layer->isVisibleHierarchy()) {
+      bool isIncluded = false;
+      for (const auto& filter : cof.includeLayers) {
+        if (filter == layer->name()) {
+          isIncluded = true;
+        }
+      }
+      if (!isIncluded) continue;
+    }
+
     if (!cof.excludeLayers.empty() &&
         !filter_layer(layer, layer_path, cof.excludeLayers, false))
       continue;


### PR DESCRIPTION
When using the CLI to export a group to a single image file any hidden
child layers in that group are also rendered to the resulting image.

The reason is that `isVisibleHierachy()` is never checked when there
are items in `includeLayers`: as it's assumed the layers are never groups. This
commit checks if the hidden layer was explicitly included (when you want to
render a hidden layer). If not then it is a child of a group, so is not rendered.

I have tested this with many includes and excludes, with groups and
layers and it seems correct: BUT! I do not have a lot of
experience with CPP (I just needed this fix!) so this code might not be canonical.

Resolves #2084