### PR TITLE
Fix panning canvas out of view clips in Auto Guides (fix #2994)

### DIFF
--- a/src/app/ui/editor/editor.cpp
+++ b/src/app/ui/editor/editor.cpp
@@ -923,10 +923,9 @@ void Editor::drawSpriteUnclippedRect(ui::Graphics* g, const gfx::Rect& _rc)
 
   // Draw active layer/cel edges
   if ((m_docPref.show.layerEdges() || m_showAutoCelGuides) &&
-      // Show layer edges only on "standby" like states where brush
-      // preview is shown (e.g. with this we avoid to showing the
-      // edges in states like DrawingState, etc.).
-      m_state->requireBrushPreview()) {
+      // Show layer edges and possibly cel guides only on states that
+      // allows it (e.g scrolling state)
+      m_state->allowLayerEdges()) {
     Cel* cel = (m_layer ? m_layer->cel(m_frame): nullptr);
     if (cel) {
       gfx::Color color = color_utils::color_for_ui(Preferences::instance().guides.layerEdgesColor());
@@ -2904,7 +2903,7 @@ void Editor::updateAutoCelGuides(ui::Message* msg)
   // Check if the user is pressing the Ctrl or Cmd key on move
   // tool to show automatic guides.
   if (m_showAutoCelGuides &&
-      m_state->requireBrushPreview()) {
+      m_state->allowLayerEdges()) {
     auto mouseMsg = dynamic_cast<ui::MouseMessage*>(msg);
 
     ColorPicker picker;

--- a/src/app/ui/editor/editor_state.h
+++ b/src/app/ui/editor/editor_state.h
@@ -124,6 +124,9 @@ namespace app {
     // drawing cursor.
     virtual bool requireBrushPreview() { return false; }
 
+    // Returns true if this state allow layer edges and cel guides
+    virtual bool allowLayerEdges() { return false; }
+
     // Returns true if this state accept the given quicktool.
     virtual bool acceptQuickTool(tools::Tool* tool) { return true; }
 

--- a/src/app/ui/editor/scrolling_state.h
+++ b/src/app/ui/editor/scrolling_state.h
@@ -24,6 +24,7 @@ namespace app {
     virtual bool onKeyDown(Editor* editor, ui::KeyMessage* msg) override;
     virtual bool onKeyUp(Editor* editor, ui::KeyMessage* msg) override;
     virtual bool onUpdateStatusBar(Editor* editor) override;
+    virtual bool allowLayerEdges() override { return true; }
 
     virtual LeaveAction onLeaveState(Editor* editor, EditorState* newState) override {
       // Just discard this state if we want to enter to another state

--- a/src/app/ui/editor/standby_state.h
+++ b/src/app/ui/editor/standby_state.h
@@ -46,6 +46,9 @@ namespace app {
     // the brush-preview.
     virtual bool requireBrushPreview() override { return true; }
 
+    // layer edges and cel guides are allowed to be drawn
+    virtual bool allowLayerEdges() override { return true; }
+
     virtual Transformation getTransformation(Editor* editor);
 
     void startSelectionTransformation(Editor* editor, const gfx::Point& move, double angle);


### PR DESCRIPTION
This PR is meant to solve the issue detailed [here](https://github.com/aseprite/aseprite/issues/2994). I'll add further technical comment about this in few hours.