### PR TITLE
Fix recent files history order on home view when the file count is greater than 10

### DIFF
--- a/src/app/recent_files.cpp
+++ b/src/app/recent_files.cpp
@@ -225,7 +225,7 @@ void RecentFiles::save()
 
     for (int j=0; j<m_paths[i].size(); ++j) {
       set_config_string(section,
-                        base::convert_to<std::string>(j).c_str(),
+                        base::convert_to_4_digits_string<std::string>(j).c_str(),
                         m_paths[i][j].c_str());
     }
     // Special entry that indicates that we've already converted


### PR DESCRIPTION
This fix requires a laf update (merge Gasparoken/add-covert branch to include the function `convert_to_4_digits_string` in `convert_to.cpp`), and it can solve issue #2388.