### PR TITLE
Add Layer Name length field to spec.

### DIFF
--- a/docs/ase-file-specs.md
+++ b/docs/ase-file-specs.md
@@ -172,6 +172,7 @@ Ignore this chunk if you find the new palette chunk (0x2019)
     BYTE        Opacity
                   Note: valid only if file header flags field has bit 1 set
     BYTE[3]     For future (set to zero)
+    WORD        Length of layer name
     STRING      Layer name
 
 ### Cel Chunk (0x2005)


### PR DESCRIPTION
Adding extra field for length of layer name which is in the file format, but not in the document that describes the format.