### PR TITLE
Fix disappearing tilemap layers on resizing canvas (fix #2942)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,8 +56,13 @@ jobs:
         if [[ "${{ runner.os }}" == "Linux" ]] ; then
           export XVFB=xvfb-run
         fi
+        if [[ "${{ github.base_ref }}" == "beta" ]] || [[ "${{ github.ref }}" == "beta" ]] ; then
+          export TESTS_BRANCH=beta
+        else
+          export TESTS_BRANCH=main
+        fi
         cd build
         export ASEPRITE=$PWD/bin/aseprite
-        git clone --recursive https://github.com/aseprite/tests.git
+        git clone --branch $TESTS_BRANCH --recursive https://github.com/aseprite/tests.git
         cd tests
         $XVFB bash run-tests.sh

--- a/src/app/commands/cmd_canvas_size.cpp
+++ b/src/app/commands/cmd_canvas_size.cpp
@@ -370,9 +370,14 @@ void CanvasSizeCommand::onExecute(Context* context)
 
     Preferences::instance().canvasSize.trimOutside(params.trimOutside());
 
-    bounds.enlarge(
-      gfx::Border(params.left(), params.top(),
-                  params.right(), params.bottom()));
+    if (params.bounds.isSet()) {
+      bounds = params.bounds();
+    }
+    else {
+      bounds.enlarge(
+        gfx::Border(params.left(), params.top(),
+                    params.right(), params.bottom()));
+    }
   }
 #endif
 


### PR DESCRIPTION
Details of bug can be seen in #2942 -- when a change to the canvas size makes the tilemap layers disappear completely.