### PR TITLE
Fix saving custom properties

### DIFF
--- a/src/doc/user_data.h
+++ b/src/doc/user_data.h
@@ -109,6 +109,14 @@ namespace doc {
     Properties& properties() { return properties(std::string()); }
     Properties& properties(const std::string& groupKey) { return m_propertiesMaps[groupKey]; }
 
+    size_t countNonEmptyPropertiesMaps() const {
+      size_t i = 0;
+      for (const auto& it : m_propertiesMaps)
+        if (!it.second.empty())
+          ++i;
+      return i;
+    }
+
     void setText(const std::string& text) { m_text = text; }
     void setColor(color_t color) { m_color = color; }
 

--- a/tests/scripts/userdata_codec.lua
+++ b/tests/scripts/userdata_codec.lua
@@ -95,3 +95,27 @@ do
   assert(spr.slices[1].properties("ext").a.width == 30)
   assert(spr.slices[1].properties("ext").a.height == 40)
 end
+
+-- Test bug saving empty properties map with a empty set of properties
+do
+  local spr = Sprite(32, 32)
+  spr:newLayer("B")
+
+  -- Just create an empty property
+  local properties1 = spr.layers[1].properties("ext")
+  if properties1.categories then
+    -- do nothing
+  end
+
+  local properties2 = spr.layers[2].properties("ext")
+  properties2.b = 32
+
+  spr:saveAs("_test_userdata_codec_2.aseprite")
+  assert(#spr.layers == 2)
+  spr:close()
+
+  spr = Sprite{ fromFile="_test_userdata_codec_2.aseprite" }
+  assert(#spr.layers[1].properties("ext") == 0)
+  assert(#spr.layers[2].properties("ext") == 1)
+  assert(spr.layers[2].properties("ext").b == 32)
+end


### PR DESCRIPTION
A problem was detected saving properties, but I'm still working on a fix.

The issue appears with the AddressSanitizer when a std::string with more than 15 characters is created for a properties map:
```
=================================================================
==103774==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 60 byte(s) in 3 object(s) allocated from:
    #0 0x7f0278eb61c7 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:99
    #1 0x7f027834ead9 in void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char*>(char*, char*, std::forward_iterator_tag) (/lib/x86_64-linux-gnu/libstdc++.so.6+0x14ead9)

SUMMARY: AddressSanitizer: 60 byte(s) leaked in 3 allocation(s).
```

Anyway there are other issues testing where the whole file is broken, I'm trying to create a test case about this.