### PR TITLE
Small UI button set painting fixes

### DIFF
--- a/src/app/ui/button_set.cpp
+++ b/src/app/ui/button_set.cpp
@@ -96,6 +96,7 @@ void ButtonSet::Item::onPaint(ui::PaintEvent& ev)
   if (m_icon || isLastRow) {
     textRc.y -= 2*guiscale();
     iconRc.y -= 1*guiscale();
+    if (isLastRow && info.row > 0) iconRc.y -= 2*guiscale();
   }
 
   if (!gfx::is_transparent(bgColor()))

--- a/src/app/ui/button_set.cpp
+++ b/src/app/ui/button_set.cpp
@@ -94,7 +94,7 @@ void ButtonSet::Item::onPaint(ui::PaintEvent& ev)
   bool isLastRow = (info.row+info.vspan >= info.grid_rows);
 
   if (m_icon || isLastRow) {
-    textRc.y -= 1*guiscale();
+    textRc.y -= 2*guiscale();
     iconRc.y -= 1*guiscale();
   }
 


### PR DESCRIPTION
This PR contains 2 fixes to the way ButtonSet items are painted.
One fixes the vertical position of the text, and the other fixes the vertical position of the icon (#2676).