### PR TITLE
Fix index mode spray not handling masked color as expected (fix #3063)

### DIFF
--- a/src/app/tools/inks.h
+++ b/src/app/tools/inks.h
@@ -120,12 +120,7 @@ public:
 
           // Opacity is set to 255 when InkType=Simple in ToolLoopBase()
           if (loop->getOpacity() == 255 &&
-              // The trace policy is "overlap" when the dynamics has
-              // a gradient between FG <-> BG
-              //
-              // TODO this trace policy is configured in
-              //      ToolLoopBase() ctor, is there a better place?
-              loop->getTracePolicy() != TracePolicy::Overlap) {
+              loop->getDynamics().gradient == DynamicSensor::Static) {
             color_t color = loop->getPrimaryColor();
 
             switch (loop->sprite()->pixelFormat()) {


### PR DESCRIPTION
This PR updates an if condition in BaseInk::prepareInk() method to let the spray tool behave like the pencil tool when the mask color is selected in an indexed mode sprite.