### PR TITLE
Add the ability to set the continuity when creating a new layer

### DIFF
--- a/src/app/commands/cmd_new_layer.cpp
+++ b/src/app/commands/cmd_new_layer.cpp
@@ -221,11 +221,11 @@ void NewLayerCommand::onExecute(Context* context)
       fmt::format(Strings::commands_NewLayer(), layerPrefix()));
     DocApi api = document->getApi(tx);
     bool afterBackground = false;
-
 #ifdef ENABLE_UI
     // Since the timeline status changes when a layer is added, get the necessary value here.
     bool allLayersContinuous = App::instance()->timeline()->allLayersContinuous();
 #endif
+
     switch (m_type) {
       case Type::Layer:
         layer = api.newLayer(parent, name);

--- a/src/app/commands/cmd_new_layer.cpp
+++ b/src/app/commands/cmd_new_layer.cpp
@@ -28,6 +28,7 @@
 #include "app/ui/main_window.h"
 #include "app/ui/status_bar.h"
 #include "app/ui_context.h"
+#include "app/ui/timeline/timeline.h"
 #include "app/util/clipboard.h"
 #include "app/util/new_image_from_mask.h"
 #include "app/util/range_utils.h"
@@ -221,9 +222,12 @@ void NewLayerCommand::onExecute(Context* context)
     DocApi api = document->getApi(tx);
     bool afterBackground = false;
 
+    bool allLayersContinuous = App::instance()->timeline()->allLayersContinuous();
     switch (m_type) {
       case Type::Layer:
         layer = api.newLayer(parent, name);
+        if (layer)
+          layer->setContinuous(allLayersContinuous);
         if (m_place == Place::BeforeActiveLayer)
           api.restackLayerBefore(layer, parent, activeLayer);
         break;
@@ -232,8 +236,10 @@ void NewLayerCommand::onExecute(Context* context)
         break;
       case Type::ReferenceLayer:
         layer = api.newLayer(parent, name);
-        if (layer)
+        if (layer) {
           layer->setReference(true);
+          layer->setContinuous(allLayersContinuous);
+        }
         afterBackground = true;
         break;
     }

--- a/src/app/commands/cmd_new_layer.cpp
+++ b/src/app/commands/cmd_new_layer.cpp
@@ -223,6 +223,7 @@ void NewLayerCommand::onExecute(Context* context)
     bool afterBackground = false;
 
 #ifdef ENABLE_UI
+    // Since the timeline status changes when a layer is added, get the necessary value here.
     bool allLayersContinuous = App::instance()->timeline()->allLayersContinuous();
 #endif
     switch (m_type) {

--- a/src/app/commands/cmd_new_layer.cpp
+++ b/src/app/commands/cmd_new_layer.cpp
@@ -223,7 +223,7 @@ void NewLayerCommand::onExecute(Context* context)
     bool afterBackground = false;
 #ifdef ENABLE_UI
     // Since the timeline status changes when a layer is added, get the necessary value here.
-    bool allLayersContinuous = App::instance()->timeline()->allLayersContinuous();
+    bool allLayersContinuous = context->isUIAvailable() ? App::instance()->timeline()->allLayersContinuous() : false;
 #endif
 
     switch (m_type) {

--- a/src/app/commands/cmd_new_layer.cpp
+++ b/src/app/commands/cmd_new_layer.cpp
@@ -222,12 +222,16 @@ void NewLayerCommand::onExecute(Context* context)
     DocApi api = document->getApi(tx);
     bool afterBackground = false;
 
+#ifdef ENABLE_UI
     bool allLayersContinuous = App::instance()->timeline()->allLayersContinuous();
+#endif
     switch (m_type) {
       case Type::Layer:
         layer = api.newLayer(parent, name);
+#ifdef ENABLE_UI
         if (layer)
           layer->setContinuous(allLayersContinuous);
+#endif
         if (m_place == Place::BeforeActiveLayer)
           api.restackLayerBefore(layer, parent, activeLayer);
         break;
@@ -238,7 +242,9 @@ void NewLayerCommand::onExecute(Context* context)
         layer = api.newLayer(parent, name);
         if (layer) {
           layer->setReference(true);
+#ifdef ENABLE_UI
           layer->setContinuous(allLayersContinuous);
+#endif
         }
         afterBackground = true;
         break;

--- a/src/app/ui/timeline/timeline.h
+++ b/src/app/ui/timeline/timeline.h
@@ -135,6 +135,9 @@ namespace app {
 
     void clearAndInvalidateRange();
 
+    bool allLayersContinuous();
+    bool allLayersDiscontinuous();
+
   protected:
     bool onProcessMessage(ui::Message* msg) override;
     void onInitTheme(ui::InitThemeEvent& ev) override;
@@ -254,8 +257,6 @@ namespace app {
     bool allLayersInvisible();
     bool allLayersLocked();
     bool allLayersUnlocked();
-    bool allLayersContinuous();
-    bool allLayersDiscontinuous();
     void detachDocument();
     void setCursor(ui::Message* msg, const Hit& hit);
     void getDrawableLayers(layer_t* firstLayer, layer_t* lastLayer);


### PR DESCRIPTION
With this change, if all existing layers are in continuous mode, when you create a new layer, it will set that layer to continuous mode.

I use a lot of layers and frames, so this feature is necessary for me.