### PR TITLE
Add warning message to deleteCel() lua function

### DIFF
--- a/src/app/script/sprite_class.cpp
+++ b/src/app/script/sprite_class.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2021  Igara Studio S.A.
+// Copyright (C) 2018-2022  Igara Studio S.A.
 // Copyright (C) 2015-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -501,11 +501,11 @@ int Sprite_newCel(lua_State* L)
 int Sprite_deleteCel(lua_State* L)
 {
   auto sprite = get_docobj<Sprite>(L, 1);
-  (void)sprite;                 // unused
-
   auto cel = may_get_docobj<doc::Cel>(L, 2);
   if (!cel) {
     if (auto layer = may_get_docobj<doc::Layer>(L, 2)) {
+      if (sprite != layer->sprite())
+        return luaL_error(L, "the layer doesn't belong to the sprite");
       doc::frame_t frame = get_frame_number_from_arg(L, 3);
       if (layer->isImage())
         cel = static_cast<doc::LayerImage*>(layer)->cel(frame);


### PR DESCRIPTION
Before this fix, the deleteCel(layer, frame) lua function didn't warn the user if its argument (a layer) didn't belong to the corresponding sprite.

Tests passed.

This PR solves #3135 2nd item.