### PR TITLE
Fix Alt+mouse wheel to scroll through tiles when we are in tiles mode (fix #2956)

### DIFF
--- a/src/app/ui/color_bar.cpp
+++ b/src/app/ui/color_bar.cpp
@@ -409,6 +409,22 @@ void ColorBar::setBgColor(const app::Color& color)
     onColorButtonChange(color);
 }
 
+void ColorBar::setFgTile(doc::tile_t tile)
+{
+  m_fgTile.setTile(tile);
+  m_tilesView.selectColor(tile);
+  if (!m_fromPalView)
+    onFgTileButtonChange(tile);
+}
+
+void ColorBar::setBgTile(doc::tile_t tile)
+{
+  m_bgTile.setTile(tile);
+  m_tilesView.selectColor(tile);
+  if (!m_fromPalView)
+    onBgTileButtonChange(tile);
+}
+
 doc::tile_index ColorBar::getFgTile() const
 {
   return m_fgTile.getTile();
@@ -1367,14 +1383,18 @@ void ColorBar::onColorButtonChange(const app::Color& color)
 
 void ColorBar::onFgTileButtonChange(doc::tile_t tile)
 {
-  if (!m_fromPref)
+  if (!m_fromPref) {
     Preferences::instance().colorBar.fgTile(tile);
+    m_tilesView.deselect();
+  }
 }
 
 void ColorBar::onBgTileButtonChange(doc::tile_t tile)
 {
-  if (!m_fromPref)
+  if (!m_fromPref) {
     Preferences::instance().colorBar.bgTile(tile);
+    m_tilesView.deselect();
+  }
 }
 
 void ColorBar::onPickSpectrum(const app::Color& color, ui::MouseButton button)
@@ -1547,10 +1567,8 @@ void ColorBar::onNewInputPriority(InputChainElement* element,
     return;
 
   if (element != this) {
-    if (m_tilemapMode == TilemapMode::Tiles)
-      m_tilesView.deselect();
-    else
-      m_paletteView.deselect();
+    m_paletteView.deselect();  
+    m_tilesView.deselect();
   }
 }
 

--- a/src/app/ui/color_bar.h
+++ b/src/app/ui/color_bar.h
@@ -76,6 +76,8 @@ namespace app {
 
     doc::tile_index getFgTile() const;
     doc::tile_index getBgTile() const;
+    void setFgTile(doc::tile_t tile);
+    void setBgTile(doc::tile_t tile);
 
     PaletteView* getPaletteView() { return &m_paletteView; }
     PaletteView* getTilesView() { return &m_tilesView; }

--- a/src/app/ui/editor/state_with_wheel_behavior.cpp
+++ b/src/app/ui/editor/state_with_wheel_behavior.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2020  Igara Studio S.A.
+// Copyright (C) 2020-2021  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This program is distributed under the terms of
@@ -56,10 +56,11 @@ bool StateWithWheelBehavior::onMouseWheel(Editor* editor, MouseMessage* msg)
   else {
     // Alt+mouse wheel changes the fg/bg colors
     if (msg->altPressed()) {
+      bool tilemapMode = (editor->getSite().tilemapMode() == TilemapMode::Tiles);
       if (msg->shiftPressed())
-        wheelAction = WheelAction::BgColor;
+        wheelAction = (tilemapMode ? WheelAction::BgTile : WheelAction::BgColor);
       else
-        wheelAction = WheelAction::FgColor;
+        wheelAction = (tilemapMode ? WheelAction::FgTile : WheelAction::FgColor);
     }
     // Normal behavior: mouse wheel zooms If the message is from a
     // precise wheel i.e. a trackpad/touch-like device, we scroll by
@@ -127,6 +128,24 @@ bool StateWithWheelBehavior::onMouseWheel(Editor* editor, MouseMessage* msg)
       int newIndex = ColorBar::instance()->getBgColor().getIndex() + int(dz);
       newIndex = base::clamp(newIndex, 0, lastIndex);
       ColorBar::instance()->setBgColor(app::Color::fromIndex(newIndex));
+      break;
+    }
+
+    case WheelAction::FgTile: {
+      auto tilesView = ColorBar::instance()->getTilesView();
+      int lastIndex = tilesView->tileset()->size()-1;
+      int newIndex = ColorBar::instance()->getFgTile() + int(dz);
+      newIndex = base::clamp(newIndex, 0, lastIndex);
+      ColorBar::instance()->setFgTile(newIndex);
+      break;
+    }
+
+    case WheelAction::BgTile: {
+      auto tilesView = ColorBar::instance()->getTilesView();
+      int lastIndex = tilesView->tileset()->size()-1;
+      int newIndex = ColorBar::instance()->getBgTile() + int(dz);
+      newIndex = base::clamp(newIndex, 0, lastIndex);
+      ColorBar::instance()->setBgTile(newIndex);
       break;
     }
 

--- a/src/app/ui/key.h
+++ b/src/app/ui/key.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2020  Igara Studio S.A.
+// Copyright (C) 2018-2021  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -73,6 +73,8 @@ namespace app {
     HScroll,
     FgColor,
     BgColor,
+    FgTile,
+    BgTile,
     Frame,
     BrushSize,
     BrushAngle,


### PR DESCRIPTION
Before this fix, Alt+mouse wheel to scroll through tiles didn't work as it did in the color palette.
Also, fixed tile deselection when user removes the focus of the tileset (for example, doing click in the editor).