### PR TITLE
Avoid dialog's window relayout during an ongoing resize event (fix #3747)

### DIFF
--- a/src/app/script/dialog_class.cpp
+++ b/src/app/script/dialog_class.cpp
@@ -470,10 +470,11 @@ int Dialog_add_widget(lua_State* L, Widget* widget)
     // specific widget is not expansive (e.g. a canvas with a fixed
     // size)
     type = lua_getfield(L, 2, "hexpand");
+    if (type != LUA_TNIL) hexpand = lua_toboolean(L, -1);
+    lua_pop(L, 1);
     type = lua_getfield(L, 2, "vexpand");
-    if (type != LUA_TNIL) hexpand = lua_toboolean(L, -2);
     if (type != LUA_TNIL) vexpand = lua_toboolean(L, -1);
-    lua_pop(L, 2);
+    lua_pop(L, 1);
   }
 
   if (label || !dlg->hbox) {

--- a/src/app/script/dialog_class.cpp
+++ b/src/app/script/dialog_class.cpp
@@ -1356,7 +1356,11 @@ int Dialog_modify(lua_State* L)
 
     // TODO shades mode? file title / open / save / filetypes? on* events?
 
-    if (relayout) {
+    // Relayout only if the the dialog window is not being resized.
+    // This is due to the possibility of a script calling a method
+    // to modify dialog's properties (which might generate a relayout)
+    // during an ongoing resize event.
+    if (relayout && !dlg->window.isResizing()) {
       dlg->window.layout();
 
       gfx::Rect bounds(dlg->window.bounds().w,

--- a/src/ui/window.cpp
+++ b/src/ui/window.cpp
@@ -735,6 +735,8 @@ void Window::onBuildTitleLabel()
 
 void Window::windowSetPosition(const gfx::Rect& rect)
 {
+  m_isResizing = bounds().size() != rect.size();
+
   // Copy the new position rectangle
   setBoundsQuietly(rect);
   Rect cpos = childrenBounds();
@@ -748,6 +750,7 @@ void Window::windowSetPosition(const gfx::Rect& rect)
   }
 
   onWindowResize();
+  m_isResizing = false;
 }
 
 void Window::limitSize(int* w, int* h)

--- a/src/ui/window.h
+++ b/src/ui/window.h
@@ -65,6 +65,7 @@ namespace ui {
     bool isWantFocus() const { return m_isWantFocus; }
     bool isSizeable() const { return m_isSizeable; }
     bool isMoveable() const { return m_isMoveable; }
+    bool isResizing() const { return m_isResizing; }
 
     bool shouldCreateNativeWindow() const {
       return !isDesktop();
@@ -128,6 +129,7 @@ namespace ui {
     bool m_isWantFocus : 1;
     bool m_isForeground : 1;
     bool m_isAutoRemap : 1;
+    bool m_isResizing : 1;
     int m_hitTest;
     gfx::Rect m_lastFrame;
   };


### PR DESCRIPTION
Fix #3747 

Also, the first commit fixes an unrelated issue I saw when looking at the code. It is about how the hexpand and vexpand were being set.