### PR TITLE
Request frame duration when opening sequences

### DIFF
--- a/data/strings/en.ini
+++ b/data/strings/en.ini
@@ -1033,6 +1033,7 @@ double_high = Double-high Pixels (1:2)
 title = Notice
 description = Do you want to load the following files as an animation?
 repeat = Do the same for other files
+duration = Duration
 agree = &Agree
 skip = &Skip
 

--- a/data/widgets/open_sequence.xml
+++ b/data/widgets/open_sequence.xml
@@ -8,6 +8,10 @@
     <view expansive="true" id="view" minwidth="128" minheight="64">
       <listbox id="files" multiselect="true" />
     </view>
+	<hbox>
+      <label text="@.duration" />
+	  <expr text="0" id="duration" suffix="ms" />
+	</hbox>
     <separator horizontal="true" />
     <check id="repeat" text="@.repeat" />
     <check id="dont_show" text="@general.dont_show" />

--- a/src/app/file/file.cpp
+++ b/src/app/file/file.cpp
@@ -385,6 +385,10 @@ FileOp* FileOp::createLoadDocumentOperation(Context* context,
               window.files()->getSelectedChild() != nullptr);
           });
 
+        window.duration()->setTextf("%d", fop->m_seq.duration);
+        window.duration()->Change.connect(
+          [&]() { fop->m_seq.duration = window.duration()->textInt(); });
+
         window.openWindowInForeground();
 
         // Don't show this alert again.
@@ -831,6 +835,8 @@ void FileOp::operate(IFileOpProgress* progress)
           add_image();
 #endif
         }
+
+        m_document->sprite()->setFrameDuration(frame, m_seq.duration);
 
         ++frame;
         m_seq.progress_offset += m_seq.progress_fraction;
@@ -1395,6 +1401,7 @@ FileOp::FileOp(FileOpType type,
   m_seq.frame = frame_t(0);
   m_seq.layer = nullptr;
   m_seq.last_cel = nullptr;
+  m_seq.duration = 100;
   m_seq.flags = 0;
 }
 

--- a/src/app/file/file.h
+++ b/src/app/file/file.h
@@ -307,6 +307,7 @@ namespace app {
       bool has_alpha;
       LayerImage* layer;
       Cel* last_cel;
+      int duration;
       // Flags after the user choose what to do with the sequence.
       int flags;
     } m_seq;


### PR DESCRIPTION
Currently, Aseprite defaults to 10fps for new files, and when opening animation sequences (`file-001.png`, `file-002.png`, ...).

While I started using it for the latter often, it became a bit irritating to set framerate each time opening the files. Mostly due to the fact that it's easy to miss and begin export at default value - takes a while for large gifs.

This commit puts duration field into the sequence popup. Alternatively, it could've been a setting for the default value, which is less flexible but affects new files as well. Or both. Input needed.

I tested that this change does not affect loaded gifs' timing, but tbh entire image loading is a large chunk, not sure what else can be affected.

![image](https://user-images.githubusercontent.com/49268426/185913025-99937c2e-67e4-489b-a6b6-4d484def29b7.png)

------------------------
I agree that my contributions are licensed under the Individual Contributor License Agreement V3.0 ("CLA") as stated in https://github.com/aseprite/sourcecode/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/aseprite/sourcecode/blob/main/sign-cla.md#sign-the-cla
