### PR TITLE
cli/save-as: update to handle format elements

### DIFF
--- a/src/app/cli/cli_processor.cpp
+++ b/src/app/cli/cli_processor.cpp
@@ -387,29 +387,34 @@ int CliProcessor::process(Context* ctx)
           if (lastDoc) {
             std::string fn = value.value();
 
-            // Automatic --split-layer, --split-tags, --split-slices
-            // in case the output filename already contains {layer},
-            // {tag}, or {slice} template elements.
-            bool hasLayerTemplate = (is_layer_in_filename_format(fn) ||
-                                     is_group_in_filename_format(fn));
-            bool hasTagTemplate = is_tag_in_filename_format(fn);
-            bool hasSliceTemplate = is_slice_in_filename_format(fn);
+            // Automatic --filename-format 
+            // in case the output filename already contains template elements.
+            bool hasTemplateElement = is_template_in_filename(fn);
 
-            if (hasLayerTemplate || hasTagTemplate || hasSliceTemplate) {
-              cof.splitLayers = (cof.splitLayers || hasLayerTemplate);
-              cof.splitTags = (cof.splitTags || hasTagTemplate);
-              cof.splitSlices = (cof.splitSlices || hasSliceTemplate);
-              cof.filenameFormat =
-                get_default_filename_format(
-                  fn,
-                  true,                                   // With path
-                  (lastDoc->sprite()->totalFrames() > 1), // Has frames
-                  false,                                  // Has layer
-                  false);                                 // Has frame tag
+            if (hasTemplateElement) {
+              cof.filenameFormat = fn;
+              // Automatic --split-layer, --split-tags, --split-slices
+              // in case the output filename already contains {layer},
+              // {tag}, or {slice} template elements.
+              bool hasLayerTemplate = (is_layer_in_filename_format(fn) ||
+                                      is_group_in_filename_format(fn));
+              bool hasTagTemplate = is_tag_in_filename_format(fn);
+              bool hasSliceTemplate = is_slice_in_filename_format(fn);
+
+              if (hasLayerTemplate || hasTagTemplate || hasSliceTemplate) {
+                cof.splitLayers = (cof.splitLayers || hasLayerTemplate);
+                cof.splitTags = (cof.splitTags || hasTagTemplate);
+                cof.splitSlices = (cof.splitSlices || hasSliceTemplate);
+              }
+              
+              if (m_exporter)
+                m_exporter->setFilenameFormat(cof.filenameFormat);
             }
+            else {
+              cof.filename = fn;
+            } 
 
             cof.document = lastDoc;
-            cof.filename = fn;
             saveFile(ctx, cof);
           }
           else

--- a/src/app/filename_formatter.cpp
+++ b/src/app/filename_formatter.cpp
@@ -73,6 +73,29 @@ bool get_frame_info_from_filename_format(
     return false;
 }
 
+bool is_template_in_filename(const std::string& format)
+{
+  std::vector<std::string> formats{
+    "{fullname}",
+    "{path}",
+    "{name}",
+    "{title}",
+    "{extension}",
+    "{layer}",
+    "{tag}",
+    "{innertag}",
+    "{outertag}",
+    "{frame}",
+    "{tagframe}"
+  };
+  for (int i = 0; i < formats.size(); i++) {
+    if (format.find(formats[i]) != std::string::npos) {
+      return true;
+    }
+  }
+  return false;
+}
+
 bool is_tag_in_filename_format(const std::string& format)
 {
   return (format.find("{tag}") != std::string::npos);

--- a/src/app/filename_formatter.h
+++ b/src/app/filename_formatter.h
@@ -81,6 +81,9 @@ namespace app {
   bool get_frame_info_from_filename_format(
     const std::string& format, int* startFrom, int* width);
 
+  // Returns true if the given filename contains a format element
+  bool is_template_in_filename(const std::string& format);
+
   // Returns true if the given filename format contains {tag}, {layer} or {group}
   bool is_tag_in_filename_format(const std::string& format);
   bool is_layer_in_filename_format(const std::string& format);


### PR DESCRIPTION
Closes #2442 

Manually tested with:
a)
```bash
aseprite -b $PATH/Sprite-0001.ase --save-as '{title}.png'
```

Output: `Sprite-0001.png`

b)
```bash
aseprite -b $PATH/Sprite-0001.ase --save-as 'a-{title}-b.png'
```

Output: `a-Sprite-0001-b.png`