### PR TITLE
Fix regression {slice} format on CLI doesn't work (fix #3801)

### DIFF
--- a/src/app/filename_formatter.cpp
+++ b/src/app/filename_formatter.cpp
@@ -101,6 +101,7 @@ bool is_template_in_filename(const std::string& format)
     "{title}",
     "{extension}",
     "{layer}",
+    "{slice}",
     "{tag}",
     "{innertag}",
     "{outertag}",


### PR DESCRIPTION
Possibly {duration} and {group} have the same problem.

fix #3801