### PR TITLE
Fix colorbar palette indicator when view is changed (fix #3082)

### DIFF
--- a/src/app/ui/color_bar.cpp
+++ b/src/app/ui/color_bar.cpp
@@ -971,8 +971,13 @@ void ColorBar::onRemapTilesButtonClick()
 
 bool ColorBar::onIsPaletteViewActive(PaletteView* paletteView) const
 {
+  // As the m_tilemapMode is kept to restore it if we go back to a tilemap layer,
+  // there is a possibility where we are in a regular layer and the tilemap
+  // mode is a tile. So we need an extra check to see if the tilemap is editable.
+  // A palette view is active iff the tile is not editable.
   return
     (paletteView == &m_paletteView && m_tilemapMode == TilemapMode::Pixels) ||
+    (paletteView == &m_paletteView && m_tilemapMode == TilemapMode::Tiles && !canEditTiles()) ||
     (paletteView == &m_tilesView && m_tilemapMode == TilemapMode::Tiles);
 }
 


### PR DESCRIPTION
This PR fixes the vanishing palette indicator when views/tabs gets switched from documents in tilemap mode to documents that may or may not have tilemaps. Details of and comments on this bug that gave birth to this PR can be found [here](https://github.com/aseprite/aseprite/issues/3082).