### PR TITLE
Fix spray painting behavior when mask color equals color (fix #3063)

### DIFF
--- a/src/app/tools/ink_processing.h
+++ b/src/app/tools/ink_processing.h
@@ -282,8 +282,10 @@ public:
   }
 
   void processPixel(int x, int y) {
-    if (m_colorIndex == m_maskIndex)
+    if (m_colorIndex == m_maskIndex) {
+      *m_dstAddress = m_maskIndex;
       return;
+    }
 
     color_t c = *m_srcAddress;
     if (int(c) == m_maskIndex)


### PR DESCRIPTION
In indexed mode, when spraying (using spray tool, simple ink) a mask color on the canvas, the color is not drawn. This is not the expected behavior and this PR fixes that. How to reproduce this bug and comments about this is detailed [here](https://github.com/aseprite/aseprite/issues/3063).