### PR TITLE
Add warning when loading unsupported property type and mark the file as read-only

### DIFF
--- a/data/strings/en.ini
+++ b/data/strings/en.ini
@@ -41,6 +41,7 @@ non_transformable_reference_layer = Layer '{}' is reference, cannot be transform
 sprite_locked_somewhere = The sprite is locked in other editor
 not_enough_transform_memory = Not enough memory to transform the selection
 not_enough_rotsprite_memory = Not enough memory for RotSprite
+unmodifiable_sprite = Read-only sprite cannot be modified
 
 [alerts]
 applying_filter = FX<<Applying effect...||&Cancel
@@ -217,6 +218,17 @@ Information
 <<Activating Aseprite will give you access to automatic updates.
 ||&OK
 END
+load_file_with_incompatibilities = <<<END
+Incompatibility error found:
+
+
+{0}.
+
+
+This file will be opened as read-only. Please upgrade Aseprite to the latest version to be able to save changes without losing data.
+END
+cannot_overwrite_readonly = Cannot save/overwrite a read-only sprite. Use File > Save As option.
+cannot_modify_readonly = Cannot modify a read-only sprite.
 
 [brightness_contrast]
 title = Brightness/Contrast

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -766,6 +766,9 @@ void App::updateDisplayTitleBar()
   if (docView) {
     // Prepend the document's filename.
     title += docView->document()->name();
+    if (docView->document()->isReadOnly()) {
+      title += " [Read-Only]";
+    }
     title += " - ";
   }
 

--- a/src/app/commands/cmd_play_animation.cpp
+++ b/src/app/commands/cmd_play_animation.cpp
@@ -41,7 +41,7 @@ PlayAnimationCommand::PlayAnimationCommand()
 
 bool PlayAnimationCommand::onEnabled(Context* ctx)
 {
-  return ctx->checkFlags(ContextFlags::ActiveDocumentIsWritable |
+  return ctx->checkFlags(ContextFlags::ActiveDocumentIsReadable |
                          ContextFlags::HasActiveSprite);
 }
 

--- a/src/app/context_flags.cpp
+++ b/src/app/context_flags.cpp
@@ -44,7 +44,7 @@ void ContextFlags::update(Context* context)
 
       updateFlagsFromSite(site);
 
-      if (document->canWriteLockFromRead())
+      if (document->canWriteLockFromRead() && !document->isReadOnly())
         m_flags |= ActiveDocumentIsWritable;
 
       document->unlock();

--- a/src/app/doc.cpp
+++ b/src/app/doc.cpp
@@ -332,6 +332,25 @@ bool Doc::isFullyBackedUp() const
   return (m_flags & kFullyBackedUp ? true: false);
 }
 
+void Doc::markAsReadOnly()
+{
+  DOC_TRACE("DOC: Mark as read-only", this);
+
+  m_flags |= kReadOnly;
+}
+
+bool Doc::isReadOnly() const
+{
+  return (m_flags & kReadOnly ? true: false);
+}
+
+void Doc::removeReadOnlyMark()
+{
+  DOC_TRACE("DOC: Read-only mark removed", this);
+
+  m_flags &= ~kReadOnly;
+}
+
 //////////////////////////////////////////////////////////////////////
 // Loaded options from file
 

--- a/src/app/doc.h
+++ b/src/app/doc.h
@@ -12,8 +12,10 @@
 #include "app/doc_observer.h"
 #include "app/extra_cel.h"
 #include "app/file/format_options.h"
+#include "app/i18n/strings.h"
 #include "app/transformation.h"
 #include "base/disable_copying.h"
+#include "base/exception.h"
 #include "base/rw_lock.h"
 #include "doc/blend_mode.h"
 #include "doc/color.h"
@@ -64,6 +66,7 @@ namespace app {
       kMaskVisible      = 2, // The mask wasn't hidden by the user
       kInhibitBackup    = 4, // Inhibit the backup process
       kFullyBackedUp    = 8, // Full backup was done
+      kReadOnly         = 16,// This document is read-only
     };
   public:
     Doc(Sprite* sprite);
@@ -145,6 +148,10 @@ namespace app {
 
     void markAsBackedUp();
     bool isFullyBackedUp() const;
+
+    void markAsReadOnly();
+    bool isReadOnly() const;
+    void removeReadOnlyMark();
 
     //////////////////////////////////////////////////////////////////////
     // Loaded options from file
@@ -266,6 +273,14 @@ namespace app {
     os::ColorSpaceRef m_osColorSpace;
 
     DISABLE_COPYING(Doc);
+  };
+
+  // Exception thrown when we want to modify a sprite (add new
+  // app::Cmd objects) marked as read-only.
+  class CannotModifyWhenReadOnlyException : public base::Exception {
+  public:
+    CannotModifyWhenReadOnlyException() throw()
+    : base::Exception(Strings::alerts_cannot_modify_readonly()) { }
   };
 
 } // namespace app

--- a/src/app/file/ase_format.cpp
+++ b/src/app/file/ase_format.cpp
@@ -54,6 +54,10 @@ public:
     m_fop->setError(msg.c_str());
   }
 
+  void incompatibilityError(const std::string& msg) override {
+    m_fop->setIncompatibilityError(msg.c_str());
+  }
+
   void progress(double fromZeroToOne) override {
     m_fop->setProgress(fromZeroToOne);
   }
@@ -289,7 +293,7 @@ bool AseFormat::onLoad(FileOp* fop)
     return false;
 
   Sprite* sprite = delegate.sprite();
-  fop->createDocument(sprite);
+  fop->createDocument(sprite, fop->hasIncompatibilityError());
 
   if (sprite->colorSpace() != nullptr &&
       sprite->colorSpace()->type() != gfx::ColorSpace::None) {

--- a/src/app/file/file.cpp
+++ b/src/app/file/file.cpp
@@ -920,6 +920,11 @@ void FileOp::operate(IFileOpProgress* progress)
         setError("Error loading data file: %s\n", ex.what());
       }
     }
+
+    if (hasIncompatibilityError()) {
+      setError(fmt::format(Strings::alerts_load_file_with_incompatibilities(),
+               m_incompatibilityError).c_str());
+    }
   }
   // Save //////////////////////////////////////////////////////////////////////
   else if (m_type == FileOpSave &&
@@ -935,6 +940,11 @@ void FileOp::operate(IFileOpProgress* progress)
                     get_app_download_url()).c_str());
     }
 #endif
+
+    if (m_document && m_document->isReadOnly()) {
+      setError(fmt::format(Strings::alerts_cannot_overwrite_readonly()).c_str());
+      return;
+    }
 
     // Save a sequence
     if (isSequence()) {
@@ -1090,12 +1100,14 @@ FileOp::~FileOp()
   delete m_seq.palette;
 }
 
-void FileOp::createDocument(Sprite* spr)
+void FileOp::createDocument(Sprite* spr, bool readOnly)
 {
   // spr can be NULL if the sprite is set in onPostLoad() then
 
   ASSERT(m_document == NULL);
   m_document = new Doc(spr);
+  if (readOnly)
+    m_document->markAsReadOnly();
 }
 
 void FileOp::postLoad()
@@ -1368,6 +1380,18 @@ void FileOp::setError(const char *format, ...)
     if (!m_error.empty() && m_error.back() != '\n')
       m_error.push_back('\n');
     m_error += buf_error;
+  }
+}
+
+void FileOp::setIncompatibilityError(const std::string& msg)
+{
+  // Concatenate the new error
+  {
+    std::lock_guard lock(m_mutex);
+    // Add a newline char automatically if it's needed
+    if (!m_incompatibilityError.empty() && m_incompatibilityError.back() != '\n')
+      m_incompatibilityError.push_back('\n');
+    m_incompatibilityError += msg;
   }
 }
 

--- a/src/app/file/file.h
+++ b/src/app/file/file.h
@@ -168,7 +168,7 @@ namespace app {
 
     const FileOpROI& roi() const { return m_roi; }
 
-    void createDocument(Sprite* spr);
+    void createDocument(Sprite* spr, bool readOnly = false);
     void operate(IFileOpProgress* progress = nullptr);
 
     void done();
@@ -247,6 +247,8 @@ namespace app {
     const std::string& error() const { return m_error; }
     void setError(const char *error, ...);
     bool hasError() const { return !m_error.empty(); }
+    void setIncompatibilityError(const std::string& msg);
+    bool hasIncompatibilityError() const { return !m_incompatibilityError.empty(); }
 
     double progress() const;
     void setProgress(double progress);
@@ -283,6 +285,7 @@ namespace app {
     double m_progress;          // Progress (1.0 is ready).
     IFileOpProgress* m_progressInterface;
     std::string m_error;        // Error string.
+    std::string m_incompatibilityError; // Incompatibility error string.
     bool m_done;                // True if the operation finished.
     bool m_stop;                // Force the break of the operation.
     bool m_oneframe;            // Load just one frame (in formats

--- a/src/app/transaction.cpp
+++ b/src/app/transaction.cpp
@@ -140,6 +140,12 @@ void Transaction::rollback(CmdTransaction* newCmds)
 
 void Transaction::execute(Cmd* cmd)
 {
+  // Read-only sprites cannot be modified.
+  if (m_doc->isReadOnly()) {
+    delete cmd;
+    throw CannotModifyWhenReadOnlyException();
+  }
+
   // If we are undoing/redoing, just throw an exception, we cannot
   // modify the sprite while we are moving throw the undo history.
   // To undo/redo we have just to call the onUndo/onRedo of each

--- a/src/app/ui/editor/editor.cpp
+++ b/src/app/ui/editor/editor.cpp
@@ -2418,7 +2418,8 @@ bool Editor::canDraw()
           m_layer->isImage() &&
           m_layer->isVisibleHierarchy() &&
           m_layer->isEditableHierarchy() &&
-          !m_layer->isReference());
+          !m_layer->isReference() &&
+          !m_document->isReadOnly());
 }
 
 bool Editor::isInsideSelection()

--- a/src/app/ui/editor/tool_loop_impl.cpp
+++ b/src/app/ui/editor/tool_loop_impl.cpp
@@ -783,6 +783,14 @@ tools::ToolLoop* create_tool_loop(
   Site site = editor->getSite();
   doc::Grid grid = site.grid();
 
+  // If the document is read-only.
+  if (site.document()->isReadOnly()) {
+    StatusBar::instance()->showTip(
+      1000,
+      fmt::format(Strings::statusbar_tips_unmodifiable_sprite()));
+    return nullptr;
+  }
+
   ToolLoopParams params;
   params.tool = editor->getCurrentEditorTool();
   params.ink = editor->getCurrentEditorInk();

--- a/src/dio/aseprite_decoder.cpp
+++ b/src/dio/aseprite_decoder.cpp
@@ -1283,20 +1283,26 @@ void AsepriteDecoder::readPropertiesMaps(doc::UserData::PropertiesMaps& properti
   auto startPos = f()->tell();
   auto size = read32();
   auto numMaps = read32();
-  for (int i=0; i<numMaps; ++i) {
-    auto id = read32();
-    std::string extensionId; // extensionId = empty by default (when id == 0)
-    if (id &&
-        !extFiles.getFilenameByID(id, extensionId)) {
-      // This shouldn't happen, but if it does, we put the properties
-      // in an artificial extensionId.
-      extensionId = fmt::format("__missed__{}", id);
-      delegate()->error(
-        fmt::format("Error: Invalid extension ID (id={0} not found)", id));
+  try {
+    for (int i=0; i<numMaps; ++i) {
+      auto id = read32();
+      std::string extensionId; // extensionId = empty by default (when id == 0)
+      if (id &&
+          !extFiles.getFilenameByID(id, extensionId)) {
+        // This shouldn't happen, but if it does, we put the properties
+        // in an artificial extensionId.
+        extensionId = fmt::format("__missed__{}", id);
+        delegate()->error(
+          fmt::format("Error: Invalid extension ID (id={0} not found)", id));
+      }
+      auto properties = readPropertyValue(USER_DATA_PROPERTY_TYPE_PROPERTIES);
+      propertiesMaps[extensionId] = doc::get_value<doc::UserData::Properties>(properties);
     }
-    auto properties = readPropertyValue(USER_DATA_PROPERTY_TYPE_PROPERTIES);
-    propertiesMaps[extensionId] = doc::get_value<doc::UserData::Properties>(properties);
   }
+  catch(const base::Exception& e) {
+    delegate()->incompatibilityError(fmt::format("Error reading custom properties: {0}", e.what()));
+  }
+
   f()->seek(startPos+size);
 }
 
@@ -1399,6 +1405,9 @@ const doc::UserData::Variant AsepriteDecoder::readPropertyValue(uint16_t type)
         value[name] = readPropertyValue(type);
       }
       return value;
+    }
+    default: {
+      throw base::Exception(fmt::format("Unexpected property type '{0}' at file position {1}", type, f()->tell()));
     }
   }
 

--- a/src/dio/decode_delegate.h
+++ b/src/dio/decode_delegate.h
@@ -24,6 +24,10 @@ public:
   // Used to log errors
   virtual void error(const std::string& msg) { }
 
+  // Sets an error when an incompatibility issue is
+  // detected.
+  virtual void incompatibilityError(const std::string &msg) { }
+
   // Used to report progress of the whole operation
   virtual void progress(double fromZeroToOne) { }
 


### PR DESCRIPTION
Fix #3812, fix #3811.

This PR shows the following message when an incompatibility issue is found when loading a .aseprite file:
<img width="1375" alt="Screen Shot 2023-04-25 at 11 45 25" src="https://user-images.githubusercontent.com/5520828/234343113-e9d0f67b-0395-471a-b9cd-0a8ca32e7516.png">

EDIT: The last message in the image above was modified after uploading it. So it now says: "Document will be marked as read-only. Please upgrade Aseprite to the latest version to be able to save this document without losing data."

Note: I have tested this PR by commenting out the `case` block for type 18 (USER_DATA_PROPERTY_TYPE_PROPERTIES) in readPropertyValue method in aseprite_decoder.cpp, and using a file that has some user data custom properties.

Then it shows the sprite and it adds [Read-Only] to the window's title bar as follows:
![Screen Shot 2023-04-25 at 11 45 42](https://user-images.githubusercontent.com/5520828/234344354-3b1cef3a-24b6-419c-9fc2-674df0411d8b.png)

Then if the user makes some changes and tries to save the sprite, it shows:
<img width="1362" alt="Screen Shot 2023-04-25 at 11 46 04" src="https://user-images.githubusercontent.com/5520828/234344612-707747ad-b5dc-450d-9431-64ad6008e379.png">

If the user tries to close the sprite after some modification was made, it first shows the regular "save before closing" warning dialog:
![warning](https://user-images.githubusercontent.com/5520828/234347748-25077192-c7ec-4ef1-b218-260bd21dd226.png)

But then when the user presses the "Save" button it shows the following message in the console and opens the warning again:
![Screen Shot 2023-04-25 at 13 08 57](https://user-images.githubusercontent.com/5520828/234346522-5d5a6035-1f19-45f0-a27d-0ee58a27e790.png)

So, the only options the user actually have are "Don't save" or "Cancel".

If the user uses the "Save As..." dialog, the file can be saved in the same path with a different name or in another path with any name.

I'm happy to make any change to this if needed. 
