### PR TITLE
Cyclic palette change

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,125 @@
+---
+Language:        Cpp
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: AcrossEmptyLines
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: None
+AlignConsecutiveDeclarations: None
+AlignEscapedNewlines: Right
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: InlineOnly
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     true
+  BeforeElse:      true
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: true
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeComma
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeComma
+BreakStringLiterals: false
+ColumnLimit:     80
+CompactNamespaces: true
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
+Cpp11BracedListStyle: false
+DeriveLineEnding: false
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+IncludeBlocks:   Preserve
+IndentCaseLabels: true
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: BeforeHash
+IndentExternBlock: AfterExternBlock
+IndentRequires:  false
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+KeepEmptyLinesAtTheStartOfBlocks: false
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 1000
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Left
+ReflowComments:  false
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard:        Latest
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+...

--- a/src/app/commands/cmd_change_color.cpp
+++ b/src/app/commands/cmd_change_color.cpp
@@ -75,15 +75,20 @@ void ChangeColorCommand::onExecute(Context* context)
       // do nothing
       break;
     case IncrementIndex: {
-      int index = color.getIndex();
-      if (index < get_current_palette()->size()-1)
-        color = app::Color::fromIndex(index+1);
+      const int palSize = get_current_palette()->size();
+      if (palSize > 1) {
+        color = app::Color::fromIndex((color.getIndex() + 1) % palSize);
+      }
       break;
     }
     case DecrementIndex: {
-      int index = color.getIndex();
-      if (index > 0)
-        color = app::Color::fromIndex(index-1);
+      const int palSize = get_current_palette()->size();
+      if (palSize > 1) {
+        // Variants on floorMod(int, int):
+        // (a % b + b) % b
+        // a - b * (a / b); if a < 0 then a += b
+        color = app::Color::fromIndex(((color.getIndex() - 1) % palSize + palSize) % palSize);
+      }
       break;
     }
   }

--- a/src/app/commands/cmd_change_color.cpp
+++ b/src/app/commands/cmd_change_color.cpp
@@ -75,20 +75,15 @@ void ChangeColorCommand::onExecute(Context* context)
       // do nothing
       break;
     case IncrementIndex: {
-      const int palSize = get_current_palette()->size();
-      if (palSize > 1) {
-        color = app::Color::fromIndex((color.getIndex() + 1) % palSize);
-      }
+      int index = color.getIndex();
+      if (index < get_current_palette()->size()-1)
+        color = app::Color::fromIndex(index+1);
       break;
     }
     case DecrementIndex: {
-      const int palSize = get_current_palette()->size();
-      if (palSize > 1) {
-        // Variants on floorMod(int, int):
-        // (a % b + b) % b
-        // a - b * (a / b); if a < 0 then a += b
-        color = app::Color::fromIndex(((color.getIndex() - 1) % palSize + palSize) % palSize);
-      }
+      int index = color.getIndex();
+      if (index > 0)
+        color = app::Color::fromIndex(index-1);
       break;
     }
   }

--- a/src/app/commands/cmd_change_color.cpp
+++ b/src/app/commands/cmd_change_color.cpp
@@ -75,15 +75,17 @@ void ChangeColorCommand::onExecute(Context* context)
       // do nothing
       break;
     case IncrementIndex: {
-      int index = color.getIndex();
-      if (index < get_current_palette()->size()-1)
-        color = app::Color::fromIndex(index+1);
+      const int palSize = get_current_palette()->size();
+      if (palSize > 1) {
+        color = app::Color::fromIndex((color.getIndex() + 1) % palSize);
+      }
       break;
     }
     case DecrementIndex: {
-      int index = color.getIndex();
-      if (index > 0)
-        color = app::Color::fromIndex(index-1);
+      const int palSize = get_current_palette()->size();
+      if (palSize > 1) {
+        color = app::Color::fromIndex(((color.getIndex() - 1) % palSize + palSize) % palSize);
+      }
       break;
     }
   }


### PR DESCRIPTION
Made Change Color: Increment/Decrement Foreground/Background cyclic instead of clamped. At last palette element, incrementing selected color returns to first element. At first palette element, decrementing color returns to last element.

I agree that my contributions are licensed under the Individual Contributor License Agreement V3.0 ("CLA") as stated in https://github.com/aseprite/sourcecode/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/aseprite/sourcecode/blob/main/sign-cla.md#sign-the-cla
