### PR TITLE
Fixed color picker extending below alpha bar

### DIFF
--- a/src/app/ui/color_spectrum.cpp
+++ b/src/app/ui/color_spectrum.cpp
@@ -40,6 +40,11 @@ app::Color ColorSpectrum::getMainAreaColor(const int u, const int umax,
 {
   double hue = 360.0 * u / umax;
   double lit = 1.0 - (double(v)/double(vmax));
+
+  if (v > vmax) {
+      return app::Color::fromMask();
+  }
+
   return app::Color::fromHsl(
     base::clamp(hue, 0.0, 360.0),
     m_color.getHslSaturation(),

--- a/src/app/ui/color_tint_shade_tone.cpp
+++ b/src/app/ui/color_tint_shade_tone.cpp
@@ -33,6 +33,11 @@ app::Color ColorTintShadeTone::getMainAreaColor(const int u, const int umax,
 {
   double sat = (1.0 * u / umax);
   double val = (1.0 - double(v) / double(vmax));
+
+  if (v > vmax) {
+      return app::Color::fromMask();
+  }
+
   return app::Color::fromHsv(
     m_color.getHsvHue(),
     base::clamp(sat, 0.0, 1.0),

--- a/src/app/ui/color_wheel.cpp
+++ b/src/app/ui/color_wheel.cpp
@@ -76,7 +76,7 @@ app::Color ColorWheel::getMainAreaColor(const int _u, const int umax,
   int u = _u - umax/2;
   int v = _v - vmax/2;
   double d = std::sqrt(u*u + v*v);
-
+  
   if (m_colorModel == ColorModel::NORMAL_MAP) {
     double a = std::atan2(-v, u);
     int di = int(128.0 * d / m_wheelRadius);
@@ -102,7 +102,7 @@ app::Color ColorWheel::getMainAreaColor(const int _u, const int umax,
         base::clamp(b, 128, 255));
     }
     else {
-      return app::Color::fromRgb(128, 128, 255);
+      return app::Color::fromMask();
     }
   }
 


### PR DESCRIPTION
Closes [#2006 ](https://github.com/aseprite/aseprite/issues/2006)

Added a simple check to make sure cursor is within the bounding box of the main color picker area before grabbing a color (so that you don't accidentally miss the alpha bar and select the color black from the outline).