### PR TITLE
Lua errors

### DIFF
--- a/src/app/script/app_object.cpp
+++ b/src/app/script/app_object.cpp
@@ -135,10 +135,12 @@ int App_transaction(lua_State* L)
   int nresults = 0;
   if (lua_isfunction(L, 1)) {
     Tx tx; // Create a new transaction so it exists in the whole
-           // duration of the argument function call.
+            // duration of the argument function call.
     lua_pushvalue(L, -1);
     if (lua_pcall(L, 0, LUA_MULTRET, 0) == LUA_OK)
       tx.commit();
+    else
+      return lua_error(L); // pcall already put an error object on the stack
     nresults = lua_gettop(L) - top;
   }
   return nresults;

--- a/src/app/script/websocket_class.cpp
+++ b/src/app/script/websocket_class.cpp
@@ -127,6 +127,11 @@ int WebSocket_gc(lua_State* L)
 int WebSocket_sendText(lua_State* L)
 {
   auto ws = get_ptr<ix::WebSocket>(L, 1);
+
+  if (ws->getReadyState() != ix::ReadyState::Open) {
+    return luaL_error(L, "Websocket is not connected, can't send text");
+  }
+
   std::stringstream data;
   int argc = lua_gettop(L);
 
@@ -137,8 +142,7 @@ int WebSocket_sendText(lua_State* L)
   }
 
   if (!ws->sendText(data.str()).success) {
-    lua_pushstring(L, "Websocket error");
-    lua_error(L);
+    return luaL_error(L, "Websocket failed to send text");
   }
   return 0;
 }
@@ -146,6 +150,11 @@ int WebSocket_sendText(lua_State* L)
 int WebSocket_sendBinary(lua_State* L)
 {
   auto ws = get_ptr<ix::WebSocket>(L, 1);
+
+  if (ws->getReadyState() != ix::ReadyState::Open) {
+    return luaL_error(L, "Websocket is not connected, can't send data");
+  } 
+
   std::stringstream data;
   int argc = lua_gettop(L);
 
@@ -154,10 +163,9 @@ int WebSocket_sendBinary(lua_State* L)
     const char* buf = lua_tolstring(L, i, &bufLen);
     data.write(buf, bufLen);
   }
-
+  
   if (!ws->sendBinary(data.str()).success) {
-    lua_pushstring(L, "Websocket error");
-    lua_error(L);
+    return luaL_error(L, "Websocket failed to send data");
   }
   return 0;
 }
@@ -165,13 +173,17 @@ int WebSocket_sendBinary(lua_State* L)
 int WebSocket_sendPing(lua_State* L)
 {
   auto ws = get_ptr<ix::WebSocket>(L, 1);
+
+  if (ws->getReadyState() != ix::ReadyState::Open) {
+    return luaL_error(L, "Websocket is not connected, can't send ping");
+  }
+
   size_t bufLen;
   const char* buf = lua_tolstring(L, 2, &bufLen);
   std::string data(buf, bufLen);
 
   if (!ws->ping(data).success) {
-    lua_pushstring(L, "Websocket error");
-    lua_error(L);
+    return luaL_error(L, "Websocket failed to send ping");
   }
   return 0;
 }


### PR DESCRIPTION
Heyo!

Fist commit - a few weeks ago someone got confused enough by those to DM me
* Formats error messages from WebSocket.sendText (binary, ping) with line number, and makes them "sending errors" instead of "websocket error" which I admit was confusing.
* Checks separately for attempts to use opening/closing/closed websocket, namely:
```
ws = WebSocket{ ... }
ws:connect() -- non-blocking
ws:sendText("hello") -- should be in the message handler, the connection haven't happened yet
```

Second commit just shows the error from pcall that App.transaction was ignoring.

-----

I agree that my contributions are licensed under the Individual Contributor License Agreement V3.0 ("CLA") as stated in https://github.com/aseprite/sourcecode/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/aseprite/sourcecode/blob/main/sign-cla.md#sign-the-cla
