### PR TITLE
Removed fillOrphanNodes, now new colors are added to the octree color arragement.

### DIFF
--- a/src/doc/octree_map.h
+++ b/src/doc/octree_map.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (c) 2020-2021 Igara Studio S.A.
+// Copyright (c) 2020-2022 Igara Studio S.A.
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -93,13 +93,7 @@ public:
   void addColor(color_t c, int level, OctreeNode* parent,
                 int paletteIndex = 0, int levelDeep = 7);
 
-  void fillOrphansNodes(const Palette* palette,
-                        const color_t upstreamBranchColor,
-                        const int level);
-
-  void fillMostSignificantNodes(int level);
-
-  int mapColor(int r, int g, int b, int a, int level) const;
+  int mapColor(int  r, int g, int b, int a, int mask_index, const Palette* palette, int level) const;
 
   void collectLeafNodes(OctreeNodes& leavesVector, int& paletteIndex);
 
@@ -114,11 +108,12 @@ private:
   void paletteIndex(int index) { m_paletteIndex = index; }
 
   static int getHextet(color_t c, int level);
+  static int getHextet(int r, int g, int b, int a, int level);
   static color_t hextetToBranchColor(int hextet, int level);
 
   LeafColor m_leafColor;
-  int m_paletteIndex = 0;
-  std::unique_ptr<std::array<OctreeNode, 16>> m_children;
+  mutable int m_paletteIndex = -1;
+  mutable std::unique_ptr<std::array<OctreeNode, 16>> m_children;
   OctreeNode* m_parent = nullptr;
 };
 
@@ -142,12 +137,20 @@ public:
   // RgbMap impl
   void regenerateMap(const Palette* palette, const int maskIndex) override;
   int mapColor(color_t rgba) const override;
+  int maskIndex() const override { return m_maskIndex; }
+  int mapColor(const int r, const int g,
+               const int b, const int a) const
+  {
+    ASSERT(r >= 0 && r < 256);
+    ASSERT(g >= 0 && g < 256);
+    ASSERT(b >= 0 && b < 256);
+    ASSERT(a >= 0 && a < 256);
+    return mapColor(rgba(r, g, b, a));
+  }
 
   int moodifications() const { return m_modifications; };
 
 private:
-  void fillOrphansNodes(const Palette* palette);
-
   OctreeNode m_root;
   OctreeNodes m_leavesVector;
   const Palette* m_palette = nullptr;

--- a/src/doc/palette.cpp
+++ b/src/doc/palette.cpp
@@ -483,37 +483,14 @@ int Palette::findBestfit(int r, int g, int b, int a, int mask_index) const
   return bestfit;
 }
 
-int Palette::findBestfit2(int r, int g, int b, int a) const
+int Palette::findMaskColor() const
 {
-  ASSERT(r >= 0 && r <= 255);
-  ASSERT(g >= 0 && g <= 255);
-  ASSERT(b >= 0 && b <= 255);
-  ASSERT(a >= 0 && a <= 255);
-
-  int bestfit = 0;
-  int lowest = std::numeric_limits<int>::max();
   int size = m_colors.size();
-
-  for (int i=0; i<size; ++i) {
-    color_t rgb = m_colors[i];
-    int rDiff = r - rgba_getr(rgb);
-    int gDiff = g - rgba_getg(rgb);
-    int bDiff = b - rgba_getb(rgb);
-    int aDiff = a - rgba_geta(rgb);
-
-    // TODO We should have two different ways to calculate the
-    // distance between colors, like "Perceptual" and "Linear", or a
-    // way to configure these coefficients.
-    int diff = rDiff * rDiff * 900  +
-               gDiff * gDiff * 3481 +
-               bDiff * bDiff * 121  +
-               aDiff * aDiff * 900; // there is no scientific reason to choose this value.
-    if (diff < lowest) {
-      lowest = diff;
-      bestfit = i;
-    }
+  for (int i = 0; i < size; ++i) {
+    if (m_colors[i] == 0)
+      return i;
   }
-  return bestfit;
+  return -1;
 }
 
 void Palette::applyRemap(const Remap& remap)

--- a/src/doc/palette.h
+++ b/src/doc/palette.h
@@ -101,7 +101,7 @@ namespace doc {
     int findExactMatch(int r, int g, int b, int a, int mask_index) const;
     bool findExactMatch(color_t color) const;
     int findBestfit(int r, int g, int b, int a, int mask_index) const;
-    int findBestfit2(int r, int g, int b, int a) const;
+    int findMaskColor() const;
 
     void applyRemap(const Remap& remap);
 

--- a/src/doc/rgbmap.h
+++ b/src/doc/rgbmap.h
@@ -1,5 +1,5 @@
 // Aseprite Document Library
-// Copyright (c) 2020 Igara Studio S.A.
+// Copyright (c) 2020-2022 Igara Studio S.A.
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -24,6 +24,8 @@ namespace doc {
 
     // Should return the best index in a palette that matches the given RGBA values.
     virtual int mapColor(const color_t rgba) const = 0;
+
+    virtual int maskIndex() const = 0;
 
     int mapColor(const int r,
                  const int g,

--- a/src/doc/rgbmap_rgb5a3.h
+++ b/src/doc/rgbmap_rgb5a3.h
@@ -1,5 +1,5 @@
 // Aseprite Document Library
-// Copyright (c) 2020 Igara Studio S.A.
+// Copyright (c) 2020-2022 Igara Studio S.A.
 // Copyright (c) 2001-2016 David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -41,7 +41,7 @@ namespace doc {
       return (v & INVALID) ? generateEntry(i, r, g, b, a): v;
     }
 
-    int maskIndex() const { return m_maskIndex; }
+    int maskIndex() const override { return m_maskIndex; }
 
   private:
     int generateEntry(int i, int r, int g, int b, int a) const;

--- a/src/doc/sprite.cpp
+++ b/src/doc/sprite.cpp
@@ -395,9 +395,6 @@ RgbMap* Sprite::rgbMap(const frame_t frame,
                        const RgbMapFor forLayer,
                        RgbMapAlgorithm mapAlgo) const
 {
-  int maskIndex = (forLayer == RgbMapFor::OpaqueLayer ?
-                   -1: transparentColor());
-
   if (!m_rgbMap || m_rgbMapAlgorithm != mapAlgo) {
     m_rgbMapAlgorithm = mapAlgo;
     switch (m_rgbMapAlgorithm) {
@@ -410,7 +407,14 @@ RgbMap* Sprite::rgbMap(const frame_t frame,
         return nullptr;
     }
   }
-
+  int maskIndex;
+  if (forLayer == RgbMapFor::OpaqueLayer)
+    maskIndex = -1;
+  else {
+    maskIndex = palette(frame)->findMaskColor();
+    if (maskIndex == -1)
+      maskIndex = 0;
+  }
   m_rgbMap->regenerateMap(palette(frame), maskIndex);
   return m_rgbMap.get();
 }

--- a/src/render/quantization.cpp
+++ b/src/render/quantization.cpp
@@ -1,5 +1,5 @@
 // Aseprite Render Library
-// Copyright (c) 2019-2021  Igara Studio S.A.
+// Copyright (c) 2019-2022  Igara Studio S.A.
 // Copyright (c) 2001-2018  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -237,7 +237,7 @@ Image* convert_pixel_format(
             a = rgba_geta(c);
 
             if (a == 0)
-              *dst_it = new_mask_color;
+              *dst_it = (new_mask_color == -1? 0 : new_mask_color);
             else if (rgbmap)
               *dst_it = rgbmap->mapColor(c);
             else
@@ -296,7 +296,7 @@ Image* convert_pixel_format(
             c = graya_getv(c);
 
             if (a == 0)
-              *dst_it = new_mask_color;
+              *dst_it = (new_mask_color == -1? 0 : new_mask_color);
             else if (rgbmap)
               *dst_it = rgbmap->mapColor(c, c, c, a);
             else


### PR DESCRIPTION
This gives more accuracy in the color picking criteria on new images pasted into an INDEXED sprite.

Also, added findMaskColor to fix the behavior reported: aseprite/aseprite#3207

Both issues are related when RGBMAP is created. The 'mask color' and 'mask index' must be defined correctly to include/exclude during the table/octree map color search.

To do: When converting sprite to INDEXED, it's needed to add 'mask color' to palette when number of colors is < 256 and transparent color is not in palette (also recommended in aseprite/aseprite#3207).