### PR TITLE
Fixed bug #2797

### DIFF
--- a/src/app/ui_context.cpp
+++ b/src/app/ui_context.cpp
@@ -112,8 +112,8 @@ void UIContext::setActiveView(DocView* docView)
   else
     current_editor = nullptr;
 
-  mainWin->getPreviewEditor()->updateUsingEditor(current_editor);
   mainWin->getTimeline()->updateUsingEditor(current_editor);
+  mainWin->getPreviewEditor()->updateUsingEditor(current_editor);
 
   // Change the image-type of color bar.
   ColorBar::instance()->setPixelFormat(app_get_current_pixel_format());


### PR DESCRIPTION
This is a fix to bug referenced in #2797

Description
========
When the active view is changed. The `UIContext` [updates both the preview editor and the timeline](https://github.com/aseprite/aseprite/blob/bbec09c752d89efe5a64996d89549b4fd70356fe/src/app/ui_context.cpp#L115) (in that particular order). Problem is: if the preview editor is currently playing in the switched-from view, the [`TagProvider`](https://github.com/aseprite/aseprite/blob/bbec09c752d89efe5a64996d89549b4fd70356fe/src/app/ui/doc_view.cpp#L108) in the [editor](https://github.com/aseprite/aseprite/blob/bbec09c752d89efe5a64996d89549b4fd70356fe/src/app/ui/editor/play_state.cpp#L70) of the switched-to view would still be pointing to the switched-from timeline because the `UIContext` has not [switched to a new timeline](https://github.com/aseprite/aseprite/blob/bbec09c752d89efe5a64996d89549b4fd70356fe/src/app/ui/timeline/timeline.cpp#L317).

This PR switches the order of the update such that the timeline is updated first, then the preview editor after. That way, the referenced timeline in the `PlayState::onEnterState` or anywhere prior can get the correct tags (if any).

Does this break any part of the UI? I may have to research that.