### PR TITLE
[lua] Add missing Dialog onchange and onrelease events and expand Dialog:modify

### DIFF
--- a/src/app/script/dialog_class.cpp
+++ b/src/app/script/dialog_class.cpp
@@ -502,6 +502,19 @@ int Dialog_entry(lua_State* L)
   }
 
   auto widget = new ui::Entry(4096, text.c_str());
+
+  if (lua_istable(L, 2)) {
+    int type = lua_getfield(L, 2, "onchange");
+    if (type == LUA_TFUNCTION) {
+      Dialog_connect_signal(
+        L, 1, widget->Change,
+        [](lua_State* L){
+          // Do nothing
+        });
+    }
+    lua_pop(L, 1);
+  }
+
   return Dialog_add_widget(L, widget);
 }
 
@@ -520,6 +533,16 @@ int Dialog_number(lua_State* L)
     type = lua_getfield(L, 2, "decimals");
     if (type != LUA_TNIL) {
       widget->setDecimals(lua_tointegerx(L, -1, nullptr));
+    }
+    lua_pop(L, 1);
+
+    type = lua_getfield(L, 2, "onchange");
+    if (type == LUA_TFUNCTION) {
+      Dialog_connect_signal(
+        L, 1, widget->Change,
+        [](lua_State* L){
+          // Do nothing
+        });
     }
     lua_pop(L, 1);
   }
@@ -554,6 +577,29 @@ int Dialog_slider(lua_State* L)
   }
 
   auto widget = new ui::Slider(min, max, value);
+
+  if (lua_istable(L, 2)) {
+    int type = lua_getfield(L, 2, "onchange");
+    if (type == LUA_TFUNCTION) {
+      Dialog_connect_signal(
+        L, 1, widget->Change,
+        [](lua_State* L){
+          // Do nothing
+        });
+    }
+    lua_pop(L, 1);
+
+    type = lua_getfield(L, 2, "onrelease");
+    if (type == LUA_TFUNCTION) {
+      Dialog_connect_signal(
+        L, 1, widget->SliderReleased,
+        [](lua_State* L){
+          // Do nothing
+        });
+    }
+    lua_pop(L, 1);
+  }
+
   return Dialog_add_widget(L, widget);
 }
 
@@ -580,6 +626,16 @@ int Dialog_combobox(lua_State* L)
         if (index >= 0)
           widget->setSelectedItemIndex(index);
       }
+    }
+    lua_pop(L, 1);
+
+    type = lua_getfield(L, 2, "onchange");
+    if (type == LUA_TFUNCTION) {
+      Dialog_connect_signal(
+        L, 1, widget->Change,
+        [](lua_State* L){
+          // Do nothing
+        });
     }
     lua_pop(L, 1);
   }

--- a/src/app/script/dialog_class.cpp
+++ b/src/app/script/dialog_class.cpp
@@ -873,7 +873,82 @@ int Dialog_modify(lua_State* L)
     }
     lua_pop(L, 1);
 
-    // TODO slider value? combobox option(s)? color? colors (shade)?)
+    type = lua_getfield(L, 2, "decimals");
+    if (type != LUA_TNIL) {
+      if (auto expr = dynamic_cast<ExprEntry*>(widget)) {
+        expr->setDecimals(lua_tointegerx(L, -1, nullptr));
+      }
+    }
+    lua_pop(L, 1);
+
+    type = lua_getfield(L, 2, "min");
+    if (type != LUA_TNIL) {
+      if (auto slider = dynamic_cast<ui::Slider*>(widget)) {
+        slider->setRange(lua_tointegerx(L, -1, nullptr), slider->getMaxValue());
+      }
+    }
+    lua_pop(L, 1);
+
+    type = lua_getfield(L, 2, "max");
+    if (type != LUA_TNIL) {
+      if (auto slider = dynamic_cast<ui::Slider*>(widget)) {
+        slider->setRange(slider->getMinValue(), lua_tointegerx(L, -1, nullptr));
+      }
+    }
+    lua_pop(L, 1);
+
+    type = lua_getfield(L, 2, "value");
+    if (type != LUA_TNIL) {
+      if (auto slider = dynamic_cast<ui::Slider*>(widget)) {
+        slider->setValue(lua_tointegerx(L, -1, nullptr));
+      }
+    }
+    lua_pop(L, 1);
+
+    type = lua_getfield(L, 2, "option");
+    if (auto p = lua_tostring(L, -1)) {
+      if (auto combobox = dynamic_cast<ui::ComboBox*>(widget)) {
+        int index = combobox->findItemIndex(p);
+        if (index >= 0)
+          combobox->setSelectedItemIndex(index);
+      }
+    }
+    lua_pop(L, 1);
+
+    type = lua_getfield(L, 2, "color");
+    if (type != LUA_TNIL) {
+      if (auto colorButton = dynamic_cast<ColorButton*>(widget)) {
+        colorButton->setColor(convert_args_into_color(L, -1));
+      }
+    }
+    lua_pop(L, 1);
+
+    type = lua_getfield(L, 2, "colors");
+    if (type != LUA_TNIL) {
+      if (auto colorShade = dynamic_cast<ColorShades*>(widget)) {
+        Shade shade;
+        if (lua_istable(L, -1)) {
+          lua_pushnil(L);
+          while (lua_next(L, -2) != 0) {
+            app::Color color = convert_args_into_color(L, -1);
+            shade.push_back(color);
+            lua_pop(L, 1);
+          }
+        }
+        colorShade->setShade(shade);
+      }
+    }
+    lua_pop(L, 1);
+
+    type = lua_getfield(L, 2, "filename");
+    if (auto p = lua_tostring(L, -1)) {
+      if (auto filenameField = dynamic_cast<FilenameField*>(widget)) {
+        filenameField->setFilename(p);
+      }
+    }
+    lua_pop(L, 1);
+
+    // TODO combobox options? shades mode? file title / open / save / filetypes? on* events?
 
     if (relayout) {
       dlg->window.layout();


### PR DESCRIPTION
Adding the following events:

Dialog:entry { onchange }
Dialog:number { onchange }
Dialog:slider { onchange, onrelease }
Dialog:combobox { onchange }

For the slider, the `onrelease` is handy in addition to onchange if the handler is a bit slow, so I hooked that up as well. Note in C++ the signal is called OnReleased, so two other naming options could be `onreleased` or `onclick`, but this is what I went with.

Support modifying the following properties:

Dialog:number { decimals }
Dialog:slider { min, max, value }
Dialog:combobox { option }
Dialog:color { color }
Dialog:shades { colors }
Dialog:file { filename }