### PR TITLE
Fix double-clicking a .aseprite file in macOS Finder doesn't open the file anymore (fix #2985)

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -306,8 +306,7 @@ int App::initialize(const AppOptions& options)
     ui::set_mouse_cursor_scale(preferences().cursor.cursorScale());
     ui::set_mouse_cursor(kArrowCursor);
 
-    auto manager = ui::Manager::getDefault();
-    manager->invalidate();
+    ui::Manager::getDefault()->invalidate();
 
     // Create the main window.
     m_mainWindow.reset(new MainWindow);
@@ -325,17 +324,15 @@ int App::initialize(const AppOptions& options)
     // Show the main window (this is not modal, the code continues)
     m_mainWindow->openWindow();
 
-    // Redraw the whole screen.
-    manager->invalidate();
-
-    // Pump some messages so we receive the first
-    // Manager::onNewDisplayConfiguration() and we known the manager
-    // initial size. This is required so if the OpenFileCommand
+    // To refresh the manager size we call to
+    // Manager::updateAllDisplaysWithNewScale(...) to call to
+    // Manager::onNewDisplayConfiguration()
+    // This is required to OpenFileCommand
     // (called when we're processing the CLI with OpenBatchOfFiles)
     // shows a dialog to open a sequence of files, the dialog is
     // centered correctly to the manager bounds.
-    ui::MessageLoop loop(manager);
-    loop.pumpMessages();
+    const int scale = Preferences::instance().general.screenScale();
+    ui::Manager::getDefault()->updateAllDisplaysWithNewScale(scale);
   }
 #endif  // ENABLE_UI
 


### PR DESCRIPTION
I tested this fix taking as base commit 2fa47b59c9812909431421461151d7897f2a46a8 (Center the "open sequence" dialog correctly when it's showed from a file specified in the CLI (fix #2899)) where the error was introduced. I made a video to show that this fix solves the issue, because I used an unconventional way to test it.

This commit addresses both situations:
1- Center the "open sequence" dialog correctly when it's showed from a file specified in the CLI.
2- Double-clicking a .aseprite file in macOS Finder opens the file.

Note: I couldn't test (2) with base commit d1e02cc3c1194a339caf326644a61415a374f452 -last commit to date- because I doesn't find a way to test it.