### PR TITLE
Fix Lua Color HSL Constructor

### DIFF
--- a/src/app/script/color_class.cpp
+++ b/src/app/script/color_class.cpp
@@ -115,7 +115,7 @@ app::Color Color_new(lua_State* L, int index)
       int a = 255;
       if (lua_getfield(L, index, "alpha") != LUA_TNIL)
         a = lua_tointeger(L, -1);
-      color = app::Color::fromHsv(lua_tonumber(L, -2),
+      color = app::Color::fromHsl(lua_tonumber(L, -2),
                                   lua_tonumber(L, -3),
                                   lua_tonumber(L, -4), a);
       lua_pop(L, 4);


### PR DESCRIPTION
Changed call from HSV to HSL for Lua Color HSL constructor. Fix for https://github.com/aseprite/aseprite/issues/3213 .

I agree that my contributions are licensed under the Individual Contributor License Agreement V3.0 ("CLA") as stated in https://github.com/aseprite/sourcecode/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/aseprite/sourcecode/blob/main/sign-cla.md#sign-the-cla
