### PR TITLE
Fix Shift+N behavior(fix #2957)

### DIFF
--- a/src/app/ui/timeline/timeline.cpp
+++ b/src/app/ui/timeline/timeline.cpp
@@ -1782,8 +1782,8 @@ paintNoDoc:;
 
 void Timeline::onBeforeCommandExecution(CommandExecutionEvent& ev)
 {
-  m_savedCounter = (m_document ? *m_document->undoHistory()->savedCounter():
-                                 std::numeric_limits<int>::min());
+  m_savedVersion = (m_document ? m_document->sprite()->version():
+                                 std::numeric_limits<doc::ObjectVersion>::max());
 }
 
 void Timeline::onAfterCommandExecution(CommandExecutionEvent& ev)
@@ -1792,8 +1792,8 @@ void Timeline::onAfterCommandExecution(CommandExecutionEvent& ev)
     return;
 
   // TODO improve this: no need to regenerate everything after each command
-  const int currentCounter = *m_document->undoHistory()->savedCounter();
-  if (m_savedCounter != currentCounter) {
+  const doc::ObjectVersion currentVersion = m_document->sprite()->version();
+  if (m_savedVersion != currentVersion) {
     regenerateRows();
     showCurrentCel();
     invalidate();

--- a/src/app/ui/timeline/timeline.h
+++ b/src/app/ui/timeline/timeline.h
@@ -21,6 +21,7 @@
 #include "base/debug.h"
 #include "doc/frame.h"
 #include "doc/layer.h"
+#include "doc/object_version.h"
 #include "doc/selected_frames.h"
 #include "doc/selected_layers.h"
 #include "doc/sprite.h"
@@ -396,7 +397,7 @@ namespace app {
     // Value of DocUndo::savedCounter() before executing a
     // command. Used to compare after executing a command to avoid
     // regenerating all rows if it's not necessary.
-    int m_savedCounter;
+    doc::ObjectVersion m_savedVersion;
 
     // Data used to display each row in the timeline
     std::vector<Row> m_rows;


### PR DESCRIPTION
Fix the bug in the timeline when focus is lost in the timeline and a new layer is added. Instead of stacking the new layer on top of the currently selected layer, it gets added to the top of the entire layer stack.