### PR TITLE
Supports keeping ancillary metadata for .png files

### DIFF
--- a/data/strings/en.ini
+++ b/data/strings/en.ini
@@ -1433,6 +1433,8 @@ double_high = Double-high Pixels (1:2)
 color_profile = Color Profile:
 assign_color_profile = Assign
 convert_color_profile = Convert
+metadata = Metadata:
+metadata_remove = Clear
 
 [sprite_size]
 title = Sprite Size

--- a/data/widgets/sprite_properties.xml
+++ b/data/widgets/sprite_properties.xml
@@ -21,23 +21,28 @@
 
       <label text="@.transparent_color" />
       <hbox>
-	<hbox id="transparent_color_placeholder" />
+        <hbox id="transparent_color_placeholder" />
       </hbox>
 
       <label text="@.pixel_ratio" />
       <combobox id="pixel_ratio" cell_align="horizontal">
-	<listitem text="@.square_pixels" value="1:1" />
-	<listitem text="@.double_wide" value="2:1" />
-	<listitem text="@.double_high" value="1:2" />
+        <listitem text="@.square_pixels" value="1:1" />
+        <listitem text="@.double_wide" value="2:1" />
+        <listitem text="@.double_high" value="1:2" />
       </combobox>
 
       <label text="@.color_profile" />
       <hbox>
-	<combobox id="color_profile" cell_align="horizontal" expansive="true"></combobox>
+        <combobox id="color_profile" cell_align="horizontal" expansive="true"></combobox>
         <hbox homogeneous="true">
           <button id="assign_color_profile" text="@.assign_color_profile">Assign</button>
           <button id="convert_color_profile" text="@.convert_color_profile">Convert</button>
-	</hbox>
+        </hbox>
+      </hbox>
+
+      <label text="@.metadata" />
+      <hbox>
+        <button id="remove_metadata" text="@.metadata_remove">Clear</button>
       </hbox>
 
     </grid>

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -445,6 +445,7 @@ add_library(app-lib
   cmd/remove_cel.cpp
   cmd/remove_frame.cpp
   cmd/remove_layer.cpp
+  cmd/remove_metadata.cpp
   cmd/remove_palette.cpp
   cmd/remove_slice.cpp
   cmd/remove_tag.cpp

--- a/src/app/cmd/remove_metadata.cpp
+++ b/src/app/cmd/remove_metadata.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2001-2015  David Capello
+// Copyright (C) 2021 Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.

--- a/src/app/cmd/remove_metadata.cpp
+++ b/src/app/cmd/remove_metadata.cpp
@@ -1,0 +1,68 @@
+// Aseprite
+// Copyright (C) 2001-2015  David Capello
+//
+// This program is distributed under the terms of
+// the End-User License Agreement for Aseprite.
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "app/cmd/remove_metadata.h"
+
+#include "app/context_access.h"
+#include "app/modules/editors.h"
+#include "app/ui/editor/editor.h"
+
+#include "app/file/file.h"
+#include "app/file/file_format.h"
+#include "app/file/file_formats_manager.h"
+#include "dio/detect_format.h"
+
+#include "app/file/png_options.h"
+
+namespace app {
+namespace cmd {
+
+using namespace doc;
+
+RemoveMetadata::RemoveMetadata()
+{
+}
+
+void RemoveMetadata::onExecute()
+{
+  Context* ctx = context();
+  ContextReader reader(ctx);
+  Doc* document(reader.document());
+
+  // Could also just do the dynamic pointer cast here, but less extensible.
+
+  const std::string& filename = document->filename();
+
+  dio::FileFormat dioFormat = dio::detect_format(filename);
+  FileFormat* ff = FileFormatsManager::instance()->getFileFormat(dioFormat);
+
+  if (ff->support(FILE_SUPPORT_METADATA)) {
+    
+    // Not sure how to properly do an interface for supporting clearing metadata based on this flag.
+    // Just hardcoding PNGs for now...
+
+    if (dioFormat == dio::FileFormat::PNG_IMAGE) {
+      auto opts = std::dynamic_pointer_cast<PngOptions>(document->formatOptions());
+      if (!opts) {
+        // If the document doesn't have format options (or the type
+        // doesn't matches T), we create default format options for
+        // this file.
+        opts = std::make_shared<PngOptions>();
+      }
+
+      opts->clearMetadata();
+    }
+
+  }
+  return;
+}
+
+} // namespace cmd
+} // namespace app

--- a/src/app/cmd/remove_metadata.h
+++ b/src/app/cmd/remove_metadata.h
@@ -1,0 +1,27 @@
+// Aseprite
+// Copyright (C) 2021 Igara Studio S.A.
+//
+// This program is distributed under the terms of
+// the End-User License Agreement for Aseprite.
+
+#ifndef APP_CMD_REMOVE_METADATA_H_INCLUDED
+#define APP_CMD_REMOVE_METADATA_H_INCLUDED
+#pragma once
+
+#include "app/cmd.h"
+
+namespace app {
+namespace cmd {
+
+  class RemoveMetadata : public Cmd {
+  public:
+    RemoveMetadata();
+
+  protected:
+    void onExecute() override;
+  };
+
+} // namespace cmd
+} // namespace app
+
+#endif  // CMD_REMOVE_METADATA_H_INCLUDED

--- a/src/app/commands/cmd_remove_metadata.cpp
+++ b/src/app/commands/cmd_remove_metadata.cpp
@@ -1,0 +1,85 @@
+// Aseprite
+// Copyright (C) 2021 Igara Studio S.A.
+//
+// This program is distributed under the terms of
+// the End-User License Agreement for Aseprite.
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "app/app.h"
+#include "app/commands/command.h"
+#include "app/context_access.h"
+#include "app/modules/editors.h"
+#include "app/ui/editor/editor.h"
+
+#include "app/file/file.h"
+#include "app/file/file_format.h"
+#include "app/file/file_formats_manager.h"
+#include "dio/detect_format.h"
+
+#include "app/file/png_options.h"
+
+namespace app {
+
+class RemoveMetadataCommand : public Command {
+public:
+  RemoveMetadataCommand();
+
+protected:
+  bool onEnabled(Context* context) override;
+  void onExecute(Context* context) override;
+};
+
+RemoveMetadataCommand::RemoveMetadataCommand()
+  : Command(CommandId::RemoveMetadata(), CmdUIOnlyFlag)
+{
+}
+
+bool RemoveMetadataCommand::onEnabled(Context* context)
+{
+  return context->checkFlags(ContextFlags::ActiveDocumentIsWritable |
+                              ContextFlags::HasActiveSprite);
+}
+
+void RemoveMetadataCommand::onExecute(Context* context)
+{
+
+  ContextReader reader(context);
+  Doc* document(reader.document());
+
+  // Could also just do the dynamic pointer cast here, but less extensible.
+
+  const std::string& filename = document->filename();
+
+  dio::FileFormat dioFormat = dio::detect_format(filename);
+  FileFormat* ff = FileFormatsManager::instance()->getFileFormat(dioFormat);
+
+  if (ff->support(FILE_SUPPORT_METADATA)) {
+    
+    // Not sure how to properly do an interface for supporting clearing metadata based on this flag.
+    // Just hardcoding PNGs for now...
+
+    if (dioFormat == dio::FileFormat::PNG_IMAGE) {
+      auto opts = std::dynamic_pointer_cast<PngOptions>(document->formatOptions());
+      if (!opts) {
+        // If the document doesn't have format options (or the type
+        // doesn't matches T), we create default format options for
+        // this file.
+        opts = std::make_shared<PngOptions>();
+      }
+
+      opts->clearMetadata();
+    }
+
+  }
+  return;
+}
+
+Command* CommandFactory::createRemoveMetadataCommand()
+{
+  return new RemoveMetadataCommand;
+}
+
+} //namespace app

--- a/src/app/file/file_format.h
+++ b/src/app/file/file_format.h
@@ -30,6 +30,7 @@
 #define FILE_SUPPORT_TAGS               0x00001000
 #define FILE_SUPPORT_BIG_PALETTES       0x00002000 // Palettes w/more than 256 colors
 #define FILE_SUPPORT_PALETTE_WITH_ALPHA 0x00004000
+#define FILE_SUPPORT_METADATA           0x00008000 // Ancillary metadata
 
 namespace app {
 

--- a/src/app/file/png_format.cpp
+++ b/src/app/file/png_format.cpp
@@ -220,6 +220,36 @@ bool PngFormat::onLoad(FileOp* fop)
   png_get_IHDR(png, info, &width, &height, &bit_depth, &color_type,
                &interlace_type, NULL, NULL);
 
+  /* Read any text metadata into our PngOptions */
+  int num_text;
+  png_textp text;
+  if (png_get_text(png, info, &text, &num_text) != 0) {
+    for (int i = 0; i < num_text; i++) {
+      auto src = text[i];
+      PngOptions::TextEntry entry;
+      entry.compression = src.compression;
+      entry.text_length = src.text_length;
+      entry.itxt_length = src.itxt_length;
+
+      if (src.key == nullptr) {
+        fop->setError("png_text doesn't contain a key\n");
+        return false;
+      } else {
+        entry.key = base::buffer(src.key, src.key + strlen(src.key) + 1);
+      }
+
+      if (src.text != nullptr) {
+        entry.text = std::unique_ptr<base::buffer>(new base::buffer(src.text, src.text + strlen(src.text) + 1));
+      }
+      if (src.lang != nullptr) {
+        entry.lang = std::unique_ptr<base::buffer>(new base::buffer(src.lang, src.lang + strlen(src.lang) + 1));
+      }
+      if (src.lang_key != nullptr) {
+        entry.lang_key = std::unique_ptr<base::buffer>(new base::buffer(src.lang_key, src.lang_key + strlen(src.lang_key) + 1));
+      }
+      opts->addTextEntry(std::move(entry));
+    }
+  }
 
   /* Set up the data transformations you want.  Note that these are all
    * optional.  Only call them if you want/need them.  Many of the
@@ -581,30 +611,53 @@ bool PngFormat::onSave(FileOp* fop)
   png_set_IHDR(png, info, width, height, 8, color_type,
                PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_BASE, PNG_FILTER_TYPE_BASE);
 
-  // User chunks
   auto opts = fop->formatOptionsOfDocument<PngOptions>();
-  if (opts && !opts->isEmpty()) {
-    int num_unknowns = opts->size();
-    ASSERT(num_unknowns > 0);
-    std::vector<png_unknown_chunk> unknowns(num_unknowns);
-    int i = 0;
-    for (const auto& chunk : opts->chunks()) {
-      png_unknown_chunk& unknown = unknowns[i];
-      for (int i=0; i<5; ++i) {
-        unknown.name[i] =
-          (i < int(chunk.name.size()) ? chunk.name[i]: 0);
+  if (opts) {
+    // Text
+    auto& text = opts->text();
+    if (!text.empty()) {
+      int num_entries = text.size();
+      ASSERT(num_text > 0);
+      std::vector<png_text> entries(num_entries);
+      int i = 0;
+      for (const auto& entry : text) {
+        png_text& dst = entries[i];
+        dst.compression = entry.compression;
+        dst.text_length = entry.text_length;
+        dst.itxt_length = entry.itxt_length;
+        dst.key = (png_charp)&entry.key[0];
+        dst.text = entry.text ? (png_charp)entry.text->data() : nullptr;
+        dst.lang = entry.lang ? (png_charp)entry.lang->data() : nullptr;
+        dst.lang_key = entry.lang_key ? (png_charp)entry.lang_key->data() : nullptr;
       }
-      PNG_TRACE("PNG: Write unknown chunk '%c%c%c%c'\n",
-                unknown.name[0],
-                unknown.name[1],
-                unknown.name[2],
-                unknown.name[3]);
-      unknown.data = (png_byte*)&chunk.data[0];
-      unknown.size = chunk.data.size();
-      unknown.location = chunk.location;
-      ++i;
+      png_set_text(png, info, &entries[0], num_entries);
     }
-    png_set_unknown_chunks(png, info, &unknowns[0], num_unknowns);
+
+    // User chunks
+    auto& chunks = opts->chunks();
+    if (!chunks.empty()) {
+      int num_unknowns = chunks.size();
+      ASSERT(num_unknowns > 0);
+      std::vector<png_unknown_chunk> unknowns(num_unknowns);
+      int i = 0;
+      for (const auto& chunk : chunks) {
+        png_unknown_chunk& unknown = unknowns[i];
+        for (int i=0; i<5; ++i) {
+          unknown.name[i] =
+            (i < int(chunk.name.size()) ? chunk.name[i]: 0);
+        }
+        PNG_TRACE("PNG: Write unknown chunk '%c%c%c%c'\n",
+                  unknown.name[0],
+                  unknown.name[1],
+                  unknown.name[2],
+                  unknown.name[3]);
+        unknown.data = (png_byte*)&chunk.data[0];
+        unknown.size = chunk.data.size();
+        unknown.location = chunk.location;
+        ++i;
+      }
+      png_set_unknown_chunks(png, info, &unknowns[0], num_unknowns);
+    }
   }
 
   if (fop->preserveColorProfile() &&

--- a/src/app/file/png_format.cpp
+++ b/src/app/file/png_format.cpp
@@ -55,7 +55,8 @@ class PngFormat : public FileFormat {
       FILE_SUPPORT_GRAYA |
       FILE_SUPPORT_INDEXED |
       FILE_SUPPORT_SEQUENCES |
-      FILE_SUPPORT_PALETTE_WITH_ALPHA;
+      FILE_SUPPORT_PALETTE_WITH_ALPHA |
+      FILE_SUPPORT_METADATA;
   }
 
   bool onLoad(FileOp* fop) override;

--- a/src/app/file/png_options.h
+++ b/src/app/file/png_options.h
@@ -16,6 +16,17 @@ namespace app {
   // Data for PNG files
   class PngOptions : public FormatOptions {
   public:
+    struct TextEntry {
+      // Flags PNG_TEXT_COMPRESSION_NONE/PNG_TEXT_COMPRESSION_zTXt/PNG_ITXT_COMPRESSION_NONE/PNG_ITXT_COMPRESSION_zTXt
+      int compression;
+      size_t text_length;
+      size_t itxt_length;
+      base::buffer key;
+      std::unique_ptr<base::buffer> text;
+      std::unique_ptr<base::buffer> lang;
+      std::unique_ptr<base::buffer> lang_key;
+    };
+
     struct Chunk {
       std::string name;
       base::buffer data;
@@ -23,23 +34,26 @@ namespace app {
       int location;
     };
 
+    using Text = std::vector<TextEntry>;
     using Chunks = std::vector<Chunk>;
+
+    void addTextEntry(TextEntry&& text) {
+      m_Text.emplace_back(std::move(text));
+    }
 
     void addChunk(Chunk&& chunk) {
       m_userChunks.emplace_back(std::move(chunk));
     }
 
-    bool isEmpty() const {
-      return m_userChunks.empty();
+    bool isEmpty() {
+      return m_Text.empty() && m_userChunks.empty();
     }
 
-    int size() const {
-      return int(m_userChunks.size());
-    }
-
+    const Text& text() const { return m_Text; }
     const Chunks& chunks() const { return m_userChunks; }
 
   private:
+    Text m_Text;
     Chunks m_userChunks;
   };
 

--- a/src/app/file/png_options.h
+++ b/src/app/file/png_options.h
@@ -49,6 +49,10 @@ namespace app {
       return m_Text.empty() && m_userChunks.empty();
     }
 
+    void clearMetadata() {
+      m_Text.clear();
+    }
+
     const Text& text() const { return m_Text; }
     const Chunks& chunks() const { return m_userChunks; }
 


### PR DESCRIPTION
Resolves #2582

**Currently a draft,** because I can't get the GUI button to link with either command/cmd implementation. _Help would be appreciated._

Essentially, this allows for metadata such as the zTXt chunks in PNG files to be kept by Aseprite.

I couldn't figure out how to implement a proper interface system, so `FILE_SUPPORT_METADATA` is somewhat useless, but is aimed towards future expansion to support other formats with the flag.

The actual loading/saving of the metadata was done by @willox.