### PR TITLE
Fix lost focus on closing tab (fix #3080)

### DIFF
--- a/src/app/commands/cmd_close_file.cpp
+++ b/src/app/commands/cmd_close_file.cpp
@@ -73,6 +73,7 @@ protected:
     }
 
     for (auto docView : docViews) {
+      workspace->setActiveView(docView);
       if (!workspace->closeView(docView, m_quitting))
         break;
     }


### PR DESCRIPTION
When you close Aseprite and have multiple documents open. The expected behavior is to switch to each documents' tabs so user could see the "content" and be able to determine if that doc should be saved. This PR makes sure a tab is switched to before the closing of that tab.