### PR TITLE
Google plus removed due to google+ being discontinued

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ You can ask for help in:
   [Twitter](https://twitter.com/aseprite/),
   [Facebook](https://facebook.com/aseprite/),
   [YouTube](https://www.youtube.com/user/aseprite),
-  [Google+](https://plus.google.com/+AsepriteOrg/posts),
   [IRC](http://webchat.freenode.net/?channels=aseprite),
   [DeviantArt](https://aseprite.deviantart.com/).
 


### PR DESCRIPTION
Google plus removed due to google+ being discontinued
you can take a look on here because I clicked on the Google+ link on the readme
https://plus.google.com/+AsepriteOrg/posts
![image](https://user-images.githubusercontent.com/33847580/63694455-7e7b6e00-c7e4-11e9-83b1-6fd074e4f17b.png)
