### PR TITLE
fixed restoring grid preference on undo/redo (fix #2872)

### DIFF
--- a/src/app/cmd/set_grid_bounds.cpp
+++ b/src/app/cmd/set_grid_bounds.cpp
@@ -13,6 +13,7 @@
 #include "app/doc.h"
 #include "app/doc_event.h"
 #include "app/doc_observer.h"
+#include "app/pref/preferences.h"
 #include "doc/sprite.h"
 
 namespace app {
@@ -31,6 +32,9 @@ void SetGridBounds::onExecute()
 {
   Sprite* spr = sprite();
   spr->setGridBounds(m_newBounds);
+  Doc* doc = static_cast<Doc*>(spr->document());
+  auto& docPref = Preferences::instance().document(doc);
+  docPref.grid.bounds(m_newBounds);
   spr->incrementVersion();
 }
 
@@ -38,6 +42,9 @@ void SetGridBounds::onUndo()
 {
   Sprite* spr = sprite();
   spr->setGridBounds(m_oldBounds);
+  Doc* doc = static_cast<Doc*>(spr->document());
+  auto& docPref = Preferences::instance().document(doc);
+  docPref.grid.bounds(m_oldBounds);
   spr->incrementVersion();
 }
 

--- a/src/app/commands/cmd_grid.cpp
+++ b/src/app/commands/cmd_grid.cpp
@@ -131,7 +131,6 @@ void GridSettingsCommand::onExecute(Context* context)
     tx.commit();
 
     auto& docPref = Preferences::instance().document(site.document());
-    docPref.grid.bounds(bounds);
     if (!docPref.show.grid()) // Make grid visible
       docPref.show.grid(true);
   }


### PR DESCRIPTION
Problem: the grid settings always save the newly set bounds of a sprite/document in the document's preference but does not do restore the old/new bounds back to the document's preference when we undo or redo changes.

This solution: In the Undo and Redo methods of the SetGridBounds, we can save the old/new bounds into the document's preference.