### PR TITLE
Minor refactor of the OctreeMap class

### DIFF
--- a/src/app/commands/cmd_select_palette.cpp
+++ b/src/app/commands/cmd_select_palette.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2021  Igara Studio SA
+// Copyright (C) 2021-2022  Igara Studio SA
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -129,16 +129,16 @@ void SelectPaletteColorsCommand::onExecute(Context* context)
 
   if (m_modifier == Modifier::UsedColors ||
       m_modifier == Modifier::UnusedColors) {
-    doc::OctreeMap octreemap;
+    doc::OctreeMap octreemap(sprite);
     const doc::Palette* currentPalette = get_current_palette();
     PalettePicks usedEntries(currentPalette->size());
 
-    auto countImage = [&octreemap, &usedEntries](const Image* image){
+    auto countImage = [&octreemap, &usedEntries](const Image* image) {
       switch (image->pixelFormat()) {
 
         case IMAGE_RGB:
         case IMAGE_GRAYSCALE:
-          octreemap.feedWithImage(image, true, image->maskColor(), 8);
+          octreemap.feedWithImage(image, true, 8);
           break;
 
         case IMAGE_INDEXED:

--- a/src/doc/octree_map.cpp
+++ b/src/doc/octree_map.cpp
@@ -232,22 +232,20 @@ void OctreeMap::feedWithImage(const Image* image,
   ASSERT(image);
   ASSERT(image->pixelFormat() == IMAGE_RGB || image->pixelFormat() == IMAGE_GRAYSCALE);
   color_t forceFullOpacity;
-  color_t alpha = 0;
+  int alpha = 0;
   const bool imageIsRGBA = image->pixelFormat() == IMAGE_RGB;
 
   auto add_color_to_octree =
-    [this, &forceFullOpacity, &maskColor, &alpha, &levelDeep, &imageIsRGBA](color_t color) {
-      if (color != maskColor) {
+    [this, &forceFullOpacity, &alpha, &levelDeep, &imageIsRGBA](color_t color) {
+      alpha = (imageIsRGBA ? rgba_geta(color) : graya_geta(color));
+      if (alpha >= MIN_ALPHA_THRESHOLD) { // Colors which alpha is less than
+                                          // MIN_ALPHA_THRESHOLD will not registered
         color |= forceFullOpacity;
-        alpha = (imageIsRGBA ? rgba_geta(color) : graya_geta(color));
-        if (alpha >= MIN_ALPHA_THRESHOLD) { // Colors which alpha is less than
-                                            // MIN_ALPHA_THRESHOLD will not registered
-          color = (imageIsRGBA ? color : rgba(graya_getv(color),
-                                              graya_getv(color),
-                                              graya_getv(color),
-                                              graya_geta(color)));
-          addColor(color, levelDeep);
-        }
+        color = (imageIsRGBA ? color : rgba(graya_getv(color),
+                                            graya_getv(color),
+                                            graya_getv(color),
+                                            alpha));
+        addColor(color, levelDeep);
       }
     };
 

--- a/src/doc/octree_map.cpp
+++ b/src/doc/octree_map.cpp
@@ -118,6 +118,27 @@ color_t OctreeNode::hextetToBranchColor(int hextet, int level)
 //////////////////////////////////////////////////////////////////////
 // OctreeMap
 
+// This constructor initializes 'm_maskIndex' and
+// 'm_includeMaskColorInPalette' according to sprite's pixel format and
+// background existence.
+// These variables are needed before makePalette() and mapColor()
+// execution.
+OctreeMap::OctreeMap(const doc::Sprite* sprite)
+{
+  m_maskIndex = -1;
+  if (sprite) {
+    if (sprite->pixelFormat() == IMAGE_INDEXED) {
+      m_maskIndex = sprite->transparentColor();
+      m_includeMaskColorInPalette = false;
+    }
+    else if (sprite->backgroundLayer() &&
+             sprite->allLayersCount() == 1)
+      m_includeMaskColorInPalette = false;
+    m_palette = sprite->palette(0);
+    m_modifications = sprite->palette(0)->getModifications();
+  }
+};
+
 bool OctreeMap::makePalette(Palette* palette,
                             int colorCount,
                             const int levelDeep)
@@ -130,7 +151,7 @@ bool OctreeMap::makePalette(Palette* palette,
     m_root.collectLeafNodes(m_leavesVector, paletteIndex);
   }
 
-  if (m_maskColor != DOC_OCTREE_IS_OPAQUE)
+  if (m_includeMaskColorInPalette)
     colorCount--;
 
   // If we can improve the octree accuracy, makePalette returns false, then
@@ -209,13 +230,13 @@ bool OctreeMap::makePalette(Palette* palette,
   }
   int leafCount = m_leavesVector.size();
   int aux = 0;
-  if (m_maskColor == DOC_OCTREE_IS_OPAQUE)
-    palette->resize(leafCount);
-  else {
+  if (m_includeMaskColorInPalette) {
     palette->resize(leafCount + 1);
-    palette->setEntry(0, m_maskColor);
+    palette->setEntry(0, 0);
     aux = 1;
   }
+  else
+    palette->resize(leafCount);
 
   for (int i=0; i<leafCount; i++)
     palette->setEntry(i+aux,
@@ -226,7 +247,6 @@ bool OctreeMap::makePalette(Palette* palette,
 
 void OctreeMap::feedWithImage(const Image* image,
                               const bool withAlpha,
-                              const color_t maskColor,
                               const int levelDeep)
 {
   ASSERT(image);
@@ -261,7 +281,6 @@ void OctreeMap::feedWithImage(const Image* image,
       break;
     }
   }
-  m_maskColor = maskColor;
 }
 
 int OctreeMap::mapColor(color_t rgba) const
@@ -289,26 +308,9 @@ void OctreeMap::regenerateMap(const Palette* palette, const int maskIndex)
   m_root = OctreeNode();
   m_leavesVector.clear();
   m_maskIndex = maskIndex;
-  int maskColorBestFitIndex;
-  if (maskIndex < 0) {
-    m_maskColor = DOC_OCTREE_IS_OPAQUE;
-    maskColorBestFitIndex = -1;
-  }
-  else {
-    m_maskColor = palette->getEntry(maskIndex);
-    maskColorBestFitIndex = palette->findBestfit(rgba_getr(m_maskColor),
-                                                 rgba_getg(m_maskColor),
-                                                 rgba_getb(m_maskColor),
-                                                 rgba_geta(m_maskColor), maskIndex);
-  }
 
-  for (int i=0; i<palette->size(); i++) {
-    if (i == maskIndex) {
-      m_root.addColor(palette->entry(i), 0, &m_root, maskColorBestFitIndex, 8);
-      continue;
-    }
+  for (int i=0; i<palette->size(); i++)
     m_root.addColor(palette->entry(i), 0, &m_root, i, 8);
-  }
 
   m_palette = palette;
   m_modifications = palette->getModifications();

--- a/src/doc/octree_map.h
+++ b/src/doc/octree_map.h
@@ -12,16 +12,11 @@
 #include "doc/image_impl.h"
 #include "doc/palette.h"
 #include "doc/rgbmap.h"
+#include "doc/sprite.h"
 
 #include <array>
 #include <memory>
 #include <vector>
-
-// When this DOC_OCTREE_IS_OPAQUE 'color' is asociated with
-// some variable which represents a mask color, it tells us that
-// there isn't any transparent color in the sprite, i.e.
-// there is a background layer in the sprite.
-#define DOC_OCTREE_IS_OPAQUE 0x00FFFFFF
 
 namespace doc {
 
@@ -119,6 +114,8 @@ private:
 
 class OctreeMap : public RgbMap {
 public:
+  OctreeMap(const doc::Sprite* sprite = nullptr);
+
   void addColor(color_t color, int levelDeep = 7) {
     m_root.addColor(color, 0, &m_root, 0, levelDeep);
   }
@@ -131,7 +128,6 @@ public:
 
   void feedWithImage(const Image* image,
                      const bool withAlpha,
-                     const color_t maskColor,
                      const int levelDeep = 7);
 
   // RgbMap impl
@@ -155,8 +151,16 @@ private:
   OctreeNodes m_leavesVector;
   const Palette* m_palette = nullptr;
   int m_modifications = 0;
-  int m_maskIndex = 0;
-  color_t m_maskColor = 0;
+
+  // Used only in makePalette() function.
+  // Mask color will be included in an output palette according to
+  // sprite characteristics.
+  // These conditions are expressed in the Octreemap constructor.
+  bool m_includeMaskColorInPalette = true;
+
+  // Used in bestfit() inside mapColor() function to discard
+  // the color entry defined as transparent in the sprite source.
+  int m_maskIndex = -1;
 };
 
 } // namespace doc

--- a/src/doc/sprite.cpp
+++ b/src/doc/sprite.cpp
@@ -400,7 +400,7 @@ RgbMap* Sprite::rgbMap(const frame_t frame,
     switch (m_rgbMapAlgorithm) {
       case RgbMapAlgorithm::RGB5A3: m_rgbMap.reset(new RgbMapRGB5A3); break;
       case RgbMapAlgorithm::DEFAULT:
-      case RgbMapAlgorithm::OCTREE: m_rgbMap.reset(new OctreeMap); break;
+      case RgbMapAlgorithm::OCTREE: m_rgbMap.reset(new OctreeMap(this)); break;
       default:
         m_rgbMap.reset(nullptr);
         ASSERT(false);


### PR DESCRIPTION
Removed unnecessary code related to member variable m_maskColor of 'OctreeMap'. The constructor 'OctreeMap(sprite)' is included to simplify the selection of 'm_maskIndex' according to the properties of the sprite (according to the format and transparent index), in addition to deciding if the mask color should be included in the final palette.