### PR TITLE
Fix bmp file and bitmap size are incorrectly set during save command (fix #3534)

### DIFF
--- a/src/app/file/bmp_format.cpp
+++ b/src/app/file/bmp_format.cpp
@@ -1213,7 +1213,7 @@ bool BmpFormat::onSave(FileOp *fop)
               + biSizeImage);                        // image data
   }
   else {
-    biSizeImage = (w*3 + filler) * h;
+    biSizeImage = (w*bpp/8 + filler) * h;
     if (withAlpha)
       bfSize = BV3INFOHEADERSIZE +
                OS2FILEHEADERSIZE + biSizeImage;  // header + image data


### PR DESCRIPTION
At the moment this fix can only be tested by opening in Godot a BMP saved in Aseprite (RGBA color mode, just one transparent layer or more)