### PR TITLE
Fix cursor and selection size on 100% screen scale (fix 2869)

### DIFF
--- a/src/app/ui/editor/brush_preview.cpp
+++ b/src/app/ui/editor/brush_preview.cpp
@@ -519,7 +519,7 @@ void BrushPreview::createCrosshairCursor(ui::Graphics* g,
   }
 
   os::Window* window = m_editor->manager()->display();
-  const int scale = window->scale();
+  const int scale = (window->scale()<2)?2:window->scale();
   os::CursorRef cursor = nullptr;
 
   // Invalidate the entire cache if the scale has changed
@@ -691,16 +691,23 @@ void BrushPreview::traceSelectionCrossPixels(
   if (size2.w == 0) size2.w = 1;
   if (size2.h == 0) size2.h = 1;
 
+  const int scaleFactor = (m_editor->manager()->display()->scale() == 1)?2:1;
+
   for (int v=0; v<6; v++) {
     for (int u=0; u<6; u++) {
       if (!cross[v*6+u])
         continue;
 
-      out = outpt;
-      out.x += ((u<3) ? u-size.w-3: u-size.w-3+size2.w);
-      out.y += ((v<3) ? v-size.h-3: v-size.h-3+size2.h);
+      for(int x=0; x<scaleFactor; x++){
+        for(int y=0; y<scaleFactor; y++){
+          out = outpt;
+          out.x += ((u<3) ? u*scaleFactor-size.w+x-3*scaleFactor: u*scaleFactor-size.w-3*scaleFactor-x+size2.w);
+          out.y += ((v<3) ? v*scaleFactor-size.h+y-3*scaleFactor: v*scaleFactor-size.h-3*scaleFactor-y+size2.h);
 
-      (this->*pixelDelegate)(g, out, color);
+          (this->*pixelDelegate)(g, out, color);
+        }
+      }
+
     }
   }
 }

--- a/src/app/ui/editor/brush_preview.cpp
+++ b/src/app/ui/editor/brush_preview.cpp
@@ -691,18 +691,18 @@ void BrushPreview::traceSelectionCrossPixels(
   if (size2.w == 0) size2.w = 1;
   if (size2.h == 0) size2.h = 1;
 
-  const int scaleFactor = (m_editor->manager()->display()->scale() == 1)?2:1;
+  const int scale = ui::guiscale();
 
   for (int v=0; v<6; v++) {
     for (int u=0; u<6; u++) {
       if (!cross[v*6+u])
         continue;
 
-      for(int x=0; x<scaleFactor; x++){
-        for(int y=0; y<scaleFactor; y++){
+      for(int x=0; x < scale; x++){
+        for(int y=0; y < scale; y++){
           out = outpt;
-          out.x += ((u<3) ? u*scaleFactor-size.w+x-3*scaleFactor: u*scaleFactor-size.w-3*scaleFactor-x+size2.w);
-          out.y += ((v<3) ? v*scaleFactor-size.h+y-3*scaleFactor: v*scaleFactor-size.h-3*scaleFactor-y+size2.h);
+          out.x += ((u<3) ? (u*scale - size.w+x - 3*scale) : (u*scale - size.w - 3*scale - x+size2.w));
+          out.y += ((v<3) ? (v*scale - size.h+y - 3*scale) : (v*scale - size.h - 3*scale - y+size2.h));
 
           (this->*pixelDelegate)(g, out, color);
         }

--- a/src/app/ui/editor/editor.cpp
+++ b/src/app/ui/editor/editor.cpp
@@ -956,6 +956,13 @@ void Editor::drawMask(Graphics* g)
   segs.path().transform(m_proj.scaleMatrix(), &path);
   path.offset(pt.x, pt.y);
   g->drawPath(path, paint);
+
+  // Double the size on 100% screen scale
+  if(manager()->display()->scale() == 1)
+  {
+    path.offset(1, 1);
+    g->drawPath(path, paint);
+  }
 }
 
 void Editor::drawMaskSafe()


### PR DESCRIPTION
Fix suggestion for issue #2869.

I don't know if it is okay if everything is just scaled on the smallest screen scale, but I'm really satisfied with the sizes at 200%.

I changed:

- The size of the pen cursor by setting the scale to 2.
- The size of the selection cursor by adding scaling to the pixel putting. 
- The size of the selection by drawing the same selection one pixel right and down again.

I hope this is helpful and wish you a nice day.
ruerob