### PR TITLE
Expose Layer Is Reference Getter

### DIFF
--- a/src/app/script/layer_class.cpp
+++ b/src/app/script/layer_class.cpp
@@ -201,6 +201,13 @@ int Layer_get_isExpanded(lua_State* L)
   return 1;
 }
 
+int Layer_get_isReference(lua_State* L)
+{
+  auto layer = get_docobj<Layer>(L, 1);
+  lua_pushboolean(L, layer->isReference());
+  return 1;
+}
+
 int Layer_get_cels(lua_State* L)
 {
   auto layer = get_docobj<Layer>(L, 1);
@@ -377,6 +384,7 @@ const Property Layer_properties[] = {
   { "isContinuous", Layer_get_isContinuous, Layer_set_isContinuous },
   { "isCollapsed", Layer_get_isCollapsed, Layer_set_isCollapsed },
   { "isExpanded", Layer_get_isExpanded, Layer_set_isExpanded },
+  { "isReference", Layer_get_isReference, nullptr },
   { "cels", Layer_get_cels, nullptr },
   { "color", UserData_get_color<Layer>, UserData_set_color<Layer> },
   { "data", UserData_get_text<Layer>, UserData_set_text<Layer> },


### PR DESCRIPTION
Exposes a getter for layer is reference in the Lua scripting API. The setter is left as a nullptr. See https://community.aseprite.org/t/do-reference-layers-have-any-special-attributes/11219 . The acceptance of this pull request would trigger a need to update the documentation at https://github.com/aseprite/api/blob/main/api/layer.md specifically (and any API versioning more generally).

I agree that my contributions are licensed under the Individual Contributor License Agreement V3.0 ("CLA") as stated in https://github.com/aseprite/sourcecode/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/aseprite/sourcecode/blob/main/sign-cla.md#sign-the-cla
