### PR TITLE
Initial path in the file dialog is set to the path of the currently open file

### DIFF
--- a/src/app/commands/cmd_open_file.cpp
+++ b/src/app/commands/cmd_open_file.cpp
@@ -117,6 +117,14 @@ void OpenFileCommand::onExecute(Context* context)
   if (context->isUIAvailable() && m_filename.empty()) {
     base::paths exts = get_readable_extensions();
 
+    auto doc = context->activeDocument();
+    if (m_folder.empty() && doc) {
+      auto filename = doc->filename();
+      if (!filename.empty()) {
+        m_folder = base::get_file_path(filename);
+      }
+    }
+
     // Add backslash as show_file_selector() expected a filename as
     // initial path (and the file part is removed from the path).
     if (!m_folder.empty() && !base::is_path_separator(m_folder[m_folder.size()-1]))


### PR DESCRIPTION
This kind of behavior is more convenient.
For example, the initial path in the file dialog of Visual Studio Code and other programs behaves like this PR.


I agree that my contributions are licensed under the Individual Contributor License Agreement V3.0 ("CLA") as stated in https://github.com/aseprite/sourcecode/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/aseprite/sourcecode/blob/main/sign-cla.md#sign-the-cla
