### PR TITLE
Implement wheel direction customization

### DIFF
--- a/data/strings/en.ini
+++ b/data/strings/en.ini
@@ -1369,6 +1369,7 @@ alt = Alt
 shift = Shift
 space = Space
 win = Win
+reverse = Reverse Wheel
 assigned_to = Assigned to:
 ok = OK
 cancel = Cancel

--- a/data/widgets/select_accelerator.xml
+++ b/data/widgets/select_accelerator.xml
@@ -16,6 +16,7 @@
           <check text="@.shift" id="shift" />
           <check text="@.space" id="space" />
           <check text="@.win" id="win" />
+          <check text="@.reverse" id="reverse"/>
         </hbox>
 
         <label text="@.assigned_to" />

--- a/src/app/commands/cmd_keyboard_shortcuts.cpp
+++ b/src/app/commands/cmd_keyboard_shortcuts.cpp
@@ -450,9 +450,13 @@ private:
   }
 
   std::string getAccelText(const Accelerator& accel) const {
-    if (m_key && m_key->type() == KeyType::WheelAction &&
-        accel.isEmpty()) {
-      return "(Default Action)";
+    if (m_key && m_key->type() == KeyType::WheelAction) {
+      if (accel.isEmpty())
+        return "(Default Action)";
+      else if (accel.reverseFlag())
+        return accel.toString() + " (Reverse)";
+      else
+        return accel.toString();
     }
     else {
       return accel.toString();

--- a/src/app/ui/editor/state_with_wheel_behavior.cpp
+++ b/src/app/ui/editor/state_with_wheel_behavior.cpp
@@ -49,7 +49,7 @@ bool StateWithWheelBehavior::onMouseWheel(Editor* editor, MouseMessage* msg)
       wheelAction = WheelAction::VScroll;
     else
       wheelAction = KeyboardShortcuts::instance()
-        ->getWheelActionFromMouseMessage(KeyContext::MouseWheel, msg);
+        ->getWheelActionFromMouseMessage(KeyContext::MouseWheel, msg, &dz);
   }
   // Default behavior
   // TODO replace this code using KeyboardShortcuts::getDefaultMouseWheelTable()

--- a/src/app/ui/keyboard_shortcuts.h
+++ b/src/app/ui/keyboard_shortcuts.h
@@ -58,7 +58,8 @@ namespace app {
     tools::Tool* getCurrentQuicktool(tools::Tool* currentTool);
     KeyAction getCurrentActionModifiers(KeyContext context);
     WheelAction getWheelActionFromMouseMessage(const KeyContext context,
-                                               const ui::Message* msg);
+                                               const ui::Message* msg,
+                                               double* dz);
     bool hasMouseWheelCustomization() const;
     void clearMouseWheelKeys();
     void addMissingMouseWheelKeys();

--- a/src/app/ui/select_accelerator.h
+++ b/src/app/ui/select_accelerator.h
@@ -29,6 +29,7 @@ namespace app {
 
   private:
     void onModifierChange(ui::KeyModifiers modifier, ui::CheckBox* checkbox);
+    void onReverseFlagChange(ui::CheckBox* checkbox);
     void onAccelChange(const ui::Accelerator* accel);
     void onClear();
     void onOK();

--- a/src/ui/accelerator.cpp
+++ b/src/ui/accelerator.cpp
@@ -151,17 +151,19 @@ Accelerator::Accelerator()
 {
 }
 
-Accelerator::Accelerator(KeyModifiers modifiers, KeyScancode scancode, int unicodeChar)
+Accelerator::Accelerator(KeyModifiers modifiers, KeyScancode scancode, int unicodeChar, bool reverseFlag)
   : m_modifiers(modifiers)
   , m_scancode(scancode)
   , m_unicodeChar(unicodeChar)
+  , m_reverseFlag(reverseFlag)
 {
 }
 
-Accelerator::Accelerator(const std::string& str)
+Accelerator::Accelerator(const std::string& str, bool reverseFlag)
   : m_modifiers(kKeyNoneModifier)
   , m_scancode(kKeyNil)
   , m_unicodeChar(0)
+  , m_reverseFlag(reverseFlag)
 {
   // Special case: plus sign
   if (str == "+") {

--- a/src/ui/accelerator.h
+++ b/src/ui/accelerator.h
@@ -21,9 +21,9 @@ namespace ui {
   class Accelerator {
   public:
     Accelerator();
-    Accelerator(KeyModifiers modifiers, KeyScancode scancode, int unicodeChar);
+    Accelerator(KeyModifiers modifiers, KeyScancode scancode, int unicodeChar, bool reverseFlag = false);
     // Convert string like "Ctrl+Q" or "Alt+X" into an accelerator.
-    explicit Accelerator(const std::string& str);
+    explicit Accelerator(const std::string& str, bool reverseFlag = false);
 
     bool isEmpty() const;
     std::string toString() const;
@@ -46,11 +46,14 @@ namespace ui {
     KeyModifiers modifiers() const { return m_modifiers; }
     KeyScancode scancode() const { return m_scancode; }
     int unicodeChar() const { return m_unicodeChar; }
+    // Used for mouse wheel hotkey reversal.
+    bool reverseFlag() const { return m_reverseFlag; }
 
   private:
     KeyModifiers m_modifiers;
     KeyScancode m_scancode;
     int m_unicodeChar;
+    bool m_reverseFlag;
   };
 
   // TODO rename this class to Shortcuts


### PR DESCRIPTION
Resolves #1801 
Implements wheel direction customization per-hotkey, completely resolving feature request.

* Adds a checkbox labeled "Reverse wheel" to reverse wheel direction on mouse wheel hotkey (Hidden when editing keyboard hotkeys).
* While editing hotkey: Scrolling wheel vertically will automatically set/reset reverse flag.
* Added `reverseFlag()` to `Accelerator` in order to signal if reverse flag is set.
* `KeyboardShortcuts::getWheelActionFromMouseMessage` now takes pointer to wheel delta argument and if accelerator has reverse flag - negates it.
* Hotkeys with reverse flag set indicate so with ` (Reverse)` label.
* Reverse flag is saved as `reverse` attribute in settings XML.