### PR TITLE
Fix eyedropper tool picks a pixel of mask color, the FG color changes to the entry 0 (fix #2813)

### DIFF
--- a/src/app/ui/palette_view.cpp
+++ b/src/app/ui/palette_view.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2020  Igara Studio S.A.
+// Copyright (C) 2018-2021  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -972,7 +972,8 @@ int PaletteView::findExactIndex(const app::Color& color) const
   switch (color.getType()) {
 
     case Color::MaskType:
-      return (current_editor ? current_editor->sprite()->transparentColor(): -1);
+      return (currentPalette()->findMaskColor() >= 0) ?
+        currentPalette()->findMaskColor() : -1;
 
     case Color::RgbType:
     case Color::HsvType:

--- a/src/doc/palette.cpp
+++ b/src/doc/palette.cpp
@@ -1,5 +1,5 @@
 // Aseprite Document Library
-// Copyright (c) 2020  Igara Studio S.A.
+// Copyright (c) 2020-2021  Igara Studio S.A.
 // Copyright (c) 2001-2017 David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -195,6 +195,15 @@ int Palette::findExactMatch(int r, int g, int b, int a, int mask_index) const
     if (getEntry(i) == rgba(r, g, b, a) && i != mask_index)
       return i;
 
+  return -1;
+}
+
+int Palette::findMaskColor() const
+{
+  for (int i=0; i<(int)m_colors.size(); ++i) {
+    if (rgba_geta(getEntry(i)) == 0)
+      return i;
+  }
   return -1;
 }
 

--- a/src/doc/palette.h
+++ b/src/doc/palette.h
@@ -1,4 +1,5 @@
 // Aseprite Document Library
+// Copyright (c) 2021 Igara Studio SA
 // Copyright (c) 2001-2018 David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -88,6 +89,7 @@ namespace doc {
     void makeGradient(int from, int to);
 
     int findExactMatch(int r, int g, int b, int a, int mask_index) const;
+    int findMaskColor() const;
     int findBestfit(int r, int g, int b, int a, int mask_index) const;
 
     void applyRemap(const Remap& remap);


### PR DESCRIPTION
Even if the mask color is present on the palette.