### PR TITLE
Replace fseek with putl/w to reduce io flushes

### DIFF
--- a/src/app/file/ase_format.cpp
+++ b/src/app/file/ase_format.cpp
@@ -526,7 +526,8 @@ static void ase_file_write_start_chunk(FILE* f, dio::AsepriteFrameHeader* frame_
   chunk->type = type;
   chunk->start = ftell(f);
 
-  fseek(f, chunk->start+6, SEEK_SET);
+  fputl(0, f);
+  fputw(0, f);
 }
 
 static void ase_file_write_close_chunk(FILE* f, dio::AsepriteChunk* chunk)


### PR DESCRIPTION
ase_file_write_start_chunk needs to skip forward the size of the chunk header, as these values will be written in later.  Using fseek was causing performance issues on my Windows machine due to causing an io flush on every chunk, for projects with many (thousands) of chunks.  Replacing with the equivalent put commands in ase_file_write_close_chunk results in significant speedup for certain test projects.

I have uploaded my test project below, which emphasizes the problem.  It is a project with many cells, as the issue seems directly corelated with chunk count, as each cell is written as a single chunk no matter how small they may be.  The project has 100 layers, and 100 frames.  The file is ~350 Kb on my machine due to the small canvas size (16x16).  But despite this it takes ~20 seconds to save!  With the fix here the file saves in just moments (less than half a second).

possibly related to #1093 

[SavingStressTest.zip](https://github.com/aseprite/aseprite/files/6914332/SavingStressTest.zip)





