### PR TITLE
Fix Right Angle Rotation Check

### DIFF
--- a/src/app/ui/editor/pixels_movement.cpp
+++ b/src/app/ui/editor/pixels_movement.cpp
@@ -873,9 +873,9 @@ void PixelsMovement::drawParallelogram(
   // as it's pixel-perfect match with the original selection when just
   // a translation is applied.
   double angle = 180.0*transformation.angle()/PI;
+  angle = angle-360.0*std::floor(angle/360.0);
   if (!Preferences::instance().selection.forceRotsprite() &&
-      (std::fabs(std::fmod(std::fabs(angle), 90.0)) < 0.01 ||
-       std::fabs(std::fmod(std::fabs(angle), 90.0)-90.0) < 0.01)) {
+      std::fmod(angle, 90.0) < 0.01) {
     rotAlgo = tools::RotationAlgorithm::FAST;
   }
 


### PR DESCRIPTION
Simplified check for right angle rotation in pixels movement. Reference to https://github.com/aseprite/aseprite/issues/3041 .

I agree that my contributions are licensed under the Individual Contributor License Agreement V3.0 ("CLA") as stated in https://github.com/aseprite/sourcecode/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/aseprite/sourcecode/blob/main/sign-cla.md#sign-the-cla
