### PR TITLE
Add crisp shape rendering for svg format

### DIFF
--- a/src/app/file/svg_format.cpp
+++ b/src/app/file/svg_format.cpp
@@ -93,7 +93,7 @@ bool SvgFormat::onSave(FileOp* fop)
     fprintf(f, "/>\n");
   };
   fprintf(f, "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n");
-  fprintf(f, "<svg version=\"1.1\" width=\"%d\" height=\"%d\" xmlns=\"http://www.w3.org/2000/svg\">\n",
+  fprintf(f, "<svg version=\"1.1\" width=\"%d\" height=\"%d\" xmlns=\"http://www.w3.org/2000/svg\" shape-rendering=\"crispEdges\">\n",
           image->width()*pixelScaleValue, image->height()*pixelScaleValue);
 
   switch (image->pixelFormat()) {


### PR DESCRIPTION
The SVG exports that Aseprite produces seem to have visual artifacts between pixels when rendered in current versions of Chrome, Safari, and Firefox.

I noticed that SVGs produced with [Pixels.svg](https://codepen.io/shshaw/full/XbxvNj) don't have this and it seems to be due to the [`shape-rendering: crisp-edges`](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/shape-rendering) attribute.

| Current Aseprite Export | With `shape-rendering: crisp-edges` |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1266011/83463906-3e2dd800-a467-11ea-8e6c-9da7fccc1ce2.png) | ![image](https://user-images.githubusercontent.com/1266011/83463895-33734300-a467-11ea-883c-230681772886.png) |

The CLA seems a bit heavy, so I haven't signed it. It's a small enough change that you can close this PR and have someone else commit it if needs be.

Thanks for the great tool!