### PR TITLE
Fix spray painting behavior when mask color equals color (fix #3063)

### DIFF
--- a/src/app/tools/inks.h
+++ b/src/app/tools/inks.h
@@ -133,7 +133,9 @@ public:
               //
               // TODO this trace policy is configured in
               //      ToolLoopBase() ctor, is there a better place?
-              loop->getTracePolicy() != TracePolicy::Overlap) {
+              (loop->getTracePolicy() != TracePolicy::Overlap ||
+               (loop->getTracePolicy() == TracePolicy::Overlap &&
+                m_type == Simple))) {
             color_t color = loop->getPrimaryColor();
 
             switch (loop->sprite()->pixelFormat()) {


### PR DESCRIPTION
In indexed mode, when spraying (using spray tool, simple ink) a mask color on the canvas, the color is not drawn. This is not the expected behavior and this PR fixes that. In simple paint ink mode, when the trace policy "overlaps", we could use the faster `CopyInkProcessing`. How to reproduce this bug and comments about this is detailed [here](https://github.com/aseprite/aseprite/issues/3063).

Addendum(2021-12-20): I am in the process of writing a Lua script to test this PR.
Addendum(2021-12-21): Done writing the test script (ensuring the correctness of the inks). @dacap reviews needed.