### PR TITLE
Remove tag range adjust when exporting sprite sheets (fix #3210)

### DIFF
--- a/src/app/doc_exporter.cpp
+++ b/src/app/doc_exporter.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2020  Igara Studio S.A.
+// Copyright (C) 2018-2022  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -609,7 +609,6 @@ void DocExporter::reset()
   m_listLayers = false;
   m_listSlices = false;
   m_documents.clear();
-  m_tagDelta.clear();
 }
 
 void DocExporter::setDocImageBuffer(const doc::ImageBufferPtr& docBuf)
@@ -965,15 +964,8 @@ void DocExporter::captureSamples(Samples& samples,
 
           // Should we ignore this empty frame? (i.e. don't include
           // the frame in the sprite sheet)
-          if (m_ignoreEmptyCels) {
-            for (Tag* tag : sprite->tags()) {
-              auto& delta = m_tagDelta[tag->id()];
-
-              if (frame < tag->fromFrame()) --delta.first;
-              if (frame <= tag->toFrame()) --delta.second;
-            }
+          if (m_ignoreEmptyCels)
             continue;
-          }
 
           // Create an entry with Size(1, 1) for this completely
           // trimmed frame anyway so we conserve the frame information
@@ -1344,13 +1336,9 @@ void DocExporter::createDataFile(const Samples& samples,
         else
           os << ",";
 
-        std::pair<int, int> delta(0, 0);
-        if (!m_tagDelta.empty())
-          delta = m_tagDelta[tag->id()];
-
         os << "\n   { \"name\": \"" << escape_for_json(tag->name()) << "\","
-           << " \"from\": " << (tag->fromFrame()+delta.first) << ","
-           << " \"to\": " << (tag->toFrame()+delta.second) << ","
+           << " \"from\": " << (tag->fromFrame()) << ","
+           << " \"to\": " << (tag->toFrame()) << ","
            << " \"direction\": \"" << escape_for_json(convert_anidir_to_string(tag->aniDir())) << "\" }";
       }
     }

--- a/src/app/doc_exporter.h
+++ b/src/app/doc_exporter.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019  Igara Studio S.A.
+// Copyright (C) 2019-2022  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -21,7 +21,6 @@
 #include "gfx/rect.h"
 
 #include <iosfwd>
-#include <map>
 #include <string>
 #include <utility>
 #include <vector>
@@ -162,11 +161,6 @@ namespace app {
     bool m_listLayers;
     bool m_listSlices;
     Items m_documents;
-
-    // Displacement for each tag from/to frames in case we export
-    // them. It's used in case we trim frames outside tags and they
-    // will not be exported at all in the final result.
-    std::map<doc::ObjectId, std::pair<int, int> > m_tagDelta;
 
     // Buffers used
     doc::ImageBufferPtr m_docBuf;


### PR DESCRIPTION
Before this fix, tag ranges were adjusted in the json data file, in the 'meta' sector, when the --list-tags and --ignore-empty flags were set.
Particularlly, when --split-layers, --list-tags, and --ignore-empty were on, the calculation of tag ranges could fail with cels with pure mask pixels.

Details on emails March 23, March 28 2022
