### PR TITLE
Test UUID user data property serialization

### DIFF
--- a/tests/scripts/userdata_codec.lua
+++ b/tests/scripts/userdata_codec.lua
@@ -167,3 +167,17 @@ do
   assert(spr.properties.a == a)
   assert(spr.properties.b == b)
 end
+
+-- Test undo and redo setting UUID property
+do
+  local a = Uuid()
+  local spr = Sprite(1, 1)
+  spr.properties.a = a
+
+  app.undo()
+  assert(#spr.properties == 0)
+
+  app.redo()
+  assert(#spr.properties == 1)
+  assert(spr.properties.a == a)
+end


### PR DESCRIPTION
This PR adds a Lua test to check that undoing and redoing setting a UUID user data property works as expected.