### PR TITLE
Fix incorrect cropping rectangle calculation in canvas size command in lua script

### DIFF
--- a/src/app/commands/cmd_canvas_size.cpp
+++ b/src/app/commands/cmd_canvas_size.cpp
@@ -370,9 +370,14 @@ void CanvasSizeCommand::onExecute(Context* context)
 
     Preferences::instance().canvasSize.trimOutside(params.trimOutside());
 
-    bounds.enlarge(
-      gfx::Border(params.left(), params.top(),
-                  params.right(), params.bottom()));
+    if (params.bounds.isSet()) {
+      bounds = params.bounds();
+    }
+    else {
+      bounds.enlarge(
+        gfx::Border(params.left(), params.top(),
+                    params.right(), params.bottom()));
+    }
   }
 #endif
 


### PR DESCRIPTION
Prior to this fix, CanvasSize command via lua script results in bad canvas and image clipping.