### PR TITLE
 Add warning message to deleteLayer() lua function

### DIFF
--- a/src/app/script/sprite_class.cpp
+++ b/src/app/script/sprite_class.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2021  Igara Studio S.A.
+// Copyright (C) 2018-2022  Igara Studio S.A.
 // Copyright (C) 2015-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -375,6 +375,8 @@ int Sprite_deleteLayer(lua_State* L)
     }
   }
   if (layer) {
+    if (sprite != layer->sprite())
+      return luaL_error(L, "the layer doesn't belong to the sprite");
     Tx tx;
     tx(new cmd::RemoveLayer(layer));
     tx.commit();


### PR DESCRIPTION
Before this fix, the deleteLayer() lua function didn't warn the user if its argument (a layer) didn't belong to the corresponding sprite.

Tests passed.

This PR solves #3135 1st item.