### PR TITLE
Fix occasional crashes in despeckle/median filter (fix #2903)

### DIFF
--- a/src/app/commands/filters/cmd_despeckle.cpp
+++ b/src/app/commands/filters/cmd_despeckle.cpp
@@ -81,6 +81,11 @@ private:
     newSize.w = base::clamp(newSize.w, 1, 100);
     newSize.h = base::clamp(newSize.h, 1, 100);
 
+    // if we had a previous filter preview running in the background, we
+    // explicitly request it be stopped. Otherwise, changing the size of
+    // the filter would cause a race condition on the filter's `m_channel`
+    requestPreviewStop();
+
     m_filter.setSize(newSize.w, newSize.h);
     restartPreview();
   }

--- a/src/app/commands/filters/filter_window.h
+++ b/src/app/commands/filters/filter_window.h
@@ -56,6 +56,7 @@ namespace app {
     void onShowPreview(ui::Event& ev);
     void onTargetButtonChange();
     void onTiledChange();
+    void requestPreviewStop() { stopPreview(); }
 
     // Derived classes WithTiledCheckBox should set its filter's tiled
     // mode overriding this method.


### PR DESCRIPTION
A data race in the `DespeckleWindow::onSizeChange` causes seldom crashes when the size of the filter is changed while a filter preview is currently running. The call to the filter's `setSize` causes [a change in the size](https://github.com/iamOgunyinka/aseprite/blob/9e23d31d84a5bfdccc32aea065ffb60b02b57856/src/filters/median_filter.cpp#L116) of the `m_channel` data [being used in the background](https://github.com/iamOgunyinka/aseprite/blob/9e23d31d84a5bfdccc32aea065ffb60b02b57856/src/filters/median_filter.cpp#L131-L178) from another thread.

This PR explicitly request that the background thread be stopped before the size of the filter is changed. This may cause a little but noticeable lapse in the despeckle window but it brings stability to its behavior.