### PR TITLE
Add Dockerfile to make compilation easier for end-users.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+FROM fedora:35 as base
+
+ENV CC=/usr/bin/clang
+ENV CXX=/usr/bin/clang++
+ENV PATH="/tmp/depot_tools:${PATH}"
+
+RUN dnf install -y clang cmake ninja-build libX11-devel libXcursor-devel libXi-devel mesa-libGL-devel \
+  fontconfig-devel git wget unzip python2 && \
+  dnf clean all
+
+WORKDIR /tmp
+
+RUN git clone --recursive https://github.com/aseprite/aseprite.git
+RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+RUN git clone -b aseprite-m96 https://github.com/aseprite/skia.git
+RUN ln -s /usr/bin/python2 depot_tools/python && python --version
+
+FROM base as build_skia
+
+WORKDIR /tmp/skia
+
+RUN python tools/git-sync-deps && \
+  gn gen out/Release-x64 --args="is_debug=false is_official_build=true skia_use_system_expat=false skia_use_system_icu=false skia_use_system_libjpeg_turbo=false skia_use_system_libpng=false skia_use_system_libwebp=false skia_use_system_zlib=false skia_use_sfntly=false skia_use_freetype=true skia_use_harfbuzz=true skia_pdf_subset_harfbuzz=true skia_use_system_freetype2=false skia_use_system_harfbuzz=false" && \
+  ninja -C out/Release-x64 skia modules
+
+FROM build_skia as build_aseprite
+
+WORKDIR /tmp/aseprite/build
+
+RUN cmake \
+  -DCMAKE_RUNTIME_OUTPUT_DIRECTORY=/tmp/bin \
+  -D_CMAKE_TOOLCHAIN_PREFIX=llvm- \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DLAF_BACKEND=skia  \
+  -DSKIA_DIR=/tmp/skia/ \
+  -DSKIA_LIBRARY_DIR=/tmp/skia/out/Release-x64 \
+  -DSKIA_LIBRARY=/tmp/skia/out/Release-x64/libskia.a \
+  -G Ninja \
+  .. 
+
+RUN ninja aseprite
+
+# based on
+# https://github.com/aseprite/skia#skia-on-linux
+# https://github.com/aseprite/aseprite/blob/main/INSTALL.md
+# https://stackoverflow.com/a/7032021
+# https://stackoverflow.com/questions/12376897/gcc-linker-errors-on-fedora-undefined-reference#12376921
+# https://github.com/aseprite/aseprite/issues/2083#issuecomment-968322129

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -238,3 +238,13 @@ configuring each `USE_SHARED_` option.
 After running `cmake -G`, you can edit `build/CMakeCache.txt` file,
 and enable the `USE_SHARED_` flag (set its value to `ON`) of the
 library that you want to be linked dynamically.
+
+# Build using podman/docker
+
+```sh
+podman build -t aseprite .
+container_id=$(podman create aseprite)
+podman cp ${container_id}:/tmp/aseprite/build/bin/aseprite .
+podman rm ${container_id}
+podman rmi aseprite # if you need to save disk space
+```


### PR DESCRIPTION
<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the Individual Contributor License Agreement V3.0. -->
<!-- If you're a first-time contributor, please sign the CLA
     as indicated in https://github.com/aseprite/sourcecode/blob/main/sign-cla.md#sign-the-cla
     and acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the Individual Contributor License Agreement V3.0 ("CLA") as stated in https://github.com/aseprite/sourcecode/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/aseprite/sourcecode/blob/main/sign-cla.md#sign-the-cla

Motivation:
I found it quite inconvenient to piece together all the invidual steps to get aseprite (and skia, I had linking problems with the pre-built binaries) compiled on linux. With this Dockerfile linux users can just build a container image and in the end copy the aseprite binary from a container without to much hassle and without messing up their systems. 

I am not too familiar with this ecosystem, otherwise I could have built it in such a way that the binary would be written to a local folder which could be mounted during the image build step. That way there would be no need to copy the file from a container.

Also I am not sure about whether the resulting binary could be run on any x86_64 linux? 