### PR TITLE
Fix [regression] textBox not rendering text (doesn't update the bounds area of the text box)

### DIFF
--- a/data/extensions/aseprite-theme/theme.xml
+++ b/data/extensions/aseprite-theme/theme.xml
@@ -503,6 +503,10 @@
             <background color="tooltip_face" />
             <text color="tooltip_text" align="left" />
         </style>
+        <style id="textbox_text" align="left top wordwrap" border="4">
+            <background color="textbox_face" />
+            <text color="textbox_text" align="left" />
+        </style>
         <style id="label" padding="1">
             <text color="text" align="left" />
             <text color="disabled" align="left" state="disabled" />

--- a/src/app/ui/skin/skin_theme.cpp
+++ b/src/app/ui/skin/skin_theme.cpp
@@ -913,9 +913,8 @@ void SkinTheme::initWidget(Widget* widget)
       break;
 
     case kTextBoxWidget:
-      BORDER(4*guiscale());
       widget->setChildSpacing(0);
-      widget->setBgColor(colors.textboxFace());
+      widget->setStyle(styles.textboxText());
       break;
 
     case kViewWidget:

--- a/src/ui/theme.cpp
+++ b/src/ui/theme.cpp
@@ -294,10 +294,9 @@ void Theme::paintTooltip(Graphics* g,
   }
 }
 
-gfx::Size Theme::paintTextBoxWithStyle(Graphics* g,
-                                       const Widget* widget)
+void Theme::paintTextBoxWithStyle(Graphics* g,
+                                  const Widget* widget)
 {
-  gfx::Size size;
   gfx::Color bg = gfx::ColorNone, fg = gfx::ColorNone;
 
   for_each_layer(
@@ -311,9 +310,7 @@ gfx::Size Theme::paintTextBoxWithStyle(Graphics* g,
     });
 
   if (fg != gfx::ColorNone)
-    Theme::drawTextBox(g, widget, &size.w, &size.h, bg, fg);
-
-  return size;
+    Theme::drawTextBox(g, widget, nullptr, nullptr, bg, fg);
 }
 
 void Theme::paintLayer(Graphics* g,

--- a/src/ui/theme.h
+++ b/src/ui/theme.h
@@ -101,8 +101,8 @@ namespace ui {
                               const int arrowAlign,
                               const gfx::Rect& target);
 
-    gfx::Size paintTextBoxWithStyle(Graphics* g,
-                                    const Widget* widget);
+    void paintTextBoxWithStyle(Graphics* g,
+                               const Widget* widget);
 
     virtual gfx::Size calcSizeHint(const Widget* widget,
                                    const Style* style);


### PR DESCRIPTION
Regression in dd0c29620974e56d9e62653804b996740a89e88a (Use tooltip_text style & color to paint tooltip windows #2554).
Prior this fix, text box do not update its bounds area because it has not a style assigned.