### PR TITLE
Fix lua error crash (fix #2635)

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2020  Igara Studio S.A.
+// Copyright (C) 2018-2021  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -334,6 +334,7 @@ int App::initialize(const AppOptions& options)
 
   // Process options
   LOG("APP: Processing options...\n");
+  int code;
   {
     std::unique_ptr<CliDelegate> delegate;
     if (options.previewCLI())
@@ -342,14 +343,12 @@ int App::initialize(const AppOptions& options)
       delegate.reset(new DefaultCliDelegate);
 
     CliProcessor cli(delegate.get(), options);
-    int code = cli.process(context());
-    if (code != 0)
-      return code;
+    code = cli.process(context());
   }
 
   LOG("APP: Finish launching...\n");
   system->finishLaunching();
-  return 0;
+  return code;
 }
 
 void App::run()

--- a/src/app/cli/cli_processor.cpp
+++ b/src/app/cli/cli_processor.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2020  Igara Studio S.A.
+// Copyright (C) 2018-2021  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -532,7 +532,14 @@ int CliProcessor::process(Context* ctx)
         // --script <filename>
         else if (opt == &m_options.script()) {
           std::string filename = value.value();
-          int code = m_delegate->execScript(filename, scriptParams);
+          int code;
+          try {
+            code = m_delegate->execScript(filename, scriptParams);
+          }
+          catch (const std::exception& ex) {
+            Console::showException(ex);
+            return -1;
+          }
           if (code != 0)
             return code;
         }

--- a/src/app/console.cpp
+++ b/src/app/console.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2020  Igara Studio S.A.
+// Copyright (C) 2018-2021  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -180,7 +180,6 @@ void Console::printf(const char* format, ...)
 // static
 void Console::showException(const std::exception& e)
 {
-  ui::assert_ui_thread();
   if (!ui::is_ui_thread()) {
     LOG(ERROR, "A problem has occurred.\n\nDetails:\n%s\n", e.what());
     return;

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2020  Igara Studio S.A.
+// Copyright (C) 2019-2021  Igara Studio S.A.
 // Copyright (C) 2001-2016  David Capello
 //
 // This program is distributed under the terms of
@@ -95,14 +95,15 @@ int app_main(int argc, char* argv[])
     }
 
     const int code = app.initialize(options);
-    if (code != 0)
-      return code;
 
     if (options.startShell())
       systemConsole.prepareShell();
 
     app.run();
-    return 0;
+
+    // After starting the GUI, we'll always return 0, but in batch
+    // mode we can return the error code.
+    return (app.isGui() ? 0: code);
   }
   catch (std::exception& e) {
     std::cerr << e.what() << '\n';


### PR DESCRIPTION
Before this fix, running aseprite from the console, caused a crash when the following conditions were true:
 . -script option.
 . a lua error in the script