### PR TITLE
Add new/delete tiles from a tileset using Lua (fix #3663)

### DIFF
--- a/src/app/script/sprite_class.cpp
+++ b/src/app/script/sprite_class.cpp
@@ -12,6 +12,7 @@
 #include "app/app.h"
 #include "app/cmd/add_layer.h"
 #include "app/cmd/add_slice.h"
+#include "app/cmd/add_tile.h"
 #include "app/cmd/assign_color_profile.h"
 #include "app/cmd/clear_cel.h"
 #include "app/cmd/convert_color_profile.h"
@@ -20,6 +21,7 @@
 #include "app/cmd/remove_layer.h"
 #include "app/cmd/remove_slice.h"
 #include "app/cmd/remove_tag.h"
+#include "app/cmd/remove_tile.h"
 #include "app/cmd/set_grid_bounds.h"
 #include "app/cmd/set_mask.h"
 #include "app/cmd/set_pixel_ratio.h"
@@ -54,11 +56,14 @@
 #include "doc/slice.h"
 #include "doc/sprite.h"
 #include "doc/tag.h"
+#include "doc/tileset.h"
 
 #include <algorithm>
 
 namespace app {
 namespace script {
+
+Tileset* get_tile_index_from_arg(lua_State* L, int index, tile_index& ts);
 
 namespace {
 
@@ -835,6 +840,44 @@ int Sprite_set_pixelRatio(lua_State* L)
   return 0;
 }
 
+int Sprite_newTile(lua_State* L)
+{
+  auto sprite = get_docobj<Sprite>(L, 1);
+  auto ts = get_docobj<Tileset>(L, 2);
+  if (!ts) {
+    return luaL_error(L, "empty argument not allowed and must be a Tileset object");
+  }
+  tile_index ti = ts->size();
+  if (lua_isinteger(L, 3)) {
+    ti = tile_index(lua_tointeger(L, 3));
+    if (ti < 1)
+      return luaL_error(L, "index must be equal to or greater than 1");
+  }
+  ts->insert(ti, ts->makeEmptyTile());
+  Tx tx;
+  tx(new cmd::AddTile(ts, ti));
+  tx.commit();
+  push_tile(L, ts, ti);
+  return 1;
+}
+
+int Sprite_deleteTile(lua_State* L)
+{
+  auto sprite = get_docobj<Sprite>(L, 1);
+  tile_index ti;
+  Tileset* ts = get_tile_index_from_arg(L, 2, ti);
+  if (!ts) {
+    return luaL_error(L, "inexistent Tileset inside of Tile object");
+  }
+  if (ti < 0 || ti >= ts->size())
+    return luaL_error(L, "index out of bounds");
+  Tx tx;
+  tx(new cmd::RemoveTile(ts, ti));
+  tx.commit();
+  push_tile(L, ts, ti);
+  return 1;
+}
+
 const luaL_Reg Sprite_methods[] = {
   { "__eq", Sprite_eq },
   { "resize", Sprite_resize },
@@ -864,6 +907,9 @@ const luaL_Reg Sprite_methods[] = {
   // Slices
   { "newSlice", Sprite_newSlice },
   { "deleteSlice", Sprite_deleteSlice },
+  // Tiles
+  { "newTile", Sprite_newTile },
+  { "deleteTile", Sprite_deleteTile },
   { nullptr, nullptr }
 };
 

--- a/src/app/script/tile_class.cpp
+++ b/src/app/script/tile_class.cpp
@@ -33,6 +33,31 @@ struct Tile {
   }
 };
 
+Tile Tile_new(lua_State* L, int index)
+{
+  Tileset* ts = get_docobj<Tileset>(L, 1);
+  tile_index ti = -1;
+  if (!ts)
+    luaL_error(L, "empty argument not allowed and must be a Tileset object");
+  if (lua_isinteger(L, 2)) {
+    ti = tile_index(lua_tointeger(L, 2));
+    lua_pop(L, 1);
+  }
+  if (ti < 1) {
+    luaL_error(L, "index must be equal to or greater than 1");
+    ti = 0;
+  }
+  Tile tile(ts, ti);
+  lua_pop(L, 1);
+  return tile;
+}
+
+int Tile_new(lua_State* L)
+{
+  push_obj(L, Tile_new(L, 1));
+  return 1;
+}
+
 int Tile_get_image(lua_State* L)
 {
   auto tile = get_obj<Tile>(L, 1);
@@ -179,12 +204,20 @@ DEF_MTNAME(Tile);
 void register_tile_class(lua_State* L)
 {
   REG_CLASS(L, Tile);
+  REG_CLASS_NEW(L, Tile);
   REG_CLASS_PROPERTIES(L, Tile);
 }
 
 void push_tile(lua_State* L, const Tileset* ts, tile_index ti)
 {
   push_new<Tile>(L, ts, ti);
+}
+
+Tileset* get_tile_index_from_arg(lua_State* L, int index, tile_index& ti)
+{
+  Tile* tile = get_obj<Tile>(L, index);
+  ti = tile->ti;
+  return static_cast<Tileset*>(get_object(tile->id));
 }
 
 } // namespace script

--- a/src/app/script/tileset_class.cpp
+++ b/src/app/script/tileset_class.cpp
@@ -130,5 +130,10 @@ void push_tileset(lua_State* L, const Tileset* tileset)
   push_docobj(L, tileset);
 }
 
+Tileset* get_tileset_from_arg(lua_State* L, int index)
+{
+  return get_obj<Tileset>(L, index);
+}
+
 } // namespace script
 } // namespace app


### PR DESCRIPTION
New approach according https://github.com/aseprite/aseprite/pull/3665#issuecomment-1377188572

## Sprite:newTile()
```lua
local tile = sprite:newTile(tileset [, tile_index])
```
Inserts an empty tile into the given `tileset` at a given `tile_index`. If `tile_index` is not provided, the new tile is added to the end of the tileset. This method generates undo information, so you could use it as an individual operation or in a [transaction](https://github.com/aseprite/api/blob/main/api/app.md#apptransaction).

## Sprite:deleteTile()
```lua
Sprite:deleteTile(tile)
```
Removes a tile from a tileset. This method generates undo information, so you could use it as an individual operation or in a [transaction](https://github.com/aseprite/api/blob/main/api/app.md#apptransaction).

## Tile()
```lua
local tile = Tile(tileset, tile_index)
```
A tile object just holds an index and a reference to a tileset.

fix aseprite/aseprite#3663