### PR TITLE
Fix vector serialization and reduce size of integer types

### DIFF
--- a/docs/ase-file-specs.md
+++ b/docs/ase-file-specs.md
@@ -413,9 +413,16 @@ there is an User Data Chunk at the first frame after the Palette Chunk.
             RECT
           + If type==0x0011 (vector)
             DWORD     Number of elements
-            WORD      Element's type
-            BYTE[]    As many values as the number of elements indicates
-                      Structure depends on the element's type
+            WORD      Element's type.
+            + If Element's type == 0 (all elements are not of the same type)
+              For each element:
+                WORD      Element's type
+                BYTE[]    Element's value. Structure depends on the
+                          element's type
+            + Else (all elements are of the same type)
+              For each element:
+                BYTE[]    Element's value. Structure depends on the
+                          element's type
           + If type==0x0012 (nested properties map)
             DWORD     Number of properties
             BYTE[]    Nested properties data

--- a/src/app/file/ase_format.cpp
+++ b/src/app/file/ase_format.cpp
@@ -1494,10 +1494,14 @@ static void ase_file_write_property_value(FILE* f,
     case USER_DATA_PROPERTY_TYPE_VECTOR: {
       auto& v = *std::get_if<UserData::Vector>(&value);
       fputl(v.size(), f);
-      const uint16_t type = (v.empty() ? 0 : v.front().type());
+      const uint16_t type = doc::all_elements_of_same_type(v);
       fputw(type, f);
       for (const auto& elem : v) {
-        ASSERT(type == elem.type()); // Check that all elements have the same type
+        // Check that all elements have the same type when mode == 0. Or just that mode == 1
+        ASSERT(type != 0 && type == elem.type() || type == 0);
+        if (type == 0) {
+          fputw(elem.type(), f);
+        }
         ase_file_write_property_value(f, elem);
       }
       break;

--- a/src/app/file/file_tests.cpp
+++ b/src/app/file/file_tests.cpp
@@ -226,7 +226,7 @@ TEST(File, CustomProperties)
                   }));
 
         ASSERT_EQ(doc::get_value<doc::UserData::Vector>(sprite->userData().properties("ext")["numbers"]),
-                  (doc::UserData::Vector {int32_t(11), int32_t(22), int32_t(33)}));
+                  (doc::UserData::Vector {int8_t(11), int8_t(22), int8_t(33)}));
 
         ASSERT_EQ(doc::get_value<doc::UserData::Properties>(sprite->userData().properties("ext")["player"]),
                   (doc::UserData::Properties {
@@ -234,6 +234,46 @@ TEST(File, CustomProperties)
                     {"coordinates", gfx::Point(45, 56)},
                     {"cards", doc::UserData::Vector {int8_t(11), int8_t(6), int8_t(0), int8_t(13)}}
                   }));
+      }
+    },
+    { // Test size reduction of integer properties
+      "test_props_4.ase", 50, 50, doc::ColorMode::INDEXED, 256,
+      {
+        {"", {
+               {"int16_to_int8", int16_t(127)},
+               {"int16_to_uint8", int16_t(128)},
+               {"int32_to_int8", int32_t(126)},
+               {"int32_to_uint8", int32_t(129)},
+               {"int32_to_int16", int32_t(32767)},
+               {"int32_to_uint16", int32_t(32768)},
+               {"int64_to_int8", int64_t(125)},
+               {"int64_to_uint8", int64_t(130)},
+               {"int64_to_int16", int64_t(32765)},
+               {"int64_to_uint16", int64_t(32769)},
+               {"int64_to_int32", int64_t(2147483647)},
+               {"int64_to_uint32", int64_t(2147483648)},
+               {"v1", doc::UserData::Vector {uint64_t(18446744073709551615ULL), uint64_t(6), uint64_t(0), uint64_t(13)}},
+             }
+        }
+      },
+      [](const TestCase& test, doc::Sprite* sprite){
+        sprite->userData().propertiesMaps() = test.propertiesMaps;
+      },
+      [](const TestCase& test, doc::Sprite* sprite){
+        ASSERT_EQ(doc::get_value<int8_t>(sprite->userData().properties()["int16_to_int8"]), 127);
+        ASSERT_EQ(doc::get_value<uint8_t>(sprite->userData().properties()["int16_to_uint8"]), 128);
+        ASSERT_EQ(doc::get_value<int8_t>(sprite->userData().properties()["int32_to_int8"]), 126);
+        ASSERT_EQ(doc::get_value<uint8_t>(sprite->userData().properties()["int32_to_uint8"]), 129);
+        ASSERT_EQ(doc::get_value<int16_t>(sprite->userData().properties()["int32_to_int16"]), 32767);
+        ASSERT_EQ(doc::get_value<uint16_t>(sprite->userData().properties()["int32_to_uint16"]), 32768);
+        ASSERT_EQ(doc::get_value<int8_t>(sprite->userData().properties()["int64_to_int8"]), 125);
+        ASSERT_EQ(doc::get_value<uint8_t>(sprite->userData().properties()["int64_to_uint8"]), 130);
+        ASSERT_EQ(doc::get_value<int16_t>(sprite->userData().properties()["int64_to_int16"]), 32765);
+        ASSERT_EQ(doc::get_value<uint16_t>(sprite->userData().properties()["int64_to_uint16"]), 32769);
+        ASSERT_EQ(doc::get_value<int32_t>(sprite->userData().properties()["int64_to_int32"]), 2147483647);
+        ASSERT_EQ(doc::get_value<uint32_t>(sprite->userData().properties()["int64_to_uint32"]), 2147483648);
+        ASSERT_EQ(doc::get_value<doc::UserData::Vector>(sprite->userData().properties()["v1"]),
+                  (doc::UserData::Vector {uint64_t(18446744073709551615ULL), uint64_t(6), uint64_t(0), uint64_t(13)}));
       }
     }
   };

--- a/src/app/script/values.cpp
+++ b/src/app/script/values.cpp
@@ -413,8 +413,6 @@ doc::UserData::Variant get_value_from_lua(lua_State* L, int index)
       lua_pushnil(L);
       while (lua_next(L, index) != 0) {
         if (lua_isinteger(L, -2)) {
-          // TODO we should check that all values are of the same type
-          //      to create the vector
           if (++i != lua_tointeger(L, -2)) {
             isArray = false;
             lua_pop(L, 2);  // Pop value and key
@@ -509,7 +507,6 @@ doc::UserData::Vector get_value_from_lua(lua_State* L, int index)
     --index;
   lua_pushnil(L);
   while (lua_next(L, index) != 0) {
-    // TODO we should check that all variants are of the same type
     v.push_back(get_value_from_lua<doc::UserData::Variant>(L, -1));
     lua_pop(L, 1);
   }

--- a/src/dio/aseprite_decoder.cpp
+++ b/src/dio/aseprite_decoder.cpp
@@ -1342,9 +1342,13 @@ const doc::UserData::Variant AsepriteDecoder::readPropertyValue(uint16_t type)
     case USER_DATA_PROPERTY_TYPE_VECTOR: {
       auto numElems = read32();
       auto elemsType = read16();
+      auto elemType = elemsType;
       std::vector<doc::UserData::Variant> value;
       for (int k=0; k<numElems;++k) {
-        value.push_back(readPropertyValue(elemsType));
+        if (elemsType == 0) {
+          elemType = read16();
+        }
+        value.push_back(readPropertyValue(elemType));
       }
       return value;
     }

--- a/src/doc/user_data.h
+++ b/src/doc/user_data.h
@@ -42,6 +42,15 @@
 #define USER_DATA_PROPERTY_TYPE_VECTOR      0x0011
 #define USER_DATA_PROPERTY_TYPE_PROPERTIES  0x0012
 
+#define INT8_COMPATIBLE(i)   i >= -128        && i <= 127
+#define UINT8_COMPATIBLE(i)  i >= 128         && i <= 255
+#define INT16_COMPATIBLE(i)  i >= -32768      && i <= 32767
+#define UINT16_COMPATIBLE(i) i >= 32768       && i <= 65535
+#define INT32_COMPATIBLE(i)  i >= -2147483648 && i <= 2147483647
+#define UINT32_COMPATIBLE(i) i >= 2147483648  && i <= 4294967295
+
+#define IS_REDUCIBLE_INT(variantType) variantType >= USER_DATA_PROPERTY_TYPE_INT16 && variantType <= USER_DATA_PROPERTY_TYPE_UINT64
+
 namespace doc {
 
   class UserData {
@@ -151,7 +160,11 @@ namespace doc {
 
   // If all the vector elements are of the same type returns such type.
   // Otherwise it returns -1.
-  int all_elements_of_same_type(const UserData::Vector& vector);
+  uint16_t all_elements_of_same_type(const UserData::Vector& vector);
+
+  UserData::Variant reduce_int_type_size(const UserData::Variant& value);
+
+  UserData::Variant cast_to_smaller_int_type(const UserData::Variant& value, uint16_t type);
 
 } // namespace doc
 

--- a/src/doc/user_data.h
+++ b/src/doc/user_data.h
@@ -149,6 +149,10 @@ namespace doc {
 
   size_t count_nonempty_properties_maps(const UserData::PropertiesMaps& propertiesMaps);
 
+  // If all the vector elements are of the same type returns such type.
+  // Otherwise it returns -1.
+  int all_elements_of_same_type(const UserData::Vector& vector);
+
 } // namespace doc
 
 #endif

--- a/src/doc/user_data.h
+++ b/src/doc/user_data.h
@@ -42,12 +42,14 @@
 #define USER_DATA_PROPERTY_TYPE_VECTOR      0x0011
 #define USER_DATA_PROPERTY_TYPE_PROPERTIES  0x0012
 
-#define INT8_COMPATIBLE(i)   i >= -128        && i <= 127
-#define UINT8_COMPATIBLE(i)  i >= 128         && i <= 255
-#define INT16_COMPATIBLE(i)  i >= -32768      && i <= 32767
-#define UINT16_COMPATIBLE(i) i >= 32768       && i <= 65535
-#define INT32_COMPATIBLE(i)  i >= -2147483648 && i <= 2147483647
-#define UINT32_COMPATIBLE(i) i >= 2147483648  && i <= 4294967295
+#define INT8_COMPATIBLE(i)   i >= -128               && i <= 127
+#define UINT8_COMPATIBLE(i)  i >= 128                && i <= 255
+#define INT16_COMPATIBLE(i)  i >= -32768             && i <= 32767
+#define UINT16_COMPATIBLE(i) i >= 32768              && i <= 65535
+// The (int) cast is to make MSVC happy. If we remove it, the condition could
+// be jumped.
+#define INT32_COMPATIBLE(i)  i >= ((int)-2147483648) && i <= 2147483647
+#define UINT32_COMPATIBLE(i) i >= 2147483648         && i <= 4294967295
 
 #define IS_REDUCIBLE_INT(variantType) variantType >= USER_DATA_PROPERTY_TYPE_INT16 && variantType <= USER_DATA_PROPERTY_TYPE_UINT64
 

--- a/src/doc/user_data_io.cpp
+++ b/src/doc/user_data_io.cpp
@@ -47,7 +47,8 @@ UserData read_user_data(std::istream& is)
   return userData;
 }
 
-size_t count_nonempty_properties_maps(const UserData::PropertiesMaps& propertiesMaps) {
+size_t count_nonempty_properties_maps(const UserData::PropertiesMaps& propertiesMaps)
+{
   size_t i = 0;
   for (const auto& it : propertiesMaps)
     if (!it.second.empty())
@@ -55,15 +56,203 @@ size_t count_nonempty_properties_maps(const UserData::PropertiesMaps& properties
   return i;
 }
 
+bool is_negative(const UserData::Variant& value)
+{
+  switch (value.type()) {
+    case USER_DATA_PROPERTY_TYPE_INT8: {
+      auto v = get_value<int8_t>(value);
+      return v < 0;
+    }
+    case USER_DATA_PROPERTY_TYPE_INT16: {
+      auto v = get_value<int16_t>(value);
+      return v < 0;
+    }
+    case USER_DATA_PROPERTY_TYPE_INT32: {
+      auto v = get_value<int32_t>(value);
+      return v < 0;
+    }
+    case USER_DATA_PROPERTY_TYPE_INT64: {
+      auto v = get_value<int64_t>(value);
+      return v < 0;
+    }
+  }
+  return false;
+}
 
-int all_elements_of_same_type(const UserData::Vector& vector) {
-  int type = vector.empty() ? 0 : vector.front().type();
+
+// If all the elements of vector have the same type, returns that type, also
+// if this type is an integer, it tries to reduce it to the minimum int type
+// capable of storing all the vector values.
+// If all the elements of vector doesn't have the same type, returns 0.
+uint16_t all_elements_of_same_type(const UserData::Vector& vector)
+{
+  uint16_t type = vector.empty() ? 0 : vector.front().type();
+  uint16_t commonReducedType = 0;
+  bool hasNegativeNumbers = false;
   for (auto value : vector) {
     if (type != value.type()) {
       return 0;
     }
+    else if (IS_REDUCIBLE_INT(value.type())) {
+      auto t = reduce_int_type_size(value).type();
+      hasNegativeNumbers |= is_negative(value);
+      if (t > commonReducedType) {
+        commonReducedType = t;
+      }
+    }
   }
-  return type;
+
+  // TODO: The following check probably is not useful right now, I believe this could
+  // become useful if at some point we want to try to find a common integer type for vectors
+  // that contains elements of different integer types only.
+
+  // If our common reduced type is unsigned and we have negative numbers
+  // in our vector we should select the next signed type that includes it.
+  if (commonReducedType != 0 &&
+      (commonReducedType & 1) &&
+      hasNegativeNumbers) {
+    commonReducedType++;
+    // We couldn't find one type that satisfies all the integers. This shouldn't ever happen.
+    if (commonReducedType >= USER_DATA_PROPERTY_TYPE_UINT64) commonReducedType = 0;
+  }
+
+  return commonReducedType ? commonReducedType : type;
+}
+
+UserData::Variant cast_to_smaller_int_type(const UserData::Variant& value, uint16_t type)
+{
+  ASSERT(type < value.type());
+  switch (value.type()) {
+    case USER_DATA_PROPERTY_TYPE_INT16: {
+      auto v = get_value<int16_t>(value);
+      if (type == USER_DATA_PROPERTY_TYPE_INT8)
+        return static_cast<int8_t>(v);
+      else if (type == USER_DATA_PROPERTY_TYPE_UINT8)
+        return static_cast<uint8_t>(v);
+      break;
+    }
+    case USER_DATA_PROPERTY_TYPE_UINT16: {
+      auto v = get_value<uint16_t>(value);
+      if (type == USER_DATA_PROPERTY_TYPE_INT8)
+        return static_cast<int8_t>(v);
+      else if (type == USER_DATA_PROPERTY_TYPE_UINT8)
+        return static_cast<uint8_t>(v);
+      break;
+    }
+    case USER_DATA_PROPERTY_TYPE_INT32: {
+      auto v = get_value<int32_t>(value);
+      if (type == USER_DATA_PROPERTY_TYPE_INT8)
+        return static_cast<int8_t>(v);
+      else if (type == USER_DATA_PROPERTY_TYPE_UINT8)
+        return static_cast<uint8_t>(v);
+      else if (type == USER_DATA_PROPERTY_TYPE_INT16)
+        return static_cast<int16_t>(v);
+      else if (type == USER_DATA_PROPERTY_TYPE_UINT16)
+        return static_cast<uint16_t>(v);
+      break;
+    }
+    case USER_DATA_PROPERTY_TYPE_UINT32: {
+      auto v = get_value<uint32_t>(value);
+      if (type == USER_DATA_PROPERTY_TYPE_INT8)
+        return static_cast<int8_t>(v);
+      else if (type == USER_DATA_PROPERTY_TYPE_UINT8)
+        return static_cast<uint8_t>(v);
+      else if (type == USER_DATA_PROPERTY_TYPE_INT16)
+        return static_cast<int16_t>(v);
+      else if (type == USER_DATA_PROPERTY_TYPE_UINT16)
+        return static_cast<uint16_t>(v);
+      break;
+    }
+    case USER_DATA_PROPERTY_TYPE_INT64: {
+      auto v = get_value<int64_t>(value);
+      if (type == USER_DATA_PROPERTY_TYPE_INT8)
+        return static_cast<int8_t>(v);
+      else if (type == USER_DATA_PROPERTY_TYPE_UINT8)
+        return static_cast<uint8_t>(v);
+      else if (type == USER_DATA_PROPERTY_TYPE_INT16)
+        return static_cast<int16_t>(v);
+      else if (type == USER_DATA_PROPERTY_TYPE_UINT16)
+        return static_cast<uint16_t>(v);
+      else if (type == USER_DATA_PROPERTY_TYPE_INT32)
+        return static_cast<int32_t>(v);
+      else if (type == USER_DATA_PROPERTY_TYPE_UINT32)
+        return static_cast<uint32_t>(v);
+      break;
+    }
+    case USER_DATA_PROPERTY_TYPE_UINT64: {
+      auto v = get_value<uint64_t>(value);
+      if (type == USER_DATA_PROPERTY_TYPE_INT8)
+        return static_cast<int8_t>(v);
+      else if (type == USER_DATA_PROPERTY_TYPE_UINT8)
+        return static_cast<uint8_t>(v);
+      else if (type == USER_DATA_PROPERTY_TYPE_INT16)
+        return static_cast<int16_t>(v);
+      else if (type == USER_DATA_PROPERTY_TYPE_UINT16)
+        return static_cast<uint16_t>(v);
+      else if (type == USER_DATA_PROPERTY_TYPE_INT32)
+        return static_cast<int32_t>(v);
+      else if (type == USER_DATA_PROPERTY_TYPE_UINT32)
+        return static_cast<uint32_t>(v);
+      break;
+    }
+  }
+  return value;
+}
+
+UserData::Variant reduce_int_type_size(const UserData::Variant& value)
+{
+  switch (value.type()) {
+    case USER_DATA_PROPERTY_TYPE_INT16: {
+      auto v = get_value<int16_t>(value);
+      if (INT8_COMPATIBLE(v)) return static_cast<int8_t>(v);
+      else if (UINT8_COMPATIBLE(v)) return static_cast<uint8_t>(v);
+      return v;
+    }
+    case USER_DATA_PROPERTY_TYPE_UINT16: {
+      auto v = get_value<uint16_t>(value);
+      if (INT8_COMPATIBLE(v)) return static_cast<int8_t>(v);
+      else if (UINT8_COMPATIBLE(v)) return static_cast<uint8_t>(v);
+      return v;
+    }
+    case USER_DATA_PROPERTY_TYPE_INT32: {
+      auto v = get_value<int32_t>(value);
+      if (INT8_COMPATIBLE(v)) return static_cast<int8_t>(v);
+      else if (UINT8_COMPATIBLE(v)) return static_cast<uint8_t>(v);
+      else if (INT16_COMPATIBLE(v)) return static_cast<int16_t>(v);
+      else if (UINT16_COMPATIBLE(v)) return static_cast<uint16_t>(v);
+      return v;
+    }
+    case USER_DATA_PROPERTY_TYPE_UINT32: {
+      auto v = get_value<uint32_t>(value);
+      if (INT8_COMPATIBLE(v)) return static_cast<int8_t>(v);
+      else if (UINT8_COMPATIBLE(v)) return static_cast<uint8_t>(v);
+      else if (INT16_COMPATIBLE(v)) return static_cast<int16_t>(v);
+      else if (UINT16_COMPATIBLE(v)) return static_cast<uint16_t>(v);
+      return v;
+    }
+    case USER_DATA_PROPERTY_TYPE_INT64: {
+      auto v = get_value<int64_t>(value);
+      if (INT8_COMPATIBLE(v)) return static_cast<int8_t>(v);
+      else if (UINT8_COMPATIBLE(v)) return static_cast<uint8_t>(v);
+      else if (INT16_COMPATIBLE(v)) return static_cast<int16_t>(v);
+      else if (UINT16_COMPATIBLE(v)) return static_cast<uint16_t>(v);
+      else if (INT32_COMPATIBLE(v)) return static_cast<int32_t>(v);
+      else if (UINT32_COMPATIBLE(v)) return static_cast<uint32_t>(v);
+      return v;
+    }
+    case USER_DATA_PROPERTY_TYPE_UINT64: {
+      auto v = get_value<uint64_t>(value);
+      if (INT8_COMPATIBLE(v)) return static_cast<int8_t>(v);
+      else if (UINT8_COMPATIBLE(v)) return static_cast<uint8_t>(v);
+      else if (INT16_COMPATIBLE(v)) return static_cast<int16_t>(v);
+      else if (UINT16_COMPATIBLE(v)) return static_cast<uint16_t>(v);
+      else if (INT32_COMPATIBLE(v)) return static_cast<int32_t>(v);
+      else if (UINT32_COMPATIBLE(v)) return static_cast<uint32_t>(v);
+      return v;
+    }
+    default:
+      return value;
+  }
 }
 
 void write_point(std::ostream& os, const gfx::Point& point)

--- a/src/doc/user_data_io.cpp
+++ b/src/doc/user_data_io.cpp
@@ -55,6 +55,17 @@ size_t count_nonempty_properties_maps(const UserData::PropertiesMaps& properties
   return i;
 }
 
+
+int all_elements_of_same_type(const UserData::Vector& vector) {
+  int type = vector.empty() ? 0 : vector.front().type();
+  for (auto value : vector) {
+    if (type != value.type()) {
+      return 0;
+    }
+  }
+  return type;
+}
+
 void write_point(std::ostream& os, const gfx::Point& point)
 {
   write32(os, point.x);
@@ -125,9 +136,8 @@ void write_property_value(std::ostream& os, const UserData::Variant& variant)
     case USER_DATA_PROPERTY_TYPE_VECTOR: {
         const std::vector<UserData::Variant>& vector = get_value<std::vector<UserData::Variant>>(variant);
         write32(os, vector.size());
-        const uint16_t type = vector.size() == 0 ? 0 : vector.front().type();
-        write16(os, type);
         for (auto elem : vector) {
+          write16(os, elem.type());
           write_property_value(os, elem);
         }
       break;
@@ -237,10 +247,10 @@ UserData::Variant read_property_value(std::istream& is, uint16_t type)
     }
     case USER_DATA_PROPERTY_TYPE_VECTOR: {
       auto numElems = read32(is);
-      auto elemsType = read16(is);
       std::vector<doc::UserData::Variant> value;
       for (int k=0; k<numElems;++k) {
-        value.push_back(read_property_value(is, elemsType));
+        auto elemType = read16(is);
+        value.push_back(read_property_value(is, elemType));
       }
       return value;
     }

--- a/tests/scripts/userdata_codec.lua
+++ b/tests/scripts/userdata_codec.lua
@@ -119,3 +119,23 @@ do
   assert(#spr.layers[2].properties("ext") == 1)
   assert(spr.layers[2].properties("ext").b == 32)
 end
+
+-- Test save vector with different types inside
+do
+  local spr = Sprite(32, 32)
+  spr.properties.a = { 3, "hi", {4, 5, 6}, {a="bye", b=10} }
+
+  spr:saveAs("_test_userdata_codec_3.aseprite")
+  spr:close()
+
+  spr = Sprite{ fromFile="_test_userdata_codec_3.aseprite" }
+  assert(#spr.properties.a == 4)
+  assert(spr.properties.a[1] == 3)
+  assert(spr.properties.a[2] == "hi")
+  assert(#spr.properties.a[3] == 3)
+  assert(spr.properties.a[3][1] == 4)
+  assert(spr.properties.a[3][2] == 5)
+  assert(spr.properties.a[3][3] == 6)
+  assert(spr.properties.a[4].a == "bye")
+  assert(spr.properties.a[4].b == 10)
+end


### PR DESCRIPTION
- [x] Fixes vector serialization to support elements of differents types all mixed in the same collection of elements. For this I have introduced two modes vector serialization:
  - Elems type == actual type. Used when all the elements have the same type. This stores the element's type only once.
  - Elems type == 0: Used when all the types don't have the same type. This stores the type for each element.
- [x] Reduces the size of the integers stored in .aseprite files as much as possible.

Fix #3677  