### PR TITLE
Theme's fixes

### DIFF
--- a/data/extensions/aseprite-theme/dark/theme.xml
+++ b/data/extensions/aseprite-theme/dark/theme.xml
@@ -625,6 +625,10 @@
             <text color="button_selected_text" state="selected" />
         </style>
         <style id="mini_check_box" extends="check_box" font="mini" />
+        <style id="combobox">
+            <background-border part="sunken2_focused" state="focus" />
+            <background-border part="sunken2_normal" />
+        </style>
         <style id="combobox_button" extends="mini_button" padding="0">
             <icon part="combobox_arrow_down" />
             <icon part="combobox_arrow_down_selected" state="selected" />
@@ -675,7 +679,7 @@
             <icon part="pal_options" />
         </style>
         <style id="new_frame_button" extends="mini_button" />
-        <style id="color_button" extends="mini_button" border="5" font="mini" />
+        <style id="color_button" extends="mini_button" font="mini" padding-bottom="1" />
         <style id="splitter">
             <background color="face" />
         </style>

--- a/data/extensions/aseprite-theme/theme.xml
+++ b/data/extensions/aseprite-theme/theme.xml
@@ -618,6 +618,10 @@
             <text color="button_selected_text" state="selected" />
         </style>
         <style id="mini_check_box" extends="check_box" font="mini" />
+        <style id="combobox">
+            <background-border part="sunken2_focused" state="focus" />
+            <background-border part="sunken2_normal" />
+        </style>
         <style id="combobox_button" extends="mini_button" padding="0">
             <icon part="combobox_arrow_down" />
             <icon part="combobox_arrow_down_selected" state="selected" />

--- a/data/extensions/aseprite-theme/theme.xml
+++ b/data/extensions/aseprite-theme/theme.xml
@@ -668,7 +668,7 @@
             <icon part="pal_options" />
         </style>
         <style id="new_frame_button" extends="mini_button" />
-        <style id="color_button" extends="mini_button" border="5" font="mini" />
+        <style id="color_button" extends="mini_button" font="mini" padding-bottom="1" />
         <style id="splitter">
             <background color="face" />
         </style>

--- a/src/app/ui/skin/skin_theme.cpp
+++ b/src/app/ui/skin/skin_theme.cpp
@@ -1505,15 +1505,9 @@ void SkinTheme::paintComboBoxEntry(ui::PaintEvent& ev)
   Graphics* g = ev.graphics();
   Entry* widget = static_cast<Entry*>(ev.getSource());
   gfx::Rect bounds = widget->clientBounds();
+  ui::Style* style = styles.combobox();
 
-  // Outside borders
-  g->fillRect(BGCOLOR, bounds);
-
-  drawRect(g, bounds,
-           (widget->hasFocus() ?
-            parts.sunken2Focused().get():
-            parts.sunken2Normal().get()));
-
+  paintWidget(g, widget, style, bounds);
   drawEntryText(g, widget);
 }
 

--- a/src/app/ui/toolbar.cpp
+++ b/src/app/ui/toolbar.cpp
@@ -323,8 +323,8 @@ void ToolBar::onPaint(ui::PaintEvent& ev)
     os::Surface* icon = theme->getToolIcon(tool->getId().c_str());
     if (icon) {
       g->drawRgbaSurface(icon,
-        toolrc.x+toolrc.w/2-icon->width()/2,
-        toolrc.y+toolrc.h/2-icon->height()/2);
+        CALC_FOR_CENTER(toolrc.x, toolrc.w, icon->width()),
+        CALC_FOR_CENTER(toolrc.y, toolrc.h, icon->height()));
     }
   }
 
@@ -342,8 +342,8 @@ void ToolBar::onPaint(ui::PaintEvent& ev)
   os::Surface* icon = theme->getToolIcon("minieditor");
   if (icon) {
     g->drawRgbaSurface(icon,
-      toolrc.x+toolrc.w/2-icon->width()/2,
-      toolrc.y+toolrc.h/2-icon->height()/2);
+      CALC_FOR_CENTER(toolrc.x, toolrc.w, icon->width()),
+      CALC_FOR_CENTER(toolrc.y, toolrc.h, icon->height()));
   }
 }
 
@@ -415,7 +415,7 @@ void ToolBar::openPopupWindow(int group_index, ToolGroup* tool_group)
 
   for (Tool* tool : *toolbox) {
     if (tool->getGroup() == tool_group)
-      w += bounds().w-border().width()-1;
+      w += bounds().w-border().width()-1*guiscale();
   }
 
   rc.x -= w;
@@ -722,8 +722,8 @@ void ToolBar::ToolStrip::onPaint(PaintEvent& ev)
       if (icon) {
         g->drawRgbaSurface(
           icon,
-          toolrc.x+toolrc.w/2-icon->width()/2,
-          toolrc.y+toolrc.h/2-icon->height()/2);
+          CALC_FOR_CENTER(toolrc.x, toolrc.w, icon->width()),
+          CALC_FOR_CENTER(toolrc.y, toolrc.h, icon->height()));
       }
     }
   }
@@ -734,7 +734,7 @@ Rect ToolBar::ToolStrip::getToolBounds(int index)
   const Rect& bounds(this->bounds());
   Size iconsize = getToolIconSize(this);
 
-  return Rect(bounds.x+index*(iconsize.w-1), bounds.y,
+  return Rect(bounds.x+index*(iconsize.w-1*guiscale()), bounds.y,
               iconsize.w, bounds.h);
 }
 

--- a/src/ui/entry.cpp
+++ b/src/ui/entry.cpp
@@ -545,7 +545,7 @@ gfx::Rect Entry::onGetEntryTextBounds() const
 {
   gfx::Rect bounds = clientBounds();
   bounds.x += border().left();
-  bounds.y += bounds.h/2 - textHeight()/2;
+  bounds.y += CALC_FOR_CENTER(0, bounds.h, textHeight());
   bounds.w -= border().width();
   bounds.h = textHeight();
   return bounds;

--- a/src/ui/theme.cpp
+++ b/src/ui/theme.cpp
@@ -462,8 +462,7 @@ void Theme::paintLayer(Graphics* g,
           else if (layer.align() & RIGHT)
             pt.x = rc.x+rc.w-textSize.w-padding.right();
           else {
-            pt.x = rc.x+padding.left()+(rc.w-padding.width())/2-textSize.w/2;
-            ADJUST_TO_GUISCALE(pt.x);
+            pt.x = CALC_FOR_CENTER(rc.x+padding.left(), rc.w-padding.width(), textSize.w);
           }
 
           if (layer.align() & TOP)
@@ -471,8 +470,7 @@ void Theme::paintLayer(Graphics* g,
           else if (layer.align() & BOTTOM)
             pt.y = rc.y+rc.h-textSize.h-padding.bottom();
           else {
-            pt.y = rc.y+padding.top()+(rc.h-padding.height())/2-textSize.h/2;
-            ADJUST_TO_GUISCALE(pt.y);
+            pt.y = CALC_FOR_CENTER(rc.y+padding.top(), rc.h-padding.height(), textSize.h);
           }
 
           pt += layer.offset();
@@ -505,8 +503,7 @@ void Theme::paintLayer(Graphics* g,
         else if (layer.align() & RIGHT)
           pt.x = rc.x+rc.w-iconSize.w-padding.right();
         else {
-          pt.x = rc.x+padding.left()+(rc.w-padding.width())/2-iconSize.w/2;
-          ADJUST_TO_GUISCALE(pt.x);
+          pt.x = CALC_FOR_CENTER(rc.x+padding.left(), rc.w-padding.width(), iconSize.w);
         }
 
         if (layer.align() & TOP)
@@ -514,8 +511,7 @@ void Theme::paintLayer(Graphics* g,
         else if (layer.align() & BOTTOM)
           pt.y = rc.y+rc.h-iconSize.h-padding.bottom();
         else {
-          pt.y = rc.y+padding.top()+(rc.h-padding.height())/2-iconSize.h/2;
-          ADJUST_TO_GUISCALE(pt.y);
+          pt.y = CALC_FOR_CENTER(rc.y+padding.top(), rc.h-padding.height(), iconSize.h);
         }
 
         pt += layer.offset();

--- a/src/ui/theme.h
+++ b/src/ui/theme.h
@@ -18,7 +18,7 @@
 #include "ui/style.h"
 #include "ui/scale.h"
 
-#define ADJUST_TO_GUISCALE(v) v -= (v % guiscale());
+#define CALC_FOR_CENTER(p, s1, s2) ((p)/guiscale() + ((s1)/guiscale())/2 - ((s2)/guiscale())/2)*guiscale()
 
 namespace gfx {
   class Region;

--- a/src/ui/widget.cpp
+++ b/src/ui/widget.cpp
@@ -973,10 +973,7 @@ void Widget::getTextIconInfo(
   if (align() & RIGHT)
     box_x = bounds.x2() - box_w - border().right();
   else if (align() & CENTER) {
-    box_x = (bounds.x + bounds.x2() - box_w) / 2;
-    // Adjust position when it is not a multiple of guiscale. Without these adjustements
-    // it could happen that an icon or text is displayed a in a fraction of a scaled pixel.
-    ADJUST_TO_GUISCALE(box_x);
+    box_x = CALC_FOR_CENTER(bounds.x + border().top(), bounds.w - border().width(), box_w);
   }
   else
     box_x = bounds.x + border().left();
@@ -984,9 +981,7 @@ void Widget::getTextIconInfo(
   if (align() & BOTTOM)
     box_y = bounds.y2() - box_h - border().bottom();
   else if (align() & MIDDLE) {
-    box_y = (bounds.y + bounds.y2() - box_h) / 2;
-    // Adjust position when it is not a multiple of guiscale
-    ADJUST_TO_GUISCALE(box_y);
+    box_y = CALC_FOR_CENTER(bounds.y + border().left(), bounds.h - border().height(), box_h);
   }
   else
     box_y = bounds.y + border().top();
@@ -999,11 +994,8 @@ void Widget::getTextIconInfo(
       icon_x = box_x + box_w - icon_w;
     }
     else if (icon_align & CENTER) {
-      text_x = box_x + (box_w - text_w)/2;
-      icon_x = box_x + (box_w - icon_w)/2;
-      // Adjust position when it is not a multiple of guiscale
-      ADJUST_TO_GUISCALE(text_x);
-      ADJUST_TO_GUISCALE(icon_x);
+      text_x = CALC_FOR_CENTER(box_x, box_w, text_w);
+      icon_x = CALC_FOR_CENTER(box_x, box_w, icon_w);
     }
     else {
       text_x = box_x + box_w - text_w;
@@ -1016,11 +1008,8 @@ void Widget::getTextIconInfo(
       icon_y = box_y + box_h - icon_h;
     }
     else if (icon_align & MIDDLE) {
-      text_y = box_y + (box_h - text_h)/2;
-      icon_y = box_y + (box_h - icon_h)/2;
-      // Adjust position when it is not a multiple of guiscale
-      ADJUST_TO_GUISCALE(text_y);
-      ADJUST_TO_GUISCALE(icon_y);
+      text_y = CALC_FOR_CENTER(box_y, box_h, text_h);
+      icon_y = CALC_FOR_CENTER(box_y, box_h, icon_h);
     }
     else {
       text_y = box_y + box_h - text_h;


### PR DESCRIPTION
Fixes some issues mentioned in #3709 when Screen scaling is 100% and UI Scaling is 200%:
- Layer name text alignment.
- Toolbar buttons icons alignment (including buttons displayed in popup when a tool is clicked).
- Editable combobox text alignment.
- Introduce combobox style.
- Tab's text alignment.
- Frame header text alignment.
- Color button text alignment.