### PR TITLE
Support saving without showing a dialog & adding to Recent Files

### DIFF
--- a/src/app/commands/cmd_save_file.cpp
+++ b/src/app/commands/cmd_save_file.cpp
@@ -115,6 +115,9 @@ void SaveFileBaseCommand::onLoadParams(const Params& params)
   const std::string useUI = params.get("useUI");
   m_useUI = (useUI.empty() || (useUI == "true"));
 
+  const std::string addToRecentFiles = params.get("addToRecentFiles");
+  m_addToRecentFiles = (addToRecentFiles == "true");
+
   m_ignoreEmpty = params.get_as<bool>("ignoreEmpty");
 }
 
@@ -172,7 +175,7 @@ std::string SaveFileBaseCommand::saveAsDialog(
 
   if (saveInBackground) {
     saveDocumentInBackground(
-      context, document, filename, markAsSaved, m_useUI);
+      context, document, filename, markAsSaved, m_addToRecentFiles, m_useUI);
 
     // Reset the "saveCopy" document preferences of the new document
     // (here "document" contains the new filename), because these
@@ -198,6 +201,7 @@ void SaveFileBaseCommand::saveDocumentInBackground(
   Doc* document,
   const std::string& filename,
   const bool markAsSaved,
+  const bool addToRecentFiles,
   const bool showAlertWindow)
 {
   if (!m_aniDir.empty()) {
@@ -240,7 +244,9 @@ void SaveFileBaseCommand::saveDocumentInBackground(
     document->impossibleToBackToSavedState();
   }
   else if (context->isUIAvailable()) {
-    App::instance()->recentFiles()->addRecentFile(filename);
+    if (addToRecentFiles) {
+      App::instance()->recentFiles()->addRecentFile(filename);
+    }
     if (markAsSaved) {
       document->markAsSaved();
       document->setFilename(filename);
@@ -283,7 +289,7 @@ void SaveFileCommand::onExecute(Context* context)
 
     saveDocumentInBackground(
       context, document,
-      documentReader->filename(), true, m_useUI);
+      documentReader->filename(), true, m_addToRecentFiles, m_useUI);
   }
   // If the document isn't associated to a file, we must to show the
   // save-as dialog to the user to select for first time the file-name
@@ -461,7 +467,7 @@ void SaveFileCopyAsCommand::onExecute(Context* context)
     PngEncoderOneAlphaPixel fixPng(isForTwitter);
 
     saveDocumentInBackground(
-      context, doc, outputFilename, false, m_useUI);
+      context, doc, outputFilename, false, m_addToRecentFiles, m_useUI);
   }
 
   // Undo resize

--- a/src/app/commands/cmd_save_file.h
+++ b/src/app/commands/cmd_save_file.h
@@ -36,6 +36,7 @@ namespace app {
       Doc* document,
       const std::string& filename,
       const bool markAsSaved,
+      const bool addToRecentFiles = true,
       const bool showAlertWindow = true);
 
     std::string m_filename;
@@ -45,6 +46,7 @@ namespace app {
     std::string m_slice;
     doc::SelectedFrames m_selFrames;
     bool m_adjustFramesByTag;
+    bool m_addToRecentFiles;
     bool m_useUI;
     bool m_ignoreEmpty;
   };

--- a/src/app/commands/cmd_save_file.h
+++ b/src/app/commands/cmd_save_file.h
@@ -35,7 +35,8 @@ namespace app {
       const Context* context,
       Doc* document,
       const std::string& filename,
-      const bool markAsSaved);
+      const bool markAsSaved,
+      const bool showAlertWindow = true);
 
     std::string m_filename;
     std::string m_filenameFormat;

--- a/src/app/job.cpp
+++ b/src/app/job.cpp
@@ -35,13 +35,13 @@ int Job::runningJobs()
   return g_runningJobs;
 }
 
-Job::Job(const char* jobName)
+Job::Job(const char* jobName, bool showAlertWindow)
 {
   m_last_progress = 0.0;
   m_done_flag = false;
   m_canceled_flag = false;
 
-  if (App::instance()->isGui()) {
+  if (App::instance()->isGui() && showAlertWindow) {
     m_alert_window = ui::Alert::create(
       fmt::format(Strings::alerts_job_working(), jobName));
     m_alert_window->addProgress();

--- a/src/app/job.h
+++ b/src/app/job.h
@@ -23,7 +23,7 @@ namespace app {
   public:
     static int runningJobs();
 
-    Job(const char* jobName);
+    Job(const char* jobName, bool showAlertWindow = true);
     virtual ~Job();
 
     // Starts the job calling onJob() event in another thread and

--- a/src/app/script/sprite_class.cpp
+++ b/src/app/script/sprite_class.cpp
@@ -218,6 +218,11 @@ int Sprite_saveAs_base(lua_State* L, std::string& absFn)
     Params params;
     params.set("filename", absFn.c_str());
     params.set("useUI", "false");
+
+    if (!lua_isnone(L, 2))
+      params.set("addToRecentFiles", lua_toboolean(L, -1) ? "true" : "false");
+    lua_pop(L, 1);
+
     appCtx->executeCommand(saveCommand, params);
 
     result = true;


### PR DESCRIPTION
My use case for these two changes is improving the "Automatic Snapshot" feature here [https://sprngr.itch.io/aseprite-record](https://t.co/qGqx88tG9A) for recording timelapses.
Specifically making it 1) not display a distracting 'saving' alert window on every snapshot and 2) not make the snapshots appear on the Recent Files list.

Wasn't sure if I should make `sprite:saveAs`/`saveCopyAs` have named params instead since that would break the API afaik. Instead I exposed the 'add to recent files' param as an optional second bool. The other one (whether to display the alert) is set to always not display (when called via scripting - I used the existing `useUI` bool).

TODO: (if merged) Update docs on https://github.com/aseprite/api.

---

I tried to contact maintainers on `#aseprite-dev` on Discord and Twitter so as to ask for feedback and not waste my time with a pre-emptive PR, but received no response.

---
<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the Individual Contributor License Agreement V3.0. -->
<!-- If you're a first-time contributor, please sign the CLA
     as indicated in https://github.com/aseprite/sourcecode/blob/main/sign-cla.md#sign-the-cla
     and acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the Individual Contributor License Agreement V3.0 ("CLA") as stated in https://github.com/aseprite/sourcecode/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/aseprite/sourcecode/blob/main/sign-cla.md#sign-the-cla
