### PR TITLE
Cyclic Color Change in Palettes

### DIFF
--- a/src/app/commands/cmd_change_color.cpp
+++ b/src/app/commands/cmd_change_color.cpp
@@ -75,15 +75,20 @@ void ChangeColorCommand::onExecute(Context* context)
       // do nothing
       break;
     case IncrementIndex: {
-      int index = color.getIndex();
-      if (index < get_current_palette()->size()-1)
-        color = app::Color::fromIndex(index+1);
+      const int palSize = get_current_palette()->size();
+      if (palSize > 1) {
+        // Seems safe to assume getIndex() will return a
+        // positive number, so use truncation modulo.
+        color = app::Color::fromIndex((color.getIndex() + 1) % palSize);
+      }
       break;
     }
     case DecrementIndex: {
-      int index = color.getIndex();
-      if (index > 0)
-        color = app::Color::fromIndex(index-1);
+      const int palSize = get_current_palette()->size();
+      if (palSize > 1) {
+        // Floor modulo.
+        color = app::Color::fromIndex(((color.getIndex() - 1) % palSize + palSize) % palSize);
+      }
       break;
     }
   }


### PR DESCRIPTION
Made Change Color: Increment/Decrement Foreground/Background methods cyclic instead of clamped. At last palette element, incrementing selected color returns to first element. At first palette element, decrementing color returns to last element.

I agree that my contributions are licensed under the Individual Contributor License Agreement V3.0 ("CLA") as stated in https://github.com/aseprite/sourcecode/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/aseprite/sourcecode/blob/main/sign-cla.md#sign-the-cla
