### PR TITLE
Fix color switching on empty palette space click (fix #2776)

### DIFF
--- a/src/app/ui/palette_view.cpp
+++ b/src/app/ui/palette_view.cpp
@@ -333,6 +333,11 @@ bool PaletteView::onProcessMessage(Message* msg)
           break;
       }
 
+      if(m_hot.color >= currentPalette()->size()){
+        deselect();
+        break;
+      }
+
       captureMouse();
 
       // Continue...


### PR DESCRIPTION
Fix for issue https://github.com/aseprite/aseprite/issues/2776.

The old behavior was, that if a user clicked on empty space in the palette view, the last palette entry was selected. And used as foreground or background color, depending on the clicked mouse button.

Now the click on empty space gets the currently selected color deselected and the foreground and background color stay the same.