### PR TITLE
Fix frametags 1514

### DIFF
--- a/data/pref.xml
+++ b/data/pref.xml
@@ -497,6 +497,7 @@
       <option id="data_filename" type="std::string" />
       <option id="data_format" type="SpriteSheetDataFormat" default="SpriteSheetDataFormat::Default" />
       <option id="filename_format" type="std::string" />
+      <option id="tagname_format" type="std::string" />
       <option id="border_padding" type="int" default="0" />
       <option id="shape_padding" type="int" default="0" />
       <option id="inner_padding" type="int" default="0" />

--- a/data/strings/en.ini
+++ b/data/strings/en.ini
@@ -667,6 +667,12 @@ Each frame in the JSON data will contain a filename
 how to build each frame. You can use special marks
 like {layer}, {frame}, {tag}, {tagframe}, etc.
 END
+data_tagname_format = Item Tagname:
+data_tagname_format_tooltip = <<<END
+Each frame tag in the JSON data will have a name
+field, formatted with the {filename}, {title},
+{path}, {tag}, etc.
+END
 preview = Preview
 open_sprite_sheet = Open Sprite Sheet
 export = &Export

--- a/data/widgets/export_sprite_sheet.xml
+++ b/data/widgets/export_sprite_sheet.xml
@@ -131,6 +131,12 @@
                tooltip="@.data_filename_format_tooltip" />
         <link text="(?)" url="https://www.aseprite.org/docs/cli/#filename-format" />
       </hbox>
+      <hbox id="data_tagname_format_placeholder" cell_hspan="3" cell_align="horizontal">
+        <label text="@.data_tagname_format" />
+        <entry id="data_tagname_format" maxsize="1024" maxwidth="256" expansive="true"
+               tooltip="@.data_tagname_format_tooltip" />
+        <link text="(?)" url="https://www.aseprite.org/docs/cli/#filename-format" />
+      </hbox>
     </grid>
 
     </panel>

--- a/src/app/cli/app_options.cpp
+++ b/src/app/cli/app_options.cpp
@@ -65,6 +65,7 @@ AppOptions::AppOptions(int argc, const char* argv[])
   , m_crop(m_po.add("crop").requiresValue("x,y,width,height").description("Crop all the images to the given rectangle"))
   , m_slice(m_po.add("slice").requiresValue("<name>").description("Crop the sprite to the given slice area"))
   , m_filenameFormat(m_po.add("filename-format").requiresValue("<fmt>").description("Special format to generate filenames"))
+  , m_tagnameFormat(m_po.add("tagname-format").requiresValue("<fmt>").description("Special format to generate tagnames"))
 #ifdef ENABLE_SCRIPTING
   , m_script(m_po.add("script").requiresValue("<filename>").description("Execute a specific script"))
   , m_scriptParam(m_po.add("script-param").requiresValue("name=value").description("Parameter for a script executed from the\nCLI that you can access with app.params"))

--- a/src/app/cli/app_options.h
+++ b/src/app/cli/app_options.h
@@ -81,6 +81,7 @@ public:
   const Option& crop() const { return m_crop; }
   const Option& slice() const { return m_slice; }
   const Option& filenameFormat() const { return m_filenameFormat; }
+  const Option& tagnameFormat() const { return m_tagnameFormat; }
 #ifdef ENABLE_SCRIPTING
   const Option& script() const { return m_script; }
   const Option& scriptParam() const { return m_scriptParam; }
@@ -147,6 +148,7 @@ private:
   Option& m_crop;
   Option& m_slice;
   Option& m_filenameFormat;
+  Option& m_tagnameFormat;
 #ifdef ENABLE_SCRIPTING
   Option& m_script;
   Option& m_scriptParam;

--- a/src/app/cli/cli_open_file.h
+++ b/src/app/cli/cli_open_file.h
@@ -24,6 +24,7 @@ namespace app {
     Doc* document;
     std::string filename;
     std::string filenameFormat;
+    std::string tagnameFormat;
     std::string tag;
     std::string slice;
     std::vector<std::string> includeLayers;

--- a/src/app/cli/cli_processor.cpp
+++ b/src/app/cli/cli_processor.cpp
@@ -382,6 +382,12 @@ int CliProcessor::process(Context* ctx)
           if (m_exporter)
             m_exporter->setFilenameFormat(cof.filenameFormat);
         }
+        // --tagname-format
+        else if (opt == &m_options.tagnameFormat()) {
+          cof.tagnameFormat = value.value();
+          if (m_exporter)
+            m_exporter->setTagnameFormat(cof.tagnameFormat);
+        }
         // --save-as <filename>
         else if (opt == &m_options.saveAs()) {
           if (lastDoc) {

--- a/src/app/doc_exporter.cpp
+++ b/src/app/doc_exporter.cpp
@@ -584,6 +584,7 @@ void DocExporter::reset()
   m_dataFilename.clear();
   m_textureFilename.clear();
   m_filenameFormat.clear();
+  m_tagnameFormat.clear();
   m_textureWidth = 0;
   m_textureHeight = 0;
   m_textureColumns = 0;
@@ -1331,8 +1332,18 @@ void DocExporter::createDataFile(const Samples& samples,
           firstTag = false;
         else
           os << ",";
+        
+        std::string format = m_tagnameFormat;
+        if (format.empty()) {
+          format = "{tag}";
+        }
 
-        os << "\n   { \"name\": \"" << escape_for_json(tag->name()) << "\","
+        FilenameInfo fnInfo;
+        fnInfo
+          .filename(doc->filename())
+          .innerTagName(tag->name());
+        std::string tagname = filename_formatter(format, fnInfo);
+        os << "\n   { \"name\": \"" << escape_for_json(tagname) << "\","
            << " \"from\": " << (tag->fromFrame()) << ","
            << " \"to\": " << (tag->toFrame()) << ","
            << " \"direction\": \"" << escape_for_json(convert_anidir_to_string(tag->aniDir())) << "\" }";

--- a/src/app/doc_exporter.h
+++ b/src/app/doc_exporter.h
@@ -50,6 +50,7 @@ namespace app {
     const std::string& textureFilename() { return m_textureFilename; }
     SpriteSheetType spriteSheetType() { return m_sheetType; }
     const std::string& filenameFormat() const { return m_filenameFormat; }
+    const std::string& tagnameFormat() const { return m_tagnameFormat; }
 
     void setDataFormat(SpriteSheetDataFormat format) { m_dataFormat = format; }
     void setDataFilename(const std::string& filename) { m_dataFilename = filename; }
@@ -69,6 +70,7 @@ namespace app {
     void setTrimByGrid(bool trimByGrid) { m_trimByGrid = trimByGrid; }
     void setExtrude(bool extrude) { m_extrude = extrude; }
     void setFilenameFormat(const std::string& format) { m_filenameFormat = format; }
+    void setTagnameFormat(const std::string& format) { m_tagnameFormat = format; }
     void setSplitLayers(bool splitLayers) { m_splitLayers = splitLayers; }
     void setSplitTags(bool splitTags) { m_splitTags = splitTags; }
     void setListTags(bool value) { m_listTags = value; }
@@ -142,6 +144,7 @@ namespace app {
     std::string m_dataFilename;
     std::string m_textureFilename;
     std::string m_filenameFormat;
+    std::string m_tagnameFormat;
     int m_textureWidth;
     int m_textureHeight;
     int m_textureColumns;


### PR DESCRIPTION
Fixes issue #1514
Utilizes a subset of the string formatting capabilities to format tag names when exporting to json


I agree that my contributions are licensed under the Individual Contributor License Agreement V3.0 ("CLA") as stated in https://github.com/aseprite/sourcecode/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/aseprite/sourcecode/blob/main/sign-cla.md#sign-the-cla