### PR TITLE
Fix Discord domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/aseprite/aseprite.svg)](https://travis-ci.org/aseprite/aseprite)
 [![Build status](https://ci.appveyor.com/api/projects/status/kdu2gt7ls014i25h?svg=true)](https://ci.appveyor.com/project/dacap/aseprite)
 [![Discourse Community](https://img.shields.io/badge/discourse-community-brightgreen.svg?style=flat)](https://community.aseprite.org/)
-[![Discord Server](https://discordapp.com/api/guilds/324979738533822464/embed.png)](https://discord.gg/Yb2CeX8)
+[![Discord Server](https://discord.com/api/guilds/324979738533822464/embed.png)](https://discord.gg/Yb2CeX8)
 
 ## Introduction
 


### PR DESCRIPTION
Hey there Discord is changing their main domain, see https://github.com/discord/discord-api-docs/issues/1585

I just ran 
```
rg '(?<!cdn.)discordapp.com' --pcre2 --files-with-matches | xargs gsed -i 's/discordapp\.com/discord\.com/g'
```
over all the random projects I have checked out and yours seemed to have a link as well so here's a drive-by PR changing it.

Have a nice day!