### PR TITLE
Fix bug that creates unlimited slice keys from existing slices (fix #3122)

### DIFF
--- a/src/doc/keyframes.h
+++ b/src/doc/keyframes.h
@@ -24,10 +24,14 @@ namespace doc {
       frame_t frame() const { return m_frame; }
       T* value() const { return m_value; }
       void setFrame(const frame_t frame) { m_frame = frame; }
-      void setValue(T* value) { m_value = value; }
+      void setValue(T* value) {
+        if (m_value)
+          delete m_value;
+        m_value = value;
+      }
     private:
-      frame_t m_frame;
-      T* m_value;
+      frame_t m_frame = -1;
+      T* m_value = nullptr;
     };
 
     typedef std::vector<Key> List;

--- a/src/doc/keyframes.h
+++ b/src/doc/keyframes.h
@@ -10,6 +10,7 @@
 
 #include "doc/frame.h"
 
+#include <algorithm>
 #include <vector>
 
 namespace doc {
@@ -124,6 +125,9 @@ namespace doc {
       else {
         ++it;
         m_keys.insert(it, Key(frame, value));
+        std::sort(begin(), end(), [](const auto& a, const auto& b) {
+          return a.frame() < b.frame();
+        });
       }
     }
 


### PR DESCRIPTION
Paragraph one is about the PR and paragraph 2 is how the PR relates to the [bug](https://github.com/aseprite/aseprite/issues/3122).

When you create a slice in a frame and edit it (by resizing or change its position) in another frame, the expected behavior is to _duplicate that slice_ in the current frame and allow the editing. Technically, it's simply [adding one more](https://github.com/aseprite/aseprite/blob/9e23d31d84a5bfdccc32aea065ffb60b02b57856/src/doc/keyframes.h#L120-L126) `SliceKey` to the `Keyframe` of the slice. IIRC, the total number of keys in a single slice should be in the range `0 >= SliceKeys < TotalFramesInSprite`. However, without this fix, when we move a slice, created in `Frame 2`, around in `Frame 1`, it wouldn't work visually (as depicted in the bug report) but the underlying slice _engine_ creates tens/hundreds of keys in the slice because of how iterators for keyframes in designed.  By sorting the key frame for a slice after an insertion, it allows the littlest frames come first and make the [iterator getter](https://github.com/aseprite/aseprite/blob/9e23d31d84a5bfdccc32aea065ffb60b02b57856/src/doc/keyframes.h#L166) work [perfectly](https://github.com/aseprite/aseprite/blob/main/src/doc/keyframes_tests.cpp).

When one saves the file, the slice to be saved saves incorrect [countKeys](https://github.com/aseprite/aseprite/blob/9e23d31d84a5bfdccc32aea065ffb60b02b57856/src/app/file/ase_format.cpp#L1044) and only [one key](https://github.com/aseprite/aseprite/blob/9e23d31d84a5bfdccc32aea065ffb60b02b57856/src/app/file/ase_format.cpp#L1052-L1057). The reader, on the other hand, tries to [read `countKeys`](https://github.com/aseprite/aseprite/blob/9e23d31d84a5bfdccc32aea065ffb60b02b57856/src/dio/aseprite_decoder.cpp#L929) keys for the [slice](https://github.com/aseprite/aseprite/blob/9e23d31d84a5bfdccc32aea065ffb60b02b57856/src/dio/aseprite_decoder.cpp#L205) and end up reading past the allotted space for slices -- thus, it encounters an [invalid chunk](https://github.com/aseprite/aseprite/blob/9e23d31d84a5bfdccc32aea065ffb60b02b57856/src/dio/aseprite_decoder.cpp#L226).


**EDIT**: This is added as a late fix (thus second commit). Every time we do an [insertion](https://github.com/aseprite/aseprite/blob/9e23d31d84a5bfdccc32aea065ffb60b02b57856/src/doc/slice.cpp#L64), this function creates a `new` object. If we have an object with the same frame number in the key frame, we [replace the object](https://github.com/aseprite/aseprite/blob/9e23d31d84a5bfdccc32aea065ffb60b02b57856/src/doc/keyframes.h#L123) with the new value [without ever deleting](https://github.com/aseprite/aseprite/blob/9e23d31d84a5bfdccc32aea065ffb60b02b57856/src/doc/keyframes.h#L26) the old one! If we drag an existing slice around a few thousand times, that's a few thousand times we leaked some object.