### PR TITLE
Fix moving rectangular marquee box while selecting color(fix #3143)

### DIFF
--- a/src/app/ui/editor/moving_pixels_state.cpp
+++ b/src/app/ui/editor/moving_pixels_state.cpp
@@ -391,6 +391,9 @@ bool MovingPixelsState::onMouseMove(Editor* editor, MouseMessage* msg)
 void MovingPixelsState::onCommitMouseMove(Editor* editor,
                                           const gfx::PointF& spritePos)
 {
+  if (!m_pixelsMovement->isDragging())
+    return;
+
   m_pixelsMovement->setFastMode(true);
 
   // Get the customization for the pixels movement (snap to grid, angle snap, etc.).


### PR DESCRIPTION
Title says it all. This PR fixes a bug that moves the rectangular marquee box from its default location when we `Alt` to select a color from within or outside of the box.