### PR TITLE
Add '{title}' and '{layer}' functionality to the Export dialog (fix aseprite/aseprite#3363)

### DIFF
--- a/src/app/commands/cmd_save_file.cpp
+++ b/src/app/commands/cmd_save_file.cpp
@@ -23,6 +23,7 @@
 #include "app/file/gif_format.h"
 #include "app/file/png_format.h"
 #include "app/file_selector.h"
+#include "app/filename_formatter.h"
 #include "app/i18n/strings.h"
 #include "app/job.h"
 #include "app/modules/gui.h"
@@ -390,7 +391,11 @@ void SaveFileCopyAsCommand::onExecute(Context* context)
     if (!result)
       return;
 
-    outputFilename = win.outputFilenameValue();
+    FilenameInfo fnInfo;
+    fnInfo
+      .filename(context->activeDocument()->name())
+      .layerName(win.layersValue());
+    outputFilename = filename_formatter(win.outputFilenameValue(), fnInfo);
 
     if (askOverwrite &&
         base::is_file(outputFilename)) {

--- a/src/app/doc_exporter.cpp
+++ b/src/app/doc_exporter.cpp
@@ -689,6 +689,11 @@ Doc* DocExporter::exportSheet(Context* ctx, base::task_token& token)
   // Save the image files.
   if (!m_textureFilename.empty()) {
     DX_TRACE("DocExporter::exportSheet", m_textureFilename);
+    // filename_formatter usage to include {title} key word on CLI.
+    FilenameInfo fnInfo;
+    fnInfo.filename(ctx->activeDocument()->name());
+    m_textureFilename = filename_formatter(m_textureFilename.c_str(), fnInfo);
+
     textureDocument->setFilename(m_textureFilename.c_str());
     int ret = save_document(ctx, textureDocument.get());
     if (ret == 0)


### PR DESCRIPTION
Also Add '{title}' functionality to CLI dialog on sprite-sheet file name

Continuation of https://github.com/aseprite/aseprite/pull/3364