### PR TITLE
Dialog:modify() support for combobox options

### DIFF
--- a/src/app/script/dialog_class.cpp
+++ b/src/app/script/dialog_class.cpp
@@ -939,6 +939,24 @@ int Dialog_modify(lua_State* L)
       }
     }
     lua_pop(L, 1);
+    // Handling options before option should support
+    // using both or only one of them at the same time
+    type = lua_getfield(L, 2, "options");
+    if (type != LUA_TNIL) {
+      if (lua_istable(L, -1)) {
+        if (auto combobox = dynamic_cast<ui::ComboBox*>(widget)) {
+          combobox->deleteAllItems();
+        lua_pushnil(L);
+        while (lua_next(L, -2) != 0) {
+          if (auto p = lua_tostring(L, -1)){
+            combobox->addItem(p);
+          }
+          lua_pop(L, 1);
+        }
+        }
+      }
+    }
+    lua_pop(L, 1);
 
     type = lua_getfield(L, 2, "option");
     if (auto p = lua_tostring(L, -1)) {
@@ -983,7 +1001,7 @@ int Dialog_modify(lua_State* L)
     }
     lua_pop(L, 1);
 
-    // TODO combobox options? shades mode? file title / open / save / filetypes? on* events?
+    // TODO shades mode? file title / open / save / filetypes? on* events?
 
     if (relayout) {
       dlg->window.layout();

--- a/src/app/script/dialog_class.cpp
+++ b/src/app/script/dialog_class.cpp
@@ -947,12 +947,16 @@ int Dialog_modify(lua_State* L)
         if (auto combobox = dynamic_cast<ui::ComboBox*>(widget)) {
           combobox->deleteAllItems();
         lua_pushnil(L);
+        bool empty = true;
         while (lua_next(L, -2) != 0) {
           if (auto p = lua_tostring(L, -1)){
             combobox->addItem(p);
+            empty = false;
           }
           lua_pop(L, 1);
         }
+        if (empty)
+          combobox->getEntryWidget()->setText("");
         }
       }
     }

--- a/src/app/script/dialog_class.cpp
+++ b/src/app/script/dialog_class.cpp
@@ -946,17 +946,17 @@ int Dialog_modify(lua_State* L)
       if (lua_istable(L, -1)) {
         if (auto combobox = dynamic_cast<ui::ComboBox*>(widget)) {
           combobox->deleteAllItems();
-        lua_pushnil(L);
-        bool empty = true;
-        while (lua_next(L, -2) != 0) {
-          if (auto p = lua_tostring(L, -1)){
-            combobox->addItem(p);
-            empty = false;
+          lua_pushnil(L);
+          bool empty = true;
+          while (lua_next(L, -2) != 0) {
+            if (auto p = lua_tostring(L, -1)){
+              combobox->addItem(p);
+              empty = false;
+            }
+            lua_pop(L, 1);
           }
-          lua_pop(L, 1);
-        }
-        if (empty)
-          combobox->getEntryWidget()->setText("");
+          if (empty)
+            combobox->getEntryWidget()->setText("");
         }
       }
     }


### PR DESCRIPTION
I agree that my contributions are licensed under the Individual Contributor License Agreement V3.0 ("CLA") as stated in https://github.com/aseprite/sourcecode/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/aseprite/sourcecode/blob/main/sign-cla.md#sign-the-cla
___
related to https://github.com/aseprite/api/issues/61
`Dialog:modify()` now supports modifying
1. both `options` and `option` which sets `options` then selects the item specified with `option`
2. `options` alone which sets the selected item to the first item in the list or sets text to `""` if the list is empty
3. `option` alone which is already supported