### PR TITLE
Interprocessing via WebSocket

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -66,3 +66,6 @@
 [submodule "src/tga"]
 	path = src/tga
 	url = https://github.com/aseprite/tga.git
+[submodule "third_party/IXWebSocket"]
+	path = third_party/IXWebSocket
+	url = https://github.com/machinezone/IXWebSocket

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ option(ENABLE_MEMLEAK      "Enable memory-leaks detector (only for developers)" 
 option(ENABLE_NEWS         "Enable the news in Home tab" on)
 option(ENABLE_UPDATER      "Enable automatic check for updates" on)
 option(ENABLE_SCRIPTING    "Compile with scripting support" on)
+option(ENABLE_WEBSOCKET    "Compile with websocket support" on)
 option(ENABLE_TESTS        "Compile unit tests" off)
 option(ENABLE_BENCHMARKS   "Compile benchmarks" off)
 option(ENABLE_TRIAL_MODE   "Compile the trial version" off)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,6 +74,11 @@ if(ENABLE_SCRIPTING)
   add_definitions(-DENABLE_SCRIPTING)
 endif()
 
+if(ENABLE_WEBSOCKET)
+  # Needed for "app" and "main"
+  add_definitions(-DENABLE_WEBSOCKET)
+endif()
+
 ######################################################################
 # Aseprite Libraries (in preferred order to be built)
 

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -673,7 +673,7 @@ if(REQUIRE_CURL)
 endif()
 
 if(ENABLE_SCRIPTING)
-  target_link_libraries(app-lib lua lauxlib lualib)
+  target_link_libraries(app-lib lua lauxlib lualib ixwebsocket)
 endif()
 
 if(ENABLE_UPDATER)

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -147,6 +147,10 @@ if(ENABLE_SCRIPTING)
       commands/cmd_open_script_folder.cpp
       ui/devconsole_view.cpp)
   endif()
+  if(ENABLE_WEBSOCKET)
+    set(scripting_files_ws
+      script/websocket_class.cpp)
+  endif()
   set(scripting_files
     commands/cmd_run_script.cpp
     script/app_command_object.cpp
@@ -189,8 +193,8 @@ if(ENABLE_SCRIPTING)
     script/tool_class.cpp
     script/values.cpp
     script/version_class.cpp
-    script/websocket_class.cpp
     shell.cpp
+    ${scripting_files_ws}
     ${scripting_files_ui})
 endif()
 
@@ -674,7 +678,11 @@ if(REQUIRE_CURL)
 endif()
 
 if(ENABLE_SCRIPTING)
-  target_link_libraries(app-lib lua lauxlib lualib ixwebsocket)
+  target_link_libraries(app-lib lua lauxlib lualib)
+
+  if(ENABLE_WEBSOCKET)
+    target_link_libraries(app-lib ixwebsocket)
+  endif()
 endif()
 
 if(ENABLE_UPDATER)

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -189,6 +189,7 @@ if(ENABLE_SCRIPTING)
     script/tool_class.cpp
     script/values.cpp
     script/version_class.cpp
+    script/websocket_class.cpp
     shell.cpp
     ${scripting_files_ui})
 endif()

--- a/src/app/script/engine.cpp
+++ b/src/app/script/engine.cpp
@@ -180,6 +180,7 @@ void register_tag_class(lua_State* L);
 void register_tags_class(lua_State* L);
 void register_tool_class(lua_State* L);
 void register_version_class(lua_State* L);
+void register_websocket_class(lua_State* L);
 
 void set_app_params(lua_State* L, const Params& params);
 
@@ -411,6 +412,7 @@ Engine::Engine()
   register_tags_class(L);
   register_tool_class(L);
   register_version_class(L);
+  register_websocket_class(L);
 
   // Check that we have a clean start (without dirty in the stack)
   ASSERT(lua_gettop(L) == top);

--- a/src/app/script/engine.cpp
+++ b/src/app/script/engine.cpp
@@ -412,7 +412,9 @@ Engine::Engine()
   register_tags_class(L);
   register_tool_class(L);
   register_version_class(L);
+#if ENABLE_WEBSOCKET
   register_websocket_class(L);
+ #endif
 
   // Check that we have a clean start (without dirty in the stack)
   ASSERT(lua_gettop(L) == top);

--- a/src/app/script/image_class.cpp
+++ b/src/app/script/image_class.cpp
@@ -483,6 +483,30 @@ int Image_resize(lua_State* L)
   return 0;
 }
 
+int Image_get_bytes(lua_State* L)
+{
+  const auto img = get_obj<ImageObj>(L, 1)->image(L);
+  lua_pushlstring(L, (const char*)img->getPixelAddress(0, 0), img->getRowStrideSize() * img->height());
+  return 1;
+}
+
+int Image_set_bytes(lua_State* L)
+{
+  const auto img = get_obj<ImageObj>(L, 1)->image(L);
+  size_t bytes_size, bytes_needed = img->getRowStrideSize() * img->height();
+  const char* bytes = lua_tolstring(L, 2, &bytes_size);
+
+  if (bytes_size == bytes_needed) {
+    memcpy_s(img->getPixelAddress(0, 0), bytes_needed, bytes, bytes_size);
+  }
+  else {
+    lua_pushfstring(L, "Data size does not match: given %d, needed %d.", bytes_size, bytes_needed);
+    lua_error(L);
+  }
+
+  return 0;
+}
+
 int Image_get_width(lua_State* L)
 {
   const auto obj = get_obj<ImageObj>(L, 1);
@@ -537,6 +561,7 @@ const luaL_Reg Image_methods[] = {
 };
 
 const Property Image_properties[] = {
+  { "bytes", Image_get_bytes, Image_set_bytes },
   { "width", Image_get_width, nullptr },
   { "height", Image_get_height, nullptr },
   { "colorMode", Image_get_colorMode, nullptr },

--- a/src/app/script/sprite_class.cpp
+++ b/src/app/script/sprite_class.cpp
@@ -172,6 +172,18 @@ int Sprite_new(lua_State* L)
   return 1;
 }
 
+int Sprite_gc(lua_State* L)
+{
+  auto sprite = get_docobj<Sprite>(L, 1);
+  auto doc = static_cast<Doc*>(sprite->document());
+
+  if (ScriptDocObserver* obs = script_observers[sprite->id()]) {
+    doc->undoHistory()->remove_observer(obs);
+    script_observers.erase(sprite->id());
+  }
+  return 0;
+}
+
 int Sprite_eq(lua_State* L)
 {
   const auto a = get_docobj<Sprite>(L, 1);
@@ -871,6 +883,7 @@ int Sprite_set_pixelRatio(lua_State* L)
 }
 
 const luaL_Reg Sprite_methods[] = {
+  { "__gc", Sprite_gc },
   { "__eq", Sprite_eq },
   { "resize", Sprite_resize },
   { "crop", Sprite_crop },

--- a/src/app/script/websocket_class.cpp
+++ b/src/app/script/websocket_class.cpp
@@ -93,7 +93,6 @@ int WebSocket_sendText(lua_State* L)
     const char* buf = lua_tolstring(L, i, &bufLen);
     data.write(buf, bufLen);
   }
-  lua_pop(L, argc);
 
   ws->sendText(data.str());
   return 0;
@@ -110,7 +109,6 @@ int WebSocket_sendBinary(lua_State* L)
     const char* buf = lua_tolstring(L, i, &bufLen);
     data.write(buf, bufLen);
   }
-  lua_pop(L, argc);
 
   ws->sendBinary(data.str());
   return 0;
@@ -119,7 +117,6 @@ int WebSocket_sendBinary(lua_State* L)
 int WebSocket_connect(lua_State* L)
 {
   auto ws = get_ptr<ix::WebSocket>(L, 1);
-  lua_pop(L, 1);
   ws->start();
   return 0;
 }
@@ -127,7 +124,6 @@ int WebSocket_connect(lua_State* L)
 int WebSocket_close(lua_State* L)
 {
   auto ws = get_ptr<ix::WebSocket>(L, 1);
-  lua_pop(L, 1);
   ws->stop();
   return 0;
 }
@@ -135,7 +131,6 @@ int WebSocket_close(lua_State* L)
 int WebSocket_get_url(lua_State* L)
 {
   auto ws = get_ptr<ix::WebSocket>(L, 1);
-  lua_pop(L, 1);
   lua_pushstring(L, ws->getUrl().c_str());
   return 1;
 }

--- a/src/app/script/websocket_class.cpp
+++ b/src/app/script/websocket_class.cpp
@@ -1,0 +1,180 @@
+// Aseprite
+// Copyright (C) 2018-2020  Igara Studio S.A.
+// Copyright (C) 2018  David Capello
+//
+// This program is distributed under the terms of
+// the End-User License Agreement for Aseprite.
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "app/app.h"
+#include "app/console.h"
+#include "app/script/docobj.h"
+#include "app/script/engine.h"
+#include "app/script/luacpp.h"
+
+#include <ixwebsocket/IXNetSystem.h>
+#include <ixwebsocket/IXWebSocket.h>
+#include <sstream>
+
+namespace app {
+namespace script {
+
+namespace {
+// additional "enum" value to make message callback simpler
+#define MESSAGE_TYPE_BINARY (int)ix::WebSocketMessageType::Fragment + 10
+
+int WebSocket_new(lua_State* L)
+{
+  static std::once_flag f;
+  std::call_once(f, &ix::initNetSystem);
+
+  auto ws = new ix::WebSocket();
+
+  push_ptr(L, ws);
+  
+  if (lua_istable(L, 1)) {
+    lua_getfield(L, 1, "url");
+    if (const char* s = lua_tostring(L, -1)) {
+      ws->setUrl(s);
+    }
+    lua_pop(L, 1);
+
+    int type = lua_getfield(L, 1, "onreceive");
+    if (type == LUA_TFUNCTION) {
+      int onreceiveRef = luaL_ref(L, LUA_REGISTRYINDEX);
+
+      ws->setOnMessageCallback([L, ws, onreceiveRef](const ix::WebSocketMessagePtr& msg) {
+        lua_rawgeti(L, LUA_REGISTRYINDEX, onreceiveRef);
+        lua_pushnumber(L, (msg->binary ? MESSAGE_TYPE_BINARY : static_cast<int>(msg->type)));
+        lua_pushlstring(L, msg->str.c_str(), msg->str.length());
+
+        if (lua_pcall(L, 2, 0, 0)) {
+          if (const char* s = lua_tostring(L, -1)) {
+            App::instance()->scriptEngine()->consolePrint(s);
+            ws->disableAutomaticReconnection();
+            ws->close();
+          }
+        }
+      });
+    }
+    else {
+      lua_pop(L, 1);
+    }
+  }
+
+  return 1;
+}
+
+int WebSocket_gc(lua_State* L)
+{
+  auto ws = get_ptr<ix::WebSocket>(L, 1);
+  ws->stop();
+  delete ws;
+  return 0;
+}
+
+int WebSocket_sendText(lua_State* L)
+{
+  auto ws = get_ptr<ix::WebSocket>(L, 1);
+  std::stringstream data;
+  int argc = lua_gettop(L);
+
+  for (int i = 2; i <= argc; i++) {
+    size_t bufLen;
+    const char* buf = lua_tolstring(L, i, &bufLen);
+    data.write(buf, bufLen);
+  }
+  lua_pop(L, argc);
+
+  ws->sendText(data.str());
+  return 0;
+}
+
+int WebSocket_sendBinary(lua_State* L)
+{
+  auto ws = get_ptr<ix::WebSocket>(L, 1);
+  std::stringstream data;
+  int argc = lua_gettop(L);
+
+  for (int i = 2; i <= argc; i++) {
+    size_t bufLen;
+    const char* buf = lua_tolstring(L, i, &bufLen);
+    data.write(buf, bufLen);
+  }
+  lua_pop(L, argc);
+
+  ws->sendBinary(data.str());
+  return 0;
+}
+
+int WebSocket_connect(lua_State* L)
+{
+  auto ws = get_ptr<ix::WebSocket>(L, 1);
+  lua_pop(L, 1);
+  ws->enableAutomaticReconnection();
+  ws->start();
+  return 0;
+}
+
+int WebSocket_close(lua_State* L)
+{
+  auto ws = get_ptr<ix::WebSocket>(L, 1);
+  lua_pop(L, 1);
+  ws->disableAutomaticReconnection();
+  ws->close();
+  return 0;
+}
+
+int WebSocket_get_url(lua_State* L)
+{
+  auto ws = get_ptr<ix::WebSocket>(L, 1);
+  lua_pop(L, 1);
+  lua_pushstring(L, ws->getUrl().c_str());
+  return 1;
+}
+
+const luaL_Reg WebSocket_methods[] = { 
+  { "__gc", WebSocket_gc },
+  { "close", WebSocket_close },
+  { "connect", WebSocket_connect },
+  { "sendText", WebSocket_sendText },
+  { "sendBinary", WebSocket_sendBinary },
+  { nullptr, nullptr }
+};
+
+const Property WebSocket_properties[] = { 
+  { "url", WebSocket_get_url, nullptr },
+  { nullptr, nullptr, nullptr }
+};
+
+} // namespace { }
+
+using WebSocket = ix::WebSocket;
+DEF_MTNAME(WebSocket);
+
+void register_websocket_class(lua_State* L)
+{
+  REG_CLASS(L, WebSocket);
+  REG_CLASS_NEW(L, WebSocket);
+  REG_CLASS_PROPERTIES(L, WebSocket);
+
+  // message type enum
+  lua_newtable(L);
+  lua_pushvalue(L, -1);
+  lua_setglobal(L, "MessageType");
+  setfield_integer(L, "Text", (int)ix::WebSocketMessageType::Message);
+  setfield_integer(L, "Binary", MESSAGE_TYPE_BINARY);
+  setfield_integer(L, "Open", (int)ix::WebSocketMessageType::Open);
+  setfield_integer(L, "Close", (int)ix::WebSocketMessageType::Close);
+  setfield_integer(L, "Error", (int)ix::WebSocketMessageType::Error);
+  setfield_integer(L, "Ping", (int)ix::WebSocketMessageType::Ping);
+  setfield_integer(L, "Pong", (int)ix::WebSocketMessageType::Pong);
+  setfield_integer(L, "Fragment", (int)ix::WebSocketMessageType::Fragment);
+  lua_pop(L, 1);
+}
+
+} // namespace script
+} // namespace app

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -160,7 +160,10 @@ if(ENABLE_SCRIPTING)
   target_include_directories(lualib PUBLIC lua)
   target_link_libraries(lauxlib lua)
 
-# ixwebsocket
-add_subdirectory(ixwebsocket)
-target_include_directories(ixwebsocket PUBLIC)
+  # ixwebsocket
+  if(ENABLE_WEBSOCKET)
+    add_subdirectory(IXWebSocket)
+    target_include_directories(ixwebsocket PUBLIC)
+  endif()
+
 endif()

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -159,4 +159,8 @@ if(ENABLE_SCRIPTING)
   target_include_directories(lauxlib PUBLIC lua)
   target_include_directories(lualib PUBLIC lua)
   target_link_libraries(lauxlib lua)
+
+# ixwebsocket
+add_subdirectory(ixwebsocket)
+target_include_directories(ixwebsocket PUBLIC)
 endif()


### PR DESCRIPTION
Suggestion of adding a websocket client available to the scripting API, and a few other things that make it useful for live syncing with other applications.

## Motivation

When using aseprite with some other applications, needing to save/export a file and reload it feels rather limiting. It’d be great to share data in real time automatically, in both directions. The patch is based on my in-house solution for updating textures in Blender. I also noticed similar desires in [LDTk](https://github.com/deepnight/ldtk) (watching for .ase file change) and [Sprytile](https://github.com/Sprytile/Sprytile) (reloading periodically). There’s also some possibilities beyond data syncing. While websocket isn’t the most elegant way of interprocessing, it’s cross-platform, well supported, and easy to understand.

## Changes in the Lua API
 - `WebSocket` type that implements a client (using https://github.com/machinezone/IXWebSocket)
 - `onchange` callback to Sprite and Site, added in order to react to the changes
 - `Image:bytes` property for getting and setting image data as a byte string

All changes [doc.md](https://github.com/aseprite/aseprite/files/7274198/apichange.md)

Demo: [external preview app](https://github.com/lampysprites/aseprite-interprocessing-demo)

## Notes and further discussion

- CMake: Websocket dependency and functionality can be disabled with `-DENABLE_WEBSOCKETS=OFF` . To avoid a warning, replace `third_party/IXWebSocket/CMakeLists.txt` (solution offered by dacap) - [diff.txt](https://github.com/aseprite/aseprite/files/7274210/diff.txt)

- Perhaps networking should prompt for a permission the same way as file ops do now.

- It’s a bit dangerous that a forgotten connection will be only closed during garbage collection. So, for example, assigning it to a global variable will keep it, and callback will be called after the script finishes. It also might be done on purpose, so I guess closing becomes a developer’s responsibility.

- Sprite’s onChange lifespan is kinda messy since internally it’s one per document, but is cleaned during GC. I haven’t realized the contradiction until writing the docs. Thinking of removing the gc at all, or just checking that it’s not some other callback being removed. Would love to hear some suggestions.

- I don’t think there’s a way to check if it’s safe to modify an image asynchronously, but in my previous blender-specific patch it was a rare event. At times it crashed, but usually only an  “another operation is happening” message showed.

- Currently, only client implementation is exposed to the API. IXWebSocket already implements the server, so adding it is not that hard, but feels a bit excessive? Needs more opinions.

-------

I agree that my contributions are licensed under the Individual Contributor License Agreement V3.0 ("CLA") as stated in https://github.com/aseprite/sourcecode/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/aseprite/sourcecode/blob/main/sign-cla.md#sign-the-cla
