### PR TITLE
[lua] Add "filenamechange" event to Sprite.events

### DIFF
--- a/src/app/script/events_class.cpp
+++ b/src/app/script/events_class.cpp
@@ -192,7 +192,7 @@ class SpriteEvents : public Events
                    , public DocUndoObserver
                    , public DocObserver {
 public:
-  enum : EventType { Unknown = -1, Change };
+  enum : EventType { Unknown = -1, Change, FilenameChange };
 
   SpriteEvents(const Sprite* sprite)
     : m_spriteId(sprite->id()) {
@@ -211,6 +211,8 @@ public:
   EventType eventType(const char* eventName) const {
     if (std::strcmp(eventName, "change") == 0)
       return Change;
+    if (std::strcmp(eventName, "filenamechange") == 0)
+      return FilenameChange;
     else
       return Unknown;
   }
@@ -224,6 +226,8 @@ public:
       g_spriteEvents.erase(it);
     }
   }
+
+  void onFileNameChanged(Doc* doc) override { call(FilenameChange); }
 
   // DocUndoObserver impl
   void onAddUndoState(DocUndo* history) override { call(Change);  }


### PR DESCRIPTION
Can be convenient for watching app state. I think it could possibly just emit "change" and expect the scripter to put an if/else.

One other use I can think of is keeping some custom data in an external file, if text .data is not enough.

`Document::setFilename` currently fires the event without checking if the string actually changed, and I think it's ok.

Doc can be :

* `'filenamechange'`: When `Sprite.filename` is modified by user saving the file or a script. It happens even if the name string remains the same.

-------------------

I agree that my contributions are licensed under the Individual Contributor License Agreement V3.0 ("CLA") as stated in https://github.com/aseprite/sourcecode/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/aseprite/sourcecode/blob/main/sign-cla.md#sign-the-cla
