### PR TITLE
Minor refactor of the OctreeMap class

### DIFF
--- a/src/app/commands/cmd_select_palette.cpp
+++ b/src/app/commands/cmd_select_palette.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2021  Igara Studio SA
+// Copyright (C) 2021-2022  Igara Studio SA
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -129,16 +129,16 @@ void SelectPaletteColorsCommand::onExecute(Context* context)
 
   if (m_modifier == Modifier::UsedColors ||
       m_modifier == Modifier::UnusedColors) {
-    doc::OctreeMap octreemap;
+    doc::OctreeMap octreemap(sprite);
     const doc::Palette* currentPalette = get_current_palette();
     PalettePicks usedEntries(currentPalette->size());
 
-    auto countImage = [&octreemap, &usedEntries](const Image* image){
+    auto countImage = [&octreemap, &usedEntries](const Image* image) {
       switch (image->pixelFormat()) {
 
         case IMAGE_RGB:
         case IMAGE_GRAYSCALE:
-          octreemap.feedWithImage(image, true, image->maskColor(), 8);
+          octreemap.feedWithImage(image, true, 8);
           break;
 
         case IMAGE_INDEXED:

--- a/src/doc/octree_map.cpp
+++ b/src/doc/octree_map.cpp
@@ -118,13 +118,11 @@ color_t OctreeNode::hextetToBranchColor(int hextet, int level)
 //////////////////////////////////////////////////////////////////////
 // OctreeMap
 
-OctreeMap::OctreeMap() {};
-
-// This constructor initializes 'm_naskIndex' and
+// This constructor initializes 'm_maskIndex' and
 // 'm_includeMaskColorInPalette' according to sprite's pixel format and
 // background existence.
-// This variables are needed previous of makePalette() execution and
-// mapColor().
+// These variables are needed before makePalette() and mapColor()
+// execution.
 OctreeMap::OctreeMap(const doc::Sprite* sprite)
 {
   m_maskIndex = -1;

--- a/src/doc/octree_map.h
+++ b/src/doc/octree_map.h
@@ -114,9 +114,7 @@ private:
 
 class OctreeMap : public RgbMap {
 public:
-  OctreeMap();
-
-  OctreeMap(const doc::Sprite* sprite);
+  OctreeMap(const doc::Sprite* sprite = nullptr);
 
   void addColor(color_t color, int levelDeep = 7) {
     m_root.addColor(color, 0, &m_root, 0, levelDeep);

--- a/src/doc/octree_map.h
+++ b/src/doc/octree_map.h
@@ -12,16 +12,11 @@
 #include "doc/image_impl.h"
 #include "doc/palette.h"
 #include "doc/rgbmap.h"
+#include "doc/sprite.h"
 
 #include <array>
 #include <memory>
 #include <vector>
-
-// When this DOC_OCTREE_IS_OPAQUE 'color' is asociated with
-// some variable which represents a mask color, it tells us that
-// there isn't any transparent color in the sprite, i.e.
-// there is a background layer in the sprite.
-#define DOC_OCTREE_IS_OPAQUE 0x00FFFFFF
 
 namespace doc {
 
@@ -119,6 +114,10 @@ private:
 
 class OctreeMap : public RgbMap {
 public:
+  OctreeMap();
+
+  OctreeMap(const doc::Sprite* sprite);
+
   void addColor(color_t color, int levelDeep = 7) {
     m_root.addColor(color, 0, &m_root, 0, levelDeep);
   }
@@ -131,7 +130,6 @@ public:
 
   void feedWithImage(const Image* image,
                      const bool withAlpha,
-                     const color_t maskColor,
                      const int levelDeep = 7);
 
   // RgbMap impl
@@ -155,8 +153,16 @@ private:
   OctreeNodes m_leavesVector;
   const Palette* m_palette = nullptr;
   int m_modifications = 0;
-  int m_maskIndex = 0;
-  color_t m_maskColor = 0;
+
+  // Used only in makePalette() function.
+  // Mask color will be included in an output palette according to
+  // sprite characteristics.
+  // These conditions are expressed in the Octreemap constructor.
+  bool m_includeMaskColorInPalette = true;
+
+  // Used in bestfit() inside mapColor() function to discard
+  // the color entry defined as transparent in the sprite source.
+  int m_maskIndex = -1;
 };
 
 } // namespace doc

--- a/src/doc/sprite.cpp
+++ b/src/doc/sprite.cpp
@@ -400,7 +400,7 @@ RgbMap* Sprite::rgbMap(const frame_t frame,
     switch (m_rgbMapAlgorithm) {
       case RgbMapAlgorithm::RGB5A3: m_rgbMap.reset(new RgbMapRGB5A3); break;
       case RgbMapAlgorithm::DEFAULT:
-      case RgbMapAlgorithm::OCTREE: m_rgbMap.reset(new OctreeMap); break;
+      case RgbMapAlgorithm::OCTREE: m_rgbMap.reset(new OctreeMap(this)); break;
       default:
         m_rgbMap.reset(nullptr);
         ASSERT(false);


### PR DESCRIPTION
Removed unnecessary code related to member variable m_maskColor of 'OctreeMap'. The constructor 'OctreeMap(sprite)' is included to simplify the selection of 'm_maskIndex' according to the properties of the sprite (according to the format and transparent index), in addition to deciding if the mask color should be included in the final palette.