### PR TITLE
Fix empty undo history crash (fix #3417)

### DIFF
--- a/src/app/commands/cmd_undo_history.cpp
+++ b/src/app/commands/cmd_undo_history.cpp
@@ -113,7 +113,7 @@ public:
           [[fallthrough]];
 
         case ui::kMouseMoveMessage:
-          if (hasCapture()) {
+          if (hasCapture() && m_undoHistory) {
             auto mouseMsg = static_cast<ui::MouseMessage*>(msg);
             const gfx::Rect bounds = this->bounds();
 


### PR DESCRIPTION
m_undoHistory is not valid for tabs other than sprites. For example
opening the README or Home tab does not initialize the undo history,
thus aseprite will segfault when it tries to get its first entry.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the Individual Contributor License Agreement V3.0. -->
<!-- If you're a first-time contributor, please sign the CLA
     as indicated in https://github.com/aseprite/sourcecode/blob/main/sign-cla.md#sign-the-cla
     and acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the Individual Contributor License Agreement V3.0 ("CLA") as stated in https://github.com/aseprite/sourcecode/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/aseprite/sourcecode/blob/main/sign-cla.md#sign-the-cla
