### PR TITLE
Fix rate of change of value too fast in some wheel actions

### DIFF
--- a/src/app/ui/editor/editor.cpp
+++ b/src/app/ui/editor/editor.cpp
@@ -481,6 +481,18 @@ void Editor::setZoom(const render::Zoom& zoom)
   }
 }
 
+// Helps to accummulate wheel delta fractions
+void Editor::addWheelDelta(gfx::PointF& deltaF)
+{
+    deltaF /= 10;
+    deltaF.x = std::clamp(deltaF.x, -1.0, 1.0);
+    deltaF.y = std::clamp(deltaF.y, -1.0, 1.0);
+    gfx::PointF wheelAcum = m_wheelAcum;
+    m_wheelAcum += deltaF;
+    deltaF.x = std::floor(m_wheelAcum.x) - std::floor(wheelAcum.x);
+    deltaF.y = std::floor(m_wheelAcum.y) - std::floor(wheelAcum.y);
+}
+
 void Editor::setDefaultScroll()
 {
   if (Preferences::instance().editor.autoFit())

--- a/src/app/ui/editor/editor.h
+++ b/src/app/ui/editor/editor.h
@@ -165,6 +165,7 @@ namespace app {
     const gfx::Point& padding() const { return m_padding; }
 
     void setZoom(const render::Zoom& zoom);
+    void addWheelDelta(gfx::PointF& deltaF);
     void setDefaultScroll();
     void setScrollToCenter();
     void setScrollAndZoomToFitScreen();
@@ -459,6 +460,9 @@ namespace app {
     EditorFlags m_flags;
 
     bool m_secondaryButton;
+    // Internal accumulation of wheel fractions to get
+    // smoother wheel zoom or color/tile selection.
+    gfx::PointF m_wheelAcum;
     Flashing m_flashing;
 
     // Animation speed multiplier.

--- a/src/app/ui/file_list.cpp
+++ b/src/app/ui/file_list.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2022  Igara Studio S.A.
+// Copyright (C) 2019-2023  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -372,13 +372,12 @@ bool FileList::onProcessMessage(Message* msg)
             msg->cmdPressed()) {
           gfx::Point delta = static_cast<MouseMessage*>(msg)->wheelDelta();
           const bool precise = static_cast<MouseMessage*>(msg)->preciseWheel();
-          double dz = delta.x + delta.y;
 
-          if (precise) {
-            dz /= 1.5;
-            if (dz < -1.0) dz = -1.0;
-            else if (dz > 1.0) dz = 1.0;
-          }
+          double dz;
+          if (precise)
+            dz = (double(delta.x) + double(delta.y)) / 10;
+          else
+            dz = delta.x + delta.y;
 
           setZoom(zoom() - dz);
           break;

--- a/src/app/ui/palette_view.cpp
+++ b/src/app/ui/palette_view.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2022  Igara Studio S.A.
+// Copyright (C) 2018-2023  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -745,7 +745,15 @@ bool PaletteView::onProcessMessage(Message* msg)
 
       if (msg->onlyCtrlPressed() ||
           msg->onlyCmdPressed()) {
-        int z = delta.x - delta.y;
+        auto editor = Editor::activeEditor();
+        int z;
+        if (editor && static_cast<MouseMessage*>(msg)->preciseWheel()) {
+          gfx::PointF deltaF(delta);
+          editor->addWheelDelta(deltaF);
+          z = deltaF.x - deltaF.y;
+        }
+        else
+          z = delta.x - delta.y;
         setBoxSize(m_boxsize + z);
       }
       else {

--- a/src/app/ui/tabs.cpp
+++ b/src/app/ui/tabs.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2022  Igara Studio S.A.
+// Copyright (C) 2018-2023  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This program is distributed under the terms of
@@ -427,9 +427,23 @@ bool Tabs::onProcessMessage(Message* msg)
 
     case kMouseWheelMessage:
       if (!m_isDragging) {
-        int dz =
-          (static_cast<MouseMessage*>(msg)->wheelDelta().x +
-           static_cast<MouseMessage*>(msg)->wheelDelta().y);
+        gfx::Point delta = static_cast<MouseMessage*>(msg)->wheelDelta();
+        bool presiceWheel = static_cast<MouseMessage*>(msg)->preciseWheel();
+        int dz;
+
+        if (presiceWheel) {
+          gfx::PointF deltaF(delta);
+          deltaF /= 10.0;
+          deltaF.x = std::clamp(deltaF.x, -1.0, 1.0);
+          deltaF.y = std::clamp(deltaF.y, -1.0, 1.0);
+          gfx::PointF wheelAcum = m_wheelAcum;
+          m_wheelAcum += deltaF;
+          deltaF.x = std::floor(m_wheelAcum.x) - std::floor(wheelAcum.x);
+          deltaF.y = std::floor(m_wheelAcum.y) - std::floor(wheelAcum.y);
+          dz = int(deltaF.x + deltaF.y);
+        }
+        else
+          dz = delta.x + delta.y;
 
         auto it = std::find(m_list.begin(), m_list.end(), m_selected);
         if (it != m_list.end()) {

--- a/src/app/ui/tabs.h
+++ b/src/app/ui/tabs.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2022  Igara Studio S.A.
+// Copyright (C) 2019-2023  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -276,6 +276,10 @@ namespace app {
 
     // Initial mouse position when we start the dragging process.
     gfx::Point m_dragMousePos;
+
+    // Internal accumulation of wheel fractions to get
+    // smoother zoom action.
+    gfx::PointF m_wheelAcum;
 
     // New position where m_selected is being dragged. It's used to
     // change the position of m_selected inside the m_list vector in

--- a/src/app/ui/timeline/timeline.cpp
+++ b/src/app/ui/timeline/timeline.cpp
@@ -1529,13 +1529,11 @@ bool Timeline::onProcessMessage(Message* msg)
         // Zoom timeline
         if (msg->ctrlPressed() || // TODO configurable
             msg->cmdPressed()) {
-          double dz = delta.x + delta.y;
-
-          if (precise) {
-            dz /= 1.5;
-            if (dz < -1.0) dz = -1.0;
-            else if (dz > 1.0) dz = 1.0;
-          }
+          double dz;
+          if (precise)
+            dz = (double(delta.x) + double(delta.y)) / 10.0;
+          else
+            dz = delta.x + delta.y;
 
           setZoomAndUpdate(m_zoom - dz, true);
         }


### PR DESCRIPTION
It was observed when 'preciseWheel' peripherals as touchpads/trackpads/magic mouse some values changes too fast. Examples (on macOS) with the 'control' or 'alt' keys held down:
- Editor zoom (on the editor viewport + 'control' + two fingers gesture)
- Color palette selection (on the editor viewport + 'alt' + two fingers gesture)
- Color bar zoom (on the colorbar + 'control' + two fingers gesture)
- File list zoom (on file selection dialog + 'control' + two fingers gesture)
- Timeline zoom (on the timeline + 'control' + two fingers gesture)
- Tab selection (on a tab + 'control' + two fingers gesture)

If this fix is well suited for multiple platforms and peripherals the issue https://github.com/aseprite/aseprite/issues/3171 will be unnecessary.