### PR TITLE
Implement enabledness check for plugin commands

### DIFF
--- a/src/app/script/plugin_class.cpp
+++ b/src/app/script/plugin_class.cpp
@@ -31,10 +31,13 @@ class PluginCommand : public Command {
 public:
   PluginCommand(const std::string& id,
                 const std::string& title,
-                int onclickRef)
+                int onclickRef,
+                int onenabledRef)
     : Command(id.c_str(), CmdUIOnlyFlag)
     , m_title(title)
-    , m_onclickRef(onclickRef) {
+    , m_onclickRef(onclickRef)
+    , m_onenabledRef(onenabledRef)
+  {
   }
 
   ~PluginCommand() {
@@ -69,8 +72,30 @@ protected:
     }
   }
 
+  bool onEnabled(Context* context) override {
+    if (m_onenabledRef) {
+      script::Engine* engine = App::instance()->scriptEngine();
+      lua_State* L = engine->luaState();
+
+      lua_rawgeti(L, LUA_REGISTRYINDEX, m_onenabledRef);
+      if (lua_pcall(L, 0, 1, 0)) {
+        if (const char* s = lua_tostring(L, -1)) {
+          Console().printf("Error: %s", s);
+          return false;
+        }
+      }
+      else {
+        bool ret = lua_toboolean(L, -1);
+        lua_pop(L, 1);
+        return ret;
+      }
+    }
+    return true;
+  }
+
   std::string m_title;
   int m_onclickRef;
+  int m_onenabledRef;
 };
 
 void deleteCommandIfExistent(Extension* ext, const std::string& id)
@@ -94,6 +119,7 @@ int Plugin_newCommand(lua_State* L)
   auto plugin = get_obj<Plugin>(L, 1);
   if (lua_istable(L, 2)) {
     std::string id, title, group;
+    int onenabledRef = 0;
 
     lua_getfield(L, 2, "id");
     if (const char* s = lua_tostring(L, -1)) {
@@ -115,8 +141,16 @@ int Plugin_newCommand(lua_State* L)
       group = s;
     }
     lua_pop(L, 1);
+    
+    int type = lua_getfield(L, 2, "onenabled");
+    if (type == LUA_TFUNCTION) {
+      onenabledRef = luaL_ref(L, LUA_REGISTRYINDEX); // does a pop
+    }
+    else {
+      lua_pop(L, 1);
+    }
 
-    int type = lua_getfield(L, 2, "onclick");
+    type = lua_getfield(L, 2, "onclick");
     if (type == LUA_TFUNCTION) {
       int onclickRef = luaL_ref(L, LUA_REGISTRYINDEX);
 
@@ -124,7 +158,7 @@ int Plugin_newCommand(lua_State* L)
       // overwriting a previous registered command)
       deleteCommandIfExistent(plugin->ext, id);
 
-      auto cmd = new PluginCommand(id, title, onclickRef);
+      auto cmd = new PluginCommand(id, title, onclickRef, onenabledRef);
       Commands::instance()->add(cmd);
       plugin->ext->addCommand(id);
 


### PR DESCRIPTION
Adds an optional callback to `Plugin.newCommand` to disable irrelevant menu items, similar to the built-in commands.

```lua
  plugin:newCommand{
    id="CommandName",
    title="User Friendly Command Name",
    group=string,
    onenabled=function()
        return ... -- true / false
    end
    onclick=function()
      ...
    end
  }
```

[Test plugin](https://github.com/aseprite/aseprite/files/7242320/test_onenabled.aseprite-extension.zip) - test entries found in the help menu

----

I agree that my contributions are licensed under the Individual Contributor License Agreement V3.0 ("CLA") as stated in https://github.com/aseprite/sourcecode/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/aseprite/sourcecode/blob/main/sign-cla.md#sign-the-cla


