### PR TITLE
Fix bounds getting reset when the dialog is closed (fix #3018)

### DIFF
--- a/src/ui/window.cpp
+++ b/src/ui/window.cpp
@@ -411,8 +411,20 @@ void Window::closeWindow(Widget* closer)
     return;
 
   m_closer = closer;
-  if (m_ownDisplay)
+  if (m_ownDisplay) {
     m_lastFrame = m_display->nativeWindow()->frame();
+    if (!m_lastFrame.isEmpty() && parent()) {
+      const auto parentDisplay = this->parent()->display();
+      const gfx::Point parentOrigin =
+        parentDisplay->nativeWindow()->contentRect().origin();
+      const gfx::Point origin =
+        this->display()->nativeWindow()->contentRect().origin();
+      const int scale = parentDisplay->scale();
+      const gfx::Rect newBounds((origin -parentOrigin) / scale,
+        m_lastFrame.size());
+      setBounds(newBounds);
+    }
+  }
 
   manager()->_closeWindow(this, true);
 


### PR DESCRIPTION
This PR attempts to fix the bug reported extensively [here](https://github.com/aseprite/aseprite/issues/3018). Comments about the problem and why this fix works is detailed in the [comment](https://github.com/aseprite/aseprite/issues/3018#issuecomment-976390803) as well.