### PR TITLE
Fixed saving of blend mode and opacity in aseprite files

### DIFF
--- a/src/dio/aseprite_decoder.cpp
+++ b/src/dio/aseprite_decoder.cpp
@@ -484,13 +484,6 @@ doc::Layer* AsepriteDecoder::readLayerChunk(AsepriteHeader* header,
 
     case ASE_FILE_LAYER_IMAGE:
       layer = new doc::LayerImage(sprite);
-
-      // Only transparent layers can have blend mode and opacity
-      if (!(flags & int(doc::LayerFlags::Background))) {
-        static_cast<doc::LayerImage*>(layer)->setBlendMode((doc::BlendMode)blendmode);
-        if (header->flags & ASE_FILE_FLAG_LAYER_WITH_OPACITY)
-          static_cast<doc::LayerImage*>(layer)->setOpacity(opacity);
-      }
       break;
 
     case ASE_FILE_LAYER_GROUP:
@@ -509,6 +502,12 @@ doc::Layer* AsepriteDecoder::readLayerChunk(AsepriteHeader* header,
   }
 
   if (layer) {
+    if (layer->isImage() && !(flags & int(doc::LayerFlags::Background))) {
+      // Only transparent layers can have blend mode and opacity
+      static_cast<doc::LayerImage*>(layer)->setBlendMode((doc::BlendMode)blendmode);
+      if (header->flags & ASE_FILE_FLAG_LAYER_WITH_OPACITY)
+        static_cast<doc::LayerImage*>(layer)->setOpacity(opacity);
+    }
     // flags
     layer->setFlags(static_cast<doc::LayerFlags>(
                       flags &


### PR DESCRIPTION
Fixed bug referenced in #2924 when blend mode and opacity are incorrectly saved because their default values are changed.