### PR TITLE
Fix displayable grid lines for tilemap layer(fix #2913)

### DIFF
--- a/src/app/commands/cmd_grid.cpp
+++ b/src/app/commands/cmd_grid.cpp
@@ -109,7 +109,7 @@ void GridSettingsCommand::onExecute(Context* context)
   gen::GridSettings window;
 
   Site site = context->activeSite();
-  Rect bounds = site.gridBounds();
+  Rect bounds = site.displayableGridBounds();
 
   window.gridX()->setTextf("%d", bounds.x);
   window.gridY()->setTextf("%d", bounds.y);

--- a/src/app/site.cpp
+++ b/src/app/site.cpp
@@ -121,6 +121,16 @@ gfx::Rect Site::gridBounds() const
   return doc::Sprite::DefaultGridBounds();
 }
 
+gfx::Rect Site::displayableGridBounds() const
+{
+  gfx::Rect bounds;
+  if (m_sprite)
+    bounds = m_sprite->gridBounds();
+  if (bounds.isEmpty())
+    bounds = gridBounds();
+  return bounds;
+}
+
 bool Site::shouldTrimCel(Cel* cel) const
 {
   return (cel &&

--- a/src/app/site.h
+++ b/src/app/site.h
@@ -110,6 +110,7 @@ namespace app {
     doc::Tileset* tileset() const;
     doc::Grid grid() const;
     gfx::Rect gridBounds() const;
+    gfx::Rect displayableGridBounds() const;
 
     void tilemapMode(const TilemapMode mode) { m_tilemapMode = mode; }
     void tilesetMode(const TilesetMode mode) { m_tilesetMode = mode; }

--- a/src/app/ui/editor/editor.cpp
+++ b/src/app/ui/editor/editor.cpp
@@ -794,7 +794,7 @@ void Editor::drawOneSpriteUnclippedRect(ui::Graphics* g, const gfx::Rect& sprite
       if (m_docPref.show.grid()) {
         gfx::Rect gridrc;
         if (!m_state->getGridBounds(this, gridrc))
-          gridrc = getSite().gridBounds();
+          gridrc = getSite().displayableGridBounds();
 
         if (m_proj.applyX(gridrc.w) > 2 &&
             m_proj.applyY(gridrc.h) > 2) {


### PR DESCRIPTION
When grid bounds for layers (other than tilemap layers) are displayed, Aseprite displays it as expected. However, the grid bounds are not displayed as expected when the layer is a tilemap layer, especially if the grid bounds specified in `View` > `Grid` > `Grid Settings` is different from the size of the tile. Detail of and how to reproduce this bug is [here](https://github.com/aseprite/aseprite/issues/2913).

This PR fixes this bug by explicitly requesting for displayable grid bounds where applicable, making the behavior of the gridBounds consistent regardless of the layer type.