### PR TITLE
Fix don't create new tiles on tilemap layer in an empty cel with hasTileManagementPlugin.

### DIFF
--- a/src/app/ui/editor/standby_state.cpp
+++ b/src/app/ui/editor/standby_state.cpp
@@ -642,6 +642,11 @@ DrawingState* StandbyState::startDrawingState(
   const DrawingType drawingType,
   const tools::Pointer& pointer)
 {
+  if (editor->layer()->isTilemap() &&
+      editor->sprite()->hasTileManagementPlugin() &&
+      !editor->layer()->cel(editor->frame())) {
+    return nullptr;
+  }
   // We need to clear and redraw the brush boundaries after the
   // first mouse pressed/point shape if drawn. This is to avoid
   // graphical glitches (invalid areas in the ToolLoop's src/dst


### PR DESCRIPTION
Related with https://github.com/aseprite/Attachment-System/issues/62

The implementation of 'hasTileManagementPlugin' implies that tile creation will rely entirely on the external plugin, so the possibility of automatic tile creation in such conditions was removed.