### PR TITLE
Fixed issue #2030 (close all command doesn't show work about to close)

### DIFF
--- a/src/app/ui/doc_view.cpp
+++ b/src/app/ui/doc_view.cpp
@@ -284,6 +284,8 @@ bool DocView::onCloseView(Workspace* workspace, bool quitting)
     {
       // see if the sprite has changes
       while (m_document->isModified()) {
+        ctx->setActiveView(this);// show user what they are about to close
+
         // ask what want to do the user with the changes in the sprite
         int ret = Alert::show(
           fmt::format(


### PR DESCRIPTION
Changes active view before the dialog box appears for closing said view. #2030 