### PR TITLE
Fix tile mode glitch with image brushes

### DIFF
--- a/src/app/tools/ink.h
+++ b/src/app/tools/ink.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018  Igara Studio S.A.
+// Copyright (C) 2018, 2020  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This program is distributed under the terms of
@@ -102,6 +102,9 @@ namespace app {
 
       // Called for each point shape.
       virtual void prepareForPointShape(ToolLoop* loop, bool firstPoint, int x, int y) { }
+      virtual void prepareVForPointShape(ToolLoop* loop, int y) { }
+      virtual void prepareUForPointShapeWholeScanline(ToolLoop* loop, int x1) { }
+      virtual void prepareUForPointShapeSlicedScanline(ToolLoop* loop, bool leftSlice, int x1) { }
 
     };
 

--- a/src/app/tools/inks.h
+++ b/src/app/tools/inks.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2019  Igara Studio S.A.
+// Copyright (C) 2018-2020  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -32,6 +32,21 @@ public:
   void prepareForPointShape(ToolLoop* loop, bool firstPoint, int x, int y) override {
     ASSERT(m_proc);
     m_proc->prepareForPointShape(loop, firstPoint, x, y);
+  }
+
+  void prepareVForPointShape(ToolLoop* loop, int y) override {
+    ASSERT(m_proc);
+    m_proc->prepareVForPointShape(loop, y);
+  }
+
+  void prepareUForPointShapeWholeScanline(ToolLoop* loop, int x1) override {
+    ASSERT(m_proc);
+    m_proc->prepareUForPointShapeWholeScanline(loop, x1);
+  }
+
+  void prepareUForPointShapeSlicedScanline(ToolLoop* loop, bool leftSlice, int x1) override {
+    ASSERT(m_proc);
+    m_proc->prepareUForPointShapeSlicedScanline(loop, leftSlice, x1);
   }
 
 protected:

--- a/src/app/tools/point_shapes.h
+++ b/src/app/tools/point_shapes.h
@@ -1,11 +1,13 @@
 // Aseprite
-// Copyright (C) 2019  Igara Studio S.A.
+// Copyright (C) 2019-2020  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
 
 #include "app/util/wrap_point.h"
+
+#include "app/tools/ink.h"
 
 namespace app {
 namespace tools {
@@ -67,13 +69,24 @@ public:
       }
     }
 
+    if (int(loop->getTiledMode()) & int(TiledMode::X_AXIS)) {
+      int wrappedPatternOriginX = wrap_value(m_brush->patternOrigin().x, loop->sprite()->width()) % m_brush->bounds().w;
+      m_brush->setPatternOrigin(gfx::Point(wrappedPatternOriginX, m_brush->patternOrigin().y));
+      x = wrap_value(x, loop->sprite()->width());
+    }
+    if (int(loop->getTiledMode()) & int(TiledMode::Y_AXIS)) {
+      int wrappedPatternOriginY = wrap_value(m_brush->patternOrigin().y, loop->sprite()->height()) % m_brush->bounds().h;
+      m_brush->setPatternOrigin(gfx::Point(m_brush->patternOrigin().x, wrappedPatternOriginY));
+      y = wrap_value(y, loop->sprite()->height());
+    }
+
     loop->getInk()->prepareForPointShape(loop, m_firstPoint, x, y);
 
     for (auto scanline : *m_compressedImage) {
       int u = x+scanline.x;
+      loop->getInk()->prepareVForPointShape(loop, y+scanline.y);
       doInkHline(u, y+scanline.y, u+scanline.w-1, loop);
     }
-
     m_firstPoint = false;
   }
 


### PR DESCRIPTION
This fix solves u,v set calculation when 'image brush' are used.

The bug origin is because we considered the set m_u, m_v as constants.

We have several cases when we are working on X axis:
- Scanline entirely contained in a tile, but OUTSIDE of the reference tile.
- Scanline entirely contained in a tile, but INSIDE of the reference tile.
- The left side of a scanline which was sliced (by the tile limit).
- The right side of a scanline which was sliced (by the tile limit).
Each one has its own m_u, so we need to recalculate it before every loop->getInk()->inkHline(...).

We have to take similar considerations when we are working in the Y axis.
We need recalculate m_v according if 'y+scanline.y' is INSIDE or OUTSIDE of the reference tile, each case has its own m_v.

Additionally, we added (x, y) considerations to negative values in app.useTool function.
Before this fix, the Points argument in useTool could result in negative (x, y) values.
Then point_shades processes were incorrect, when tile mode were on.