### PR TITLE
Fix tilemap layers empty after converting to a color profile (fix #3052)

### DIFF
--- a/src/app/cmd/convert_color_profile.cpp
+++ b/src/app/cmd/convert_color_profile.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2020  Igara Studio S.A.
+// Copyright (C) 2018-2021  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -88,10 +88,12 @@ void convert_color_profile(doc::Sprite* sprite,
   if (sprite->pixelFormat() != doc::IMAGE_INDEXED) {
     for (Cel* cel : sprite->uniqueCels()) {
       ImageRef old_image = cel->imageRef();
-      ImageRef new_image = convert_image_color_space(
-        old_image.get(), newCS, conversion.get());
+      if (old_image.get()->pixelFormat() != IMAGE_TILEMAP) {
+        ImageRef new_image = convert_image_color_space(
+          old_image.get(), newCS, conversion.get());
 
-      sprite->replaceImage(old_image->id(), new_image);
+        sprite->replaceImage(old_image->id(), new_image);
+      }
     }
   }
 
@@ -181,10 +183,12 @@ ConvertColorProfile::ConvertColorProfile(doc::Sprite* sprite, const gfx::ColorSp
   if (sprite->pixelFormat() != doc::IMAGE_INDEXED) {
     for (Cel* cel : sprite->uniqueCels()) {
       ImageRef old_image = cel->imageRef();
-      ImageRef new_image = convert_image_color_space(
-        old_image.get(), newCS, conversion.get());
+      if (old_image.get()->pixelFormat() != IMAGE_TILEMAP) {
+        ImageRef new_image = convert_image_color_space(
+          old_image.get(), newCS, conversion.get());
 
-      m_seq.add(new cmd::ReplaceImage(sprite, old_image, new_image));
+        m_seq.add(new cmd::ReplaceImage(sprite, old_image, new_image));
+      }
     }
   }
 


### PR DESCRIPTION
Before this fix, tilemap layers disappeared after converting the Sprite's Color Profile in the Sprite Property dialog.