### PR TITLE
Floor Modulo in Shift Image Mask

### DIFF
--- a/src/doc/algorithm/shift_image.cpp
+++ b/src/doc/algorithm/shift_image.cpp
@@ -90,18 +90,28 @@ ImageRef shift_image_with_mask(const Cel* cel,
   ImageRef imageToShift(Image::create(compImage->pixelFormat(), maskedBounds.w, maskedBounds.h));
   imageToShift->copy(compImage.get(), gfx::Clip(0, 0, maskedBounds));
 
-  // Shiftting the masked area of the COMPOUND IMAGE (compImage).
-  int initialX = maskedBounds.x;
-  int initialY = maskedBounds.y;
-  int finalX = maskedBounds.x2();
-  int finalY = maskedBounds.y2();
-  for (int y=initialY; y<finalY; ++y) {
-    for (int x=initialX; x<finalX; ++x) {
-        put_pixel(compImage.get(),
-                  initialX + (maskedBounds.w + dx + x-initialX) % maskedBounds.w,
-                  initialY + (maskedBounds.h + dy + y-initialY) % maskedBounds.h,
-                  get_pixel(imageToShift.get(), x - initialX, y - initialY));
-    }
+  // Shifting the masked area of the COMPOUND IMAGE (compImage).
+  const int xInitial = maskedBounds.x;
+  const int yInitial = maskedBounds.y;
+  const int wMask = maskedBounds.w;
+  const int hMask = maskedBounds.h;
+  const int pxLen = wMask * hMask;
+  for (int i=0; i<pxLen; ++i) {
+    const int x = i % wMask;
+    const int y = i / wMask;
+    
+    // Use floor modulo (Euclidean remainder).
+    // Shifts are broken out and stored in separate variables
+    // to make them easier to recognize and change in the event
+    // that rem_eucl is implemented formally in the future.
+    const int xShift = ((dx + x) % wMask + wMask) % wMask;
+    const int yShift = ((dy + y) % hMask + hMask) % hMask;
+    
+    put_pixel(
+      compImage.get(),
+      xInitial + xShift,
+      yInitial + yShift,
+      get_pixel(imageToShift.get(), x, y));
   }
 
   // Bounds and Image shrinking (we have to fit compound image (compImage) and bounds (compCelBounds))


### PR DESCRIPTION
Changed shift image with mask routine to use floor modulo (or Euclidean remainder). Changed two nested for loops to one for loop.

In response to bug report at https://community.aseprite.org/t/app-command-movemask-error-when-wrapping-with-a-value-higher-than-sprite-width/10437 .

Tested with this image from the original post:

![mandrill](https://user-images.githubusercontent.com/12038348/137385556-00895198-7260-412f-ad98-5e866e9d8e46.png)

and this Lua script:

```lua
app.command.MoveMask {
    target = "content",
    wrap = true,
    direction = "left",
    units = "pixel",
    quantity = 320
}

app.refresh()
```

Behavior before in v1.3-beta6-x64 vs. after in pull request:

![shiftBehave1_3_b6](https://user-images.githubusercontent.com/12038348/137386804-f1d3efc6-1680-40ed-a8e5-b6e5d717587f.png) ![shiftBehavePr](https://user-images.githubusercontent.com/12038348/137386823-c84b077f-c572-4561-8fcd-398c3aa24025.png)

On undo:

![shiftUndo1_3_b6](https://user-images.githubusercontent.com/12038348/137387181-08796ed8-684b-42a6-8170-822f8f47fcce.png) ![shiftUndoPr](https://user-images.githubusercontent.com/12038348/137387210-6941818e-2e5f-43d7-a193-5b7f1fc90da0.png)

There are wrapping behaviors that users may find counterintuitive or unexpected, but which I'm assuming are as designed.

From the PR build:

![prBeyondLayerEdges01](https://user-images.githubusercontent.com/12038348/137388548-78357c41-9a2c-452b-8020-2d601b6554fc.png)
![prBeyondLayerEdges02](https://user-images.githubusercontent.com/12038348/137388565-4cc374ad-062d-4a27-a82d-82081f1f2d06.png)

I agree that my contributions are licensed under the Individual Contributor License Agreement V3.0 ("CLA") as stated in https://github.com/aseprite/sourcecode/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/aseprite/sourcecode/blob/main/sign-cla.md#sign-the-cla
