### PR TITLE
Fix timeline is not repainted/invalidated when we switch onion skin option (F3 key) (fix #3806)

### DIFF
--- a/src/app/ui/timeline/timeline.cpp
+++ b/src/app/ui/timeline/timeline.cpp
@@ -388,6 +388,8 @@ void Timeline::updateUsingEditor(Editor* editor)
   m_firstFrameConn = Preferences::instance().document(m_document)
     .timeline.firstFrame.AfterChange.connect([this]{ invalidate(); });
 
+  m_onionskinConn = docPref.onionskin.AfterChange.connect([this]{ invalidate(); });
+
   setFocusStop(true);
   regenerateRows();
   setViewScroll(view->timelineScroll());
@@ -400,6 +402,7 @@ void Timeline::detachDocument()
     m_confPopup->closeWindow(nullptr);
 
   m_firstFrameConn.disconnect();
+  m_onionskinConn.disconnect();
 
   if (m_document) {
     m_thumbnailsPrefConn.disconnect();

--- a/src/app/ui/timeline/timeline.h
+++ b/src/app/ui/timeline/timeline.h
@@ -424,6 +424,7 @@ namespace app {
     std::unique_ptr<ConfigureTimelinePopup> m_confPopup;
     obs::scoped_connection m_ctxConn1, m_ctxConn2;
     obs::connection m_firstFrameConn;
+    obs::connection m_onionskinConn;
 
     // Marching ants stuff to show the range in the clipboard.
     // TODO merge this with the marching ants of the sprite editor (ui::Editor)


### PR DESCRIPTION
fix #3806