### PR TITLE
Fix crash on undo command after creating new tilemap layer with custom properties added via plugin.

### DIFF
--- a/src/app/cmd/set_user_data_properties.cpp
+++ b/src/app/cmd/set_user_data_properties.cpp
@@ -28,16 +28,18 @@ SetUserDataProperties::SetUserDataProperties(
 
 void SetUserDataProperties::onExecute()
 {
-  auto obj = doc::get<doc::WithUserData>(m_objId);
-  obj->userData().properties(m_group) = m_newProperties;
-  obj->incrementVersion();
+  if (auto obj = doc::get<doc::WithUserData>(m_objId)) {
+    obj->userData().properties(m_group) = m_newProperties;
+    obj->incrementVersion();
+  }
 }
 
 void SetUserDataProperties::onUndo()
 {
-  auto obj = doc::get<doc::WithUserData>(m_objId);
-  obj->userData().properties(m_group) = m_oldProperties;
-  obj->incrementVersion();
+  if (auto obj = doc::get<doc::WithUserData>(m_objId)) {
+    obj->userData().properties(m_group) = m_oldProperties;
+    obj->incrementVersion();
+  }
 }
 
 } // namespace cmd

--- a/src/app/cmd/set_user_data_property.cpp
+++ b/src/app/cmd/set_user_data_property.cpp
@@ -30,36 +30,38 @@ SetUserDataProperty::SetUserDataProperty(
 
 void SetUserDataProperty::onExecute()
 {
-  auto obj = doc::get<doc::WithUserData>(m_objId);
-  auto& properties = obj->userData().properties(m_group);
+  if (auto obj = doc::get<doc::WithUserData>(m_objId)) {
+    auto& properties = obj->userData().properties(m_group);
 
-  if (m_newValue.type() == USER_DATA_PROPERTY_TYPE_NULLPTR) {
-    auto it = properties.find(m_field);
-    if (it != properties.end())
-      properties.erase(it);
-  }
-  else {
-    properties[m_field] = m_newValue;
-  }
+    if (m_newValue.type() == USER_DATA_PROPERTY_TYPE_NULLPTR) {
+      auto it = properties.find(m_field);
+      if (it != properties.end())
+        properties.erase(it);
+    }
+    else {
+      properties[m_field] = m_newValue;
+    }
 
-  obj->incrementVersion();
+    obj->incrementVersion();
+  }
 }
 
 void SetUserDataProperty::onUndo()
 {
-  auto obj = doc::get<doc::WithUserData>(m_objId);
-  auto& properties = obj->userData().properties(m_group);
+  if (auto obj = doc::get<doc::WithUserData>(m_objId)) {
+    auto& properties = obj->userData().properties(m_group);
 
-  if (m_oldValue.type() == USER_DATA_PROPERTY_TYPE_NULLPTR) {
-    auto it = properties.find(m_field);
-    if (it != properties.end())
-      properties.erase(it);
-  }
-  else {
-    properties[m_field] = m_oldValue;
-  }
+    if (m_oldValue.type() == USER_DATA_PROPERTY_TYPE_NULLPTR) {
+      auto it = properties.find(m_field);
+      if (it != properties.end())
+        properties.erase(it);
+    }
+    else {
+      properties[m_field] = m_oldValue;
+    }
 
-  obj->incrementVersion();
+    obj->incrementVersion();
+  }
 }
 
 } // namespace cmd


### PR DESCRIPTION
There may be something deeper to this, for now this solution avoids a major crash when it comes to plugin custom properties.