### PR TITLE
Fix potential memory leak when exception thrown

### DIFF
--- a/src/app/ui/color_bar.cpp
+++ b/src/app/ui/color_bar.cpp
@@ -75,6 +75,7 @@
 
 #include <cstring>
 #include <limits>
+#include <memory>
 
 namespace app {
 
@@ -1182,9 +1183,16 @@ void ColorBar::updateCurrentSpritePalette(const char* operationName)
           cmd->execute(UIContext::instance());
         }
         else {
-          Tx tx(writer.context(), operationName, ModifyDocument);
-          tx(cmd);
-          tx.commit();
+          std::unique_ptr<Tx> tx;
+          try {
+            tx = std::unique_ptr<Tx>(new Tx(writer.context(), operationName, ModifyDocument));
+          }
+          catch (...) {
+            delete cmd;
+            throw;
+          }
+          (*tx)(cmd);
+          tx->commit();
         }
       }
     }

--- a/src/app/widget_loader.cpp
+++ b/src/app/widget_loader.cpp
@@ -203,7 +203,13 @@ Widget* WidgetLoader::convertXmlElementToWidget(const TiXmlElement* elem, Widget
         // Automatic bind <check> widget with bool preference option
         if (pref) {
           auto prefWidget = new BoolPrefWidget<CheckBox>("");
-          prefWidget->setPref(pref);
+          try {
+            prefWidget->setPref(pref);
+          }
+          catch (...) {
+            delete prefWidget;
+            throw;
+          }
           widget = prefWidget;
         }
         else {


### PR DESCRIPTION
Fix potential memory leak when `prefWidget->setPref(pref)` / `Tx tx(writer.context(), operationName, ModifyDocument)` throws an exception. I use `unique_ptr` to avoid memory leak on `tx` when `(*tx)(cmd)` throws an exception.



I'm not sure whether the default constructor of `Tx` will throw exceptions or not. If it will, there are some more code to be modified. (In file src/app/script/sprint_class.cpp)

