### PR TITLE
Fix confusion bug when layer name is an integer(fix #3045)

### DIFF
--- a/src/app/script/layers_class.cpp
+++ b/src/app/script/layers_class.cpp
@@ -61,7 +61,7 @@ int Layers_index(lua_State* L)
   auto obj = get_obj<LayersObj>(L, 1);
 
   // Index by layer name
-  if (lua_isstring(L, 2)) {
+  if (lua_type(L, 2) == LUA_TSTRING) {
     if (const char* name = lua_tostring(L, 2)) {
       for (ObjectId layerId : obj->layers) {
         Layer* layer = doc::get<Layer>(layerId);


### PR DESCRIPTION
This PR fixes a bug in the scripting engine where having an integer as a layer name confuses the `Layers_index`, so we add a check that is a lot stricter and avoids conversion from integer to strings.