### PR TITLE
Fix multi layer movement in tilemap mode (fix #3144)

### DIFF
--- a/src/app/ui/editor/pixels_movement.h
+++ b/src/app/ui/editor/pixels_movement.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2021  Igara Studio S.A.
+// Copyright (C) 2019-2022  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -159,6 +159,15 @@ namespace app {
                             const double angle);
     CelList getEditableCels();
     void reproduceAllTransformationsWithInnerCmds();
+
+    void alignMasksAndTransformData(const Mask* initialMask0,
+                                    const Mask* initialMask,
+                                    const Mask* currentMask,
+                                    const Transformation* initialData,
+                                    const Transformation* currentData,
+                                    const doc::Grid& grid,
+                                    const gfx::SizeF& initialScaleRatio);
+
 #if _DEBUG
     void dumpInnerCmds();
 #endif

--- a/src/doc/grid.cpp
+++ b/src/doc/grid.cpp
@@ -1,5 +1,5 @@
 // Aseprite Document Library
-// Copyright (c) 2019-2021  Igara Studio S.A.
+// Copyright (c) 2019-2022  Igara Studio S.A.
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -181,6 +181,50 @@ std::vector<gfx::Point> Grid::tilesInCanvasRegion(const gfx::Region& rgn) const
                                   it.y()+bounds.y));
   }
   return result;
+}
+
+Mask Grid::makeAlignedMask(const Mask* mask) const {
+  // Fact: the newBounds will be always larger or equal than oldBounds
+  Mask maskOutput;
+  if (mask->isFrozen()) {
+    ASSERT(false);
+    return maskOutput;
+  }
+  gfx::Rect oldBounds = mask->bounds();
+  gfx::Rect newBounds = alignBounds(mask->bounds());
+  ASSERT(newBounds.w > 0 && newBounds.h > 0);
+  ImageRef newBitmap;
+  if (!mask->bitmap()) {
+    maskOutput.replace(newBounds);
+    return maskOutput;
+  }
+
+  newBitmap.reset(Image::create(IMAGE_BITMAP, newBounds.w, newBounds.h));
+  maskOutput.freeze();
+  maskOutput.reserve(newBounds);
+
+  const LockImageBits<BitmapTraits> bits(mask->bitmap());
+  typename LockImageBits<BitmapTraits>::const_iterator it = bits.begin();
+  // We must travel thought the old bitmap and masking the new bitmap
+  gfx::Point previousPoint(std::numeric_limits<int>::max(), std::numeric_limits<int>::max());
+  for (int y=0; y < oldBounds.h; ++y) {
+    for (int x=0; x < oldBounds.w; ++x, ++it) {
+      ASSERT(it != bits.end());
+      if (*it) {
+        gfx::Rect newBoundsTile = alignBounds(gfx::Rect(oldBounds.x + x, oldBounds.y + y, 1, 1));
+        if (previousPoint != newBoundsTile.origin()) {
+          // Fill a tile region in the newBitmap
+          fill_rect(maskOutput.bitmap(),
+                    gfx::Rect(newBoundsTile.x - newBounds.x, newBoundsTile.y - newBounds.y,
+                              tileSize().w, tileSize().h),
+                    1);
+          previousPoint = newBoundsTile.origin();
+        }
+      }
+    }
+  }
+  maskOutput.unfreeze();
+  return maskOutput;
 }
 
 } // namespace doc

--- a/src/doc/grid.h
+++ b/src/doc/grid.h
@@ -1,5 +1,5 @@
 // Aseprite Document Library
-// Copyright (c) 2019-2020  Igara Studio S.A.
+// Copyright (c) 2019-2022  Igara Studio S.A.
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -8,6 +8,7 @@
 #define DOC_GRID_H_INCLUDED
 #pragma once
 
+#include "doc/mask.h"
 #include "doc/image_ref.h"
 #include "gfx/fwd.h"
 #include "gfx/point.h"
@@ -64,6 +65,18 @@ namespace doc {
 
     // Returns an array of tile positions that are touching the given region in the canvas
     std::vector<gfx::Point> tilesInCanvasRegion(const gfx::Region& rgn) const;
+
+    // Returns a mask aligned to the current grid, starting from other not aligned mask
+    Mask makeAlignedMask(const Mask* mask) const;
+
+    inline bool operator!=(const Grid& gridB) const {
+      return (this->tileSize() != gridB.tileSize() ||
+              this->origin() != gridB.origin() ||
+              this->tileOffset() != gridB.tileOffset()  ||
+              this->oddColOffset() != gridB.oddColOffset() ||
+              this->oddRowOffset() != gridB.oddRowOffset() ||
+              this->tileCenter() != gridB.tileCenter());// Perhaps this last condition isn't needed.
+    };
 
   private:
     gfx::Size m_tileSize;


### PR DESCRIPTION
Before this fix, a multi-layer mask move (with mixed layer types: normal layer and tilemap layers with different grids) caused loss of drawing areas.
The heart of this solution is to correctly align the 'selection mask' and 'transform data' according to the layer's grid, and also, forcing 'site' TilemapMode/TilesetMode before each reproduceAllTransformationsWithInnerCmds() iteration.

Additionally:
Fix scaling a tilemap produces unexpected cel position and unwanted transform size.
Before this fix, it can be reproduced:
. Make a selection in Pixels Mode on a tilemap layer
. The selection bounds doesn't match with the tilemap grid AND some tiles are partially selected.
. Switch to Tilemap Mode
. Scale it with a Handle
. Result: unexpected cel position and unwanted transform size.

fix #3144