### PR TITLE
Fix bug when drawing on images with no parent cel (fix #3069)

### DIFF
--- a/src/app/script/image_class.cpp
+++ b/src/app/script/image_class.cpp
@@ -231,7 +231,7 @@ int Image_drawImage(lua_State* L)
 
   // If the destination image is not related to a sprite, we just draw
   // the source image without undo information.
-  if (obj->cel(L) == nullptr) {
+  if (doc::get<doc::Cel>(obj->celId) == nullptr) {
     doc::copy_image(dst, src, pos.x, pos.y);
   }
   else {
@@ -262,7 +262,7 @@ int Image_drawSprite(lua_State* L)
 
   // If the destination image is not related to a sprite, we just draw
   // the source image without undo information.
-  if (obj->cel(L) == nullptr) {
+  if (doc::get<doc::Cel>(obj->celId) == nullptr) {
     render_sprite(dst, sprite, frame, pos.x, pos.y);
   }
   else {


### PR DESCRIPTION
The check on some images that are standalone and are thus unattached to cels (e.g. they could be cloned from cel images) usually generate errors but this isn't the desired behavior. This PR _relaxes_ this restriction.

Technical detail: calling `ImageObj::cel` performs a value/type check on the bject the user is operating on and thus throw an exception in cases where a `Cel` object is expected. In these two cases though, we do not need to throw an exception since having no `Cel` is an expected behavior.