### PR TITLE
Fix crash after saving a GIF file from an indexed image which transparent index is gone

### DIFF
--- a/src/app/cmd/set_palette.cpp
+++ b/src/app/cmd/set_palette.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2020  Igara Studio S.A.
+// Copyright (C) 2019-2021  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -53,6 +53,13 @@ SetPalette::SetPalette(Sprite* sprite, frame_t frame, const Palette* newPalette)
         m_newColors[i] = newPalette->getEntry(m_from+i);
     }
   }
+  if (sprite->pixelFormat() == IMAGE_INDEXED) {
+    m_oldTransparentIndex = sprite->transparentColor();
+    if (m_oldTransparentIndex >= newPalette->size())
+      m_newTransparentIndex = newPalette->size() -1;
+    else
+      m_newTransparentIndex = m_oldTransparentIndex;
+  }
 }
 
 void SetPalette::onExecute()
@@ -64,6 +71,7 @@ void SetPalette::onExecute()
   for (size_t i=0; i<m_newColors.size(); ++i)
     palette->setEntry(m_from+i, m_newColors[i]);
 
+  sprite->setTransparentColor(m_newTransparentIndex);
   palette->incrementVersion();
 }
 
@@ -76,6 +84,7 @@ void SetPalette::onUndo()
   for (size_t i=0; i<m_oldColors.size(); ++i)
     palette->setEntry(m_from+i, m_oldColors[i]);
 
+  sprite->setTransparentColor(m_oldTransparentIndex);
   palette->incrementVersion();
 }
 

--- a/src/app/cmd/set_palette.h
+++ b/src/app/cmd/set_palette.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019  Igara Studio S.A.
+// Copyright (C) 2019-2021  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -45,6 +45,8 @@ namespace cmd {
     int m_from, m_to;
     int m_oldNColors;
     int m_newNColors;
+    int m_oldTransparentIndex;
+    int m_newTransparentIndex;
     std::vector<color_t> m_oldColors;
     std::vector<color_t> m_newColors;
   };

--- a/src/app/ui/color_bar.cpp
+++ b/src/app/ui/color_bar.cpp
@@ -578,7 +578,9 @@ void ColorBar::onRemapButtonClick()
       }
 
       color_t oldTransparent = sprite->transparentColor();
-      color_t newTransparent = remap[oldTransparent];
+      color_t newTransparent = (remap[oldTransparent] >= 0) ? remap[oldTransparent] : oldTransparent;
+      if (newTransparent >= get_current_palette()->size())
+        newTransparent = get_current_palette()->size() - 1;
       if (oldTransparent != newTransparent)
         tx(new cmd::SetTransparentColor(sprite, newTransparent));
 


### PR DESCRIPTION
Before this fix, it was possible to lose the transparent index at Indexed Color Mode.
It was reproducible doing:
- New file, Indexed mode, Black background.
- Erase all the palette, add 40 colors slots (these all will be black)
- Press Remap button
- Go to Sprite > Properties...  set transparent color to 11.
- Erase color entries 2 to 20
- Press Remap button

You'll see the transparent index is gone (transparent index = -1)
To reproduce the crash, additional steps are needed:
- Right click to layer and select 'Layer from Background'
- Make a color RGBA(0, 0, 0, 0) and add to the palette
- Paint on canvas with this color (it'll act like a eraser)
- File > Save As... save in GIF format.
- Press OK

Crash!

This crash was reported on ticket 2620 and 2621.
Aseprite version 1.2.28