### PR TITLE
[lua] Add blend modes to Image:drawImage()

### DIFF
--- a/src/app/script/blend_mode.h
+++ b/src/app/script/blend_mode.h
@@ -135,6 +135,7 @@ inline app::script::BlendMode convert_to(const os::BlendMode& from) {
 template<>
 inline doc::BlendMode convert_to(const app::script::BlendMode& from) {
   switch (from) {
+    case app::script::BlendMode::SRC:         return doc::BlendMode::SRC;
     case app::script::BlendMode::SRC_OVER:    return doc::BlendMode::NORMAL;
     case app::script::BlendMode::PLUS:        return doc::BlendMode::ADDITION;
     case app::script::BlendMode::MULTIPLY:    return doc::BlendMode::MULTIPLY;
@@ -157,7 +158,6 @@ inline doc::BlendMode convert_to(const app::script::BlendMode& from) {
     case app::script::BlendMode::DIVIDE:      return doc::BlendMode::DIVIDE;
     // Default value
     case app::script::BlendMode::CLEAR:
-    case app::script::BlendMode::SRC:
     case app::script::BlendMode::DST:
     case app::script::BlendMode::DST_OVER:
     case app::script::BlendMode::SRC_IN:
@@ -175,6 +175,7 @@ inline doc::BlendMode convert_to(const app::script::BlendMode& from) {
 template<>
 inline app::script::BlendMode convert_to(const doc::BlendMode& from) {
   switch (from) {
+    case doc::BlendMode::SRC: return app::script::BlendMode::SRC;
     case doc::BlendMode::NORMAL: return app::script::BlendMode::SRC_OVER;
     case doc::BlendMode::MULTIPLY: return app::script::BlendMode::MULTIPLY;
     case doc::BlendMode::SCREEN: return app::script::BlendMode::SCREEN;

--- a/src/app/script/image_class.cpp
+++ b/src/app/script/image_class.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2022  Igara Studio S.A.
+// Copyright (C) 2018-2023  Igara Studio S.A.
 // Copyright (C) 2015-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -15,6 +15,7 @@
 #include "app/context.h"
 #include "app/doc.h"
 #include "app/file/file.h"
+#include "app/script/blend_mode.h"
 #include "app/script/docobj.h"
 #include "app/script/engine.h"
 #include "app/script/luacpp.h"
@@ -40,6 +41,8 @@ namespace app {
 namespace script {
 
 namespace {
+
+static ImageBufferPtr buf; // TODO non-thread safe
 
 struct ImageObj {
   doc::ObjectId imageId = 0;
@@ -247,23 +250,41 @@ int Image_drawImage(lua_State* L)
   auto obj = get_obj<ImageObj>(L, 1);
   auto sprite = get_obj<ImageObj>(L, 2);
   gfx::Point pos = convert_args_into_point(L, 3);
+
+  int opacity = 255;
+  if (lua_isinteger(L, 4))
+    opacity = std::clamp(int(lua_tointeger(L, 4)), 0, 255);
+
+  doc::BlendMode blendMode = doc::BlendMode::NORMAL;
+  if (lua_isinteger(L, 5)) {
+    blendMode = base::convert_to<doc::BlendMode>(
+                  app::script::BlendMode(lua_tointeger(L, 5)));
+  }
+
   Image* dst = obj->image(L);
   const Image* src = sprite->image(L);
 
   // If the destination image is not related to a sprite, we just draw
   // the source image without undo information.
   if (obj->cel(L) == nullptr) {
-    doc::copy_image(dst, src, pos.x, pos.y);
+    doc::blend_image(dst, src,
+                     pos.x, pos.y,
+                     opacity, blendMode);
   }
   else {
     gfx::Rect bounds(0, 0, src->size().w, src->size().h);
-
+    buf.reset(new doc::ImageBuffer);
+    ImageRef tmp_src(
+      doc::crop_image(dst,
+                      gfx::Rect(pos.x, pos.y, src->size().w, src->size().h),
+                      0, buf));
+    doc::blend_image(tmp_src.get(), src, 0, 0, opacity, blendMode);
     // TODO Use something similar to doc::algorithm::shrink_bounds2()
     //      but we need something that does the render and compares
     //      the minimal modified area.
     Tx tx;
     tx(new cmd::CopyRegion(
-         dst, src, gfx::Region(bounds),
+         dst, tmp_src.get(), gfx::Region(bounds),
          gfx::Point(pos.x + bounds.x, pos.y + bounds.y)));
     tx.commit();
   }

--- a/src/doc/primitives.h
+++ b/src/doc/primitives.h
@@ -1,5 +1,5 @@
 // Aseprite Document Library
-// Copyright (c) 2018-2021 Igara Studio S.A.
+// Copyright (c) 2018-2023 Igara Studio S.A.
 // Copyright (c) 2001-2016 David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "base/ints.h"
+#include "doc/blend_mode.h"
 #include "doc/color.h"
 #include "doc/image_buffer.h"
 #include "gfx/fwd.h"
@@ -27,6 +28,8 @@ namespace doc {
 
   void copy_image(Image* dst, const Image* src);
   void copy_image(Image* dst, const Image* src, int x, int y);
+  void blend_image(Image* dst, const Image* src, int x, int y,
+                   const int opacity, const doc::BlendMode blendMode);
   void copy_image(Image* dst, const Image* src, const gfx::Region& rgn);
   Image* crop_image(const Image* image, int x, int y, int w, int h, color_t bg, const ImageBufferPtr& buffer = ImageBufferPtr());
   Image* crop_image(const Image* image, const gfx::Rect& bounds, color_t bg, const ImageBufferPtr& buffer = ImageBufferPtr());

--- a/tests/scripts/compare_sprite_sheets.lua
+++ b/tests/scripts/compare_sprite_sheets.lua
@@ -1,4 +1,4 @@
--- Copyright (C) 2019  Igara Studio S.A.
+-- Copyright (C) 2019-2023  Igara Studio S.A.
 --
 -- This file is released under the terms of the MIT license.
 -- Read LICENSE.txt for more information.
@@ -43,13 +43,13 @@ for k,v in pairs(data1.frames) do
 
   local celImage1 = Image(fr1.frame.w, fr1.frame.h, sheet1.colorMode)
   local celImage2 = Image(fr2.frame.w, fr2.frame.h, sheet2.colorMode)
-  celImage1:drawSprite(sheet1, 1, -fr1.frame.x, -fr1.frame.y)
-  celImage2:drawSprite(sheet2, 1, -fr2.frame.x, -fr2.frame.y)
+  celImage1:drawSprite(sheet1, 1, Point(-fr1.frame.x, -fr1.frame.y))
+  celImage2:drawSprite(sheet2, 1, Point(-fr2.frame.x, -fr2.frame.y))
 
   local frImage1 = Image(fr1.sourceSize.w, fr1.sourceSize.h, sheet1.colorMode)
   local frImage2 = Image(fr2.sourceSize.w, fr2.sourceSize.h, sheet2.colorMode)
-  frImage1:drawImage(celImage1, fr1.spriteSourceSize.x, fr1.spriteSourceSize.y)
-  frImage2:drawImage(celImage2, fr2.spriteSourceSize.x, fr2.spriteSourceSize.y)
+  frImage1:drawImage(celImage1, Point(fr1.spriteSourceSize.x, fr1.spriteSourceSize.y), 255, BlendMode.SRC)
+  frImage2:drawImage(celImage2, Point(fr2.spriteSourceSize.x, fr2.spriteSourceSize.y), 255, BlendMode.SRC)
 
   -- To debug this function
   --frImage1:saveAs(replace_filename(file1, k .. "-fr1.png"))


### PR DESCRIPTION
Also added tests.

This commit includes a default `NORMAL` blend mode (instead `SRC`). `NORMAL` blend mode is more intuitive in image composition.

To get the old `drawImage()` behavior you should add `opacity` and `blend mode` as final arguments of function:
- `Image:drawImage(image) `   -->   `Image:drawImage(image, Point(0, 0), 255, BlendMode.SRC)`
- `Image:drawImage(image, position)` --> `Image:drawImage(image, position, 255, BlendMode.SRC)`