### PR TITLE
Add extended support to BMP files (fix #3277, fix #1495)

### DIFF
--- a/src/doc/color_scales.h
+++ b/src/doc/color_scales.h
@@ -1,5 +1,5 @@
 // Aseprite Document Library
-// Copyright (C) 2020  Igara Studio S.A.
+// Copyright (C) 2020-2022  Igara Studio S.A.
 // Copyright (C) 2001-2016  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -26,6 +26,18 @@ namespace doc {
   inline int scale_6bits_to_8bits(const int v) {
     ASSERT(v >= 0 && v < 64);
     return (v << 2) | (v >> 4);
+  }
+
+  inline int scale_xxbits_to_8bits(const int xx, const int v) {
+    switch (xx) {
+      case 3:
+        return scale_3bits_to_8bits(v);
+      case 5:
+        return scale_5bits_to_8bits(v);
+      case 6:
+        return scale_6bits_to_8bits(v);
+    }
+    return (int)(255.0 / (double(1<<xx) - 1.0) * (double)v);
   }
 
 } // namespace doc


### PR DESCRIPTION
Before this fix, the supported BMP header sizes were:
- Size = 12 (OS/2 BMP 1.0)
- Size = 40 (Windows BMP v3)

Now is possible:
- Load BMP files with BMP header size:
  - Size = 12 (OS/2 BMP 1.0)
  - Size = 16 (OS/2 BMP 2.0 - size 16)
  - Size = 24 (OS/2 BMP 2.0 - size 24)
  - Size = 40 (Windows BMP v3)
  - Size = 52 (BITMAPV2INFOHEADER)
  - Size = 56 (BITMAPV3INFOHEADER)
  - Size = 60 (OS/2 BMP 2.0 - size 60)
  - Size = 64 (OS/2 BMP 2.0 - size 64)
  - Size = 108 (BITMAPV4INFOHEADER) at the moment colorimetry isn’t supported.
  - Size = 124 (BITMAPV5INFOHEADER) at the moment ICC profiles not supported.
- Load BMP with alpha channel.
- Export BMP files with alpha channel (not palette based).

Warning: not every app is compatible with BMP files with alpha channel. BMP isn’t recommended with images with transparent content.