### PR TITLE
Fix lld-link error when building with clang on Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,12 @@ if(MSVC)
   # As Skia is compiled with /GL flag (whole program optimization),
   # the linker prefer a /LTCG parameter to improve link times.
   if(LAF_OS_BACKEND STREQUAL "skia")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LTCG")
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fuse-ld=lld -flto=thin")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fuse-ld=lld -flto=thin")
+    else()
+      set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LTCG")
+    endif()
   endif()
 
   add_definitions(-D_SCL_SECURE_NO_WARNINGS)


### PR DESCRIPTION
Under some settings, `lld-link` is the default linker, but doesn't accept `/LTCG` flag.
Use lld when compiling with clang and replace `/LTCG` by  '-flto=thin' optimization.