### PR TITLE
Save and retain color profile when saving palettes (fix #2893)

### DIFF
--- a/src/app/commands/cmd_save_palette.cpp
+++ b/src/app/commands/cmd_save_palette.cpp
@@ -14,6 +14,7 @@
 #include "app/commands/commands.h"
 #include "app/commands/params.h"
 #include "app/context.h"
+#include "app/doc.h"
 #include "app/file/palette_file.h"
 #include "app/file_selector.h"
 #include "app/i18n/strings.h"
@@ -82,13 +83,17 @@ void SavePaletteCommand::onExecute(Context* ctx)
       return;
     }
   }
+  gfx::ColorSpaceRef colorSpace = nullptr;
+  auto activeDoc = ctx->activeDocument();
+  if (activeDoc)
+    colorSpace = activeDoc->sprite()->colorSpace();
 
-  if (!save_palette(filename.c_str(), palette, 16)) // TODO 16 should be configurable
+  if (!save_palette(filename.c_str(), palette, 16, colorSpace)) // TODO 16 should be configurable
     ui::Alert::show(fmt::format(Strings::alerts_error_saving_file(), filename));
 
   if (m_preset == get_default_palette_preset_name()) {
     set_default_palette(palette);
-    if (!ctx->activeDocument())
+    if (!activeDoc)
       set_current_palette(palette, false);
   }
   if (m_saveAsPreset) {

--- a/src/app/file/palette_file.cpp
+++ b/src/app/file/palette_file.cpp
@@ -118,7 +118,8 @@ Palette* load_palette(const char* filename,
   return pal;
 }
 
-bool save_palette(const char* filename, const Palette* pal, int columns)
+bool save_palette(const char* filename, const Palette* pal, int columns,
+                  const gfx::ColorSpaceRef& cs)
 {
   dio::FileFormat dioFormat = dio::detect_format_by_file_extension(filename);
   bool success = false;
@@ -154,11 +155,12 @@ bool save_palette(const char* filename, const Palette* pal, int columns)
       int h = (pal->size() / w) + (pal->size() % w > 0 ? 1: 0);
 
       Context tmpContext;
+      gfx::ColorSpaceRef colorSpace = (cs ? cs: gfx::ColorSpace::MakeNone());
       Doc* doc = tmpContext.documents().add(
         new Doc(Sprite::MakeStdSprite(
                   ImageSpec((pal->size() <= 256 ? doc::ColorMode::INDEXED:
                                                   doc::ColorMode::RGB),
-                            w, h), pal->size())));
+                            w, h, 0, colorSpace), pal->size())));
 
       Sprite* sprite = doc->sprite();
       doc->sprite()->setPalette(pal, false);

--- a/src/app/file/palette_file.h
+++ b/src/app/file/palette_file.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "base/paths.h"
+#include "gfx/color_space.h"
 
 namespace doc {
   class Palette;
@@ -23,8 +24,10 @@ namespace app {
 
   doc::Palette* load_palette(const char *filename,
                              const FileOpConfig* config = nullptr);
-  bool save_palette(const char *filename, const doc::Palette* pal,
-                    int columns);
+  bool save_palette(const char *filename,
+                    const doc::Palette* pal,
+                    int columns,
+                    const gfx::ColorSpaceRef& colorSpace);
 
 } // namespace app
 

--- a/src/app/modules/palettes.cpp
+++ b/src/app/modules/palettes.cpp
@@ -109,7 +109,7 @@ void load_default_palette()
     // Save default.ase file
     if (pal) {
       palFile = defaultPalName;
-      save_palette(palFile.c_str(), pal.get(), 0);
+      save_palette(palFile.c_str(), pal.get(), 0, nullptr);
     }
   }
 

--- a/src/app/script/palette_class.cpp
+++ b/src/app/script/palette_class.cpp
@@ -238,12 +238,17 @@ int Palette_saveAs(lua_State* L)
   auto obj = get_obj<PaletteObj>(L, 1);
   auto pal = obj->palette(L);
   const char* fn = luaL_checkstring(L, 2);
+  Sprite* sprite = obj->sprite(L);
+
   if (fn) {
     std::string absFn = base::get_absolute_path(fn);
     if (!ask_access(L, absFn.c_str(), FileAccessMode::Write, ResourceType::File))
       return luaL_error(L, "script doesn't have access to write file %s",
                         absFn.c_str());
-    save_palette(absFn.c_str(), pal, pal->size());
+    save_palette(absFn.c_str(),
+                 pal,
+                 pal->size(),
+                 (sprite ? sprite->colorSpace(): nullptr));
   }
   return 0;
 }


### PR DESCRIPTION
This PR allows retaining color profile (in file format that is capable of holding it), when saving palettes from palette panel.