### PR TITLE
Fix Marqueed selection 1 px distortion when move it outside the canvas (left and top) with Ctrl still pressed (fix #2891))

### DIFF
--- a/src/app/transformation.cpp
+++ b/src/app/transformation.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2020-2021  Igara Studio S.A.
+// Copyright (C) 2020-2022  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -89,7 +89,7 @@ RectF Transformation::transformedBounds() const
   for (int i=0; i<Corners::NUM_OF_CORNERS; ++i)
     bounds = bounds.createUnion(RectF(corners[i].x, corners[i].y, m_cornerThick, m_cornerThick));
 
-  return bounds;
+  return bounds.floor();
 }
 
 } // namespace app

--- a/src/app/transformation.h
+++ b/src/app/transformation.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2020-2021  Igara Studio S.A.
+// Copyright (C) 2020-2022  Igara Studio S.A.
 // Copyright (C) 2001-2016  David Capello
 //
 // This program is distributed under the terms of
@@ -63,7 +63,7 @@ public:
         gfx::RectF bounds;
         for (int i=0; i<Corners::NUM_OF_CORNERS; ++i)
           bounds |= gfx::RectF(m_corners[i].x, m_corners[i].y, cornerThick, cornerThick);
-        return bounds;
+        return bounds.floor();
       }
 
     private:


### PR DESCRIPTION
Prior to this fix, moving a marquee selection while holding down the Ctrl key outside the left/top area of the canvas results in a 1px distortion of the marquee image. This distortion is due to a false transformation when it is required to get the corner bounds, due to rounding the float coordinates towards 0 instead of the nearest left/top integer. The discrepancy occurs within the `getDraggedImageCopy`, `redrawExtraImage`, `drawImage` and `drawMask` functions.