### PR TITLE
Improve indexed color conversion and ordered dithering

### DIFF
--- a/src/doc/color.h
+++ b/src/doc/color.h
@@ -55,7 +55,8 @@ namespace doc {
   }
 
   inline int rgb_luma(int r, int g, int b) {
-    return (r*2126 + g*7152 + b*722) / 10000;
+    // gamma correction of 2.2 would be ideal but 2.0 is way faster
+    return (unsigned) (r*r*13933 + g*g*46871 + b*b*4732) >> 24;
   }
 
   inline uint8_t rgba_luma(uint32_t c) {


### PR DESCRIPTION
Aseprite currently has incorrect color distance calculation, specifically the color weights which are in powers of two instead of one. This makes indexed color conversion result in incorrect closest colors and tones. Also, its ordered dithering implementation in both old and new has a noise around the halfway of a gradient due to color choices being swapped around per pixel basis. This PR introduces a better color distance function and fixes aforementioned dithering problems.

Here is an example of a resulting indexed color conversion into DB32 palette with Ordered Dithering + Bayer Matrix 4x4. Left is original image, middle is Aseprite 1.2.25's output and right is after this fix.

![colorcomp](https://user-images.githubusercontent.com/75361779/100901289-42aa7a80-34f6-11eb-8b52-128d1e21a7bf.png)

Also, the luma calculation is now gamma-corrected so that the value is more linear to the grayscale. This improvement can be noticed in palette sorting. Here is a result of sorting the VGA 13h palette by luminance, left is before and right is after this fix.

![gammacorr](https://user-images.githubusercontent.com/75361779/100901331-48a05b80-34f6-11eb-8ebd-c38b0fdd7dc3.png)