### PR TITLE
Fix crash resulting from deleting topmost layer via script (fix #3087)

### DIFF
--- a/src/app/script/sprite_class.cpp
+++ b/src/app/script/sprite_class.cpp
@@ -375,6 +375,10 @@ int Sprite_deleteLayer(lua_State* L)
     }
   }
   if (layer) {
+    const auto& rootLayers = sprite->root()->layers();
+    if (rootLayers.size() == 1 && rootLayers[0] == layer)
+      return luaL_error(L, "You cannot delete all layers");
+
     Tx tx;
     tx(new cmd::RemoveLayer(layer));
     tx.commit();


### PR DESCRIPTION
Deleting the only and topmost layer in a sprite should not be possible -- this is the behavior when we use Aseprite UI but this can be done via scripting. This PR fixes this bug and the desired behavior is restored.