### PR TITLE
Fix multiple tileset layers selection move is broken (fix #3144)

### DIFF
--- a/src/app/commands/cmd_toggle_tiles_mode.cpp
+++ b/src/app/commands/cmd_toggle_tiles_mode.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (c) 2019-2020  Igara Studio S.A.
+// Copyright (c) 2019-2024  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -30,10 +30,12 @@ protected:
 
   void onExecute(Context* context) override {
     auto colorBar = ColorBar::instance();
-    colorBar->setTilemapMode(
-      colorBar->tilemapMode() == TilemapMode::Pixels ?
-      TilemapMode::Tiles:
-      TilemapMode::Pixels);
+    if (!colorBar->isTilemapModeLocked()) {
+      colorBar->setTilemapMode(
+        colorBar->tilemapMode() == TilemapMode::Pixels ?
+        TilemapMode::Tiles:
+        TilemapMode::Pixels);
+    }
   }
 };
 

--- a/src/app/script/site_class.cpp
+++ b/src/app/script/site_class.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018  Igara Studio S.A.
+// Copyright (C) 2018-2024  Igara Studio S.A.
 // Copyright (C) 2018  David Capello
 //
 // This program is distributed under the terms of
@@ -83,6 +83,26 @@ int Site_get_image(lua_State* L)
   return 1;
 }
 
+int Site_get_tilemapMode(lua_State* L)
+{
+  auto site = get_obj<Site>(L, 1);
+  if (site)
+    lua_pushinteger(L, (int)site->tilemapMode());
+  else
+    lua_pushnil(L);
+  return 1;
+}
+
+int Site_get_tilesetMode(lua_State* L)
+{
+  auto site = get_obj<Site>(L, 1);
+  if (site)
+    lua_pushinteger(L, (int)site->tilesetMode());
+  else
+    lua_pushnil(L);
+  return 1;
+}
+
 const luaL_Reg Site_methods[] = {
   { nullptr, nullptr }
 };
@@ -94,6 +114,8 @@ const Property Site_properties[] = {
   { "frame", Site_get_frame, nullptr },
   { "frameNumber", Site_get_frameNumber, nullptr },
   { "image", Site_get_image, nullptr },
+  { "tilemapMode", Site_get_tilemapMode, nullptr },
+  { "tilesetMode", Site_get_tilesetMode, nullptr },
   { nullptr, nullptr, nullptr }
 };
 

--- a/src/app/ui/color_bar.h
+++ b/src/app/ui/color_bar.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2023  Igara Studio S.A.
+// Copyright (C) 2018-2024  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -92,6 +92,9 @@ namespace app {
 
     TilemapMode tilemapMode() const;
     void setTilemapMode(TilemapMode mode);
+    void lockTilemapMode() { m_tilesButton.setEnabled(false); };
+    void unlockTilemapMode() { m_tilesButton.setEnabled(true); };
+    bool isTilemapModeLocked() const { return !m_tilesButton.isEnabled(); };
 
     TilesetMode tilesetMode() const;
     void setTilesetMode(TilesetMode mode);

--- a/src/app/ui/editor/moving_pixels_state.cpp
+++ b/src/app/ui/editor/moving_pixels_state.cpp
@@ -736,6 +736,10 @@ void MovingPixelsState::onBeforeCommandExecution(CommandExecutionEvent& ev)
       return;
     }
   }
+  else if (command->id() == CommandId::ToggleTilesMode()) {
+    ev.cancel();
+    return;
+  }
 
   if (m_pixelsMovement)
     dropPixels();

--- a/src/app/ui/editor/pixels_movement.h
+++ b/src/app/ui/editor/pixels_movement.h
@@ -74,6 +74,7 @@ namespace app {
                    const Image* moveThis,
                    const Mask* mask,
                    const char* operationName);
+    ~PixelsMovement();
 
     const Site& site() { return m_site; }
 
@@ -161,6 +162,16 @@ namespace app {
                             const double angle);
     CelList getEditableCels();
     void reproduceAllTransformationsWithInnerCmds();
+
+    void alignMasksAndTransformData(const Mask* initialMask0,
+                                    const Mask* initialMask,
+                                    const Mask* currentMask,
+                                    const Transformation* initialData,
+                                    const Transformation* currentData,
+                                    const doc::Grid& grid,
+                                    const gfx::Size& deltaA,
+                                    const gfx::Size& deltaB);
+
 #if _DEBUG
     void dumpInnerCmds();
 #endif

--- a/src/doc/grid_tests.cpp
+++ b/src/doc/grid_tests.cpp
@@ -1,5 +1,5 @@
 // Aseprite Document Library
-// Copyright (c) 2019 Igara Studio S.A.
+// Copyright (c) 2019-2024 Igara Studio S.A.
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -11,6 +11,8 @@
 #include <gtest/gtest.h>
 
 #include "doc/grid.h"
+#include "doc/mask.h"
+#include "doc/util.h"
 #include "gfx/rect_io.h"
 #include "gfx/region.h"
 
@@ -77,6 +79,80 @@ TEST(Grid, RectWithOffset)
 
   grid.origin(gfx::Point(-1, -1));
   EXPECT_EQ(Rect(1, 1, 1, 1), grid.canvasToTile(Rect(30, 30, 1, 1)));
+}
+
+TEST(Grid, MakeAlignedMask)
+{
+  auto grid = Grid::MakeRect(Size(4, 4));
+  grid.origin(gfx::Point(1,1));
+  auto mask = Mask();
+  mask.replace(gfx::Rect(3, 3, 4, 4));
+  auto gridAlignedMask = make_aligned_mask(&grid, &mask);
+  EXPECT_EQ(gfx::Rect(1,1,8,8), gridAlignedMask.bounds());
+
+  mask.replace(gfx::Rect(1, 1, 4, 4));
+  auto gridAlignedMask2 = make_aligned_mask(&grid, &mask);
+  EXPECT_EQ(gfx::Rect(1,1,4,4), gridAlignedMask2.bounds());
+
+  mask.add(gfx::Rect(8, 4, 1, 1));
+  mask.add(gfx::Rect(7, 7, 1, 1));
+  auto gridAlignedMask3 = make_aligned_mask(&grid, &mask);
+  const bool _ = false;
+  const bool X = true;
+  bool expected[8*8] = {
+     X, X, X, X,  X, X, X, X,
+     X, X, X, X,  X, X, X, X,
+     X, X, X, X,  X, X, X, X,
+     X, X, X, X,  X, X, X, X,
+
+     _, _, _, _,  X, X, X, X,
+     _, _, _, _,  X, X, X, X,
+     _, _, _, _,  X, X, X, X,
+     _, _, _, _,  X, X, X, X,
+  };
+  int c=0;
+  for (int j=0; j<8; ++j)
+    for (int i=0; i<8; ++i)
+      EXPECT_EQ(expected[c++], gridAlignedMask3.bitmap()->getPixel(i, j));
+
+  mask.replace(gfx::Rect(4, 4, 1, 1));
+  mask.add(gfx::Rect(5, 5, 1, 1));
+  mask.add(gfx::Rect(8, 4, 1, 1));
+  mask.add(gfx::Rect(9, 1, 1, 1));
+  auto gridAlignedMask4 = make_aligned_mask(&grid, &mask);
+  bool expected2[12*8] = {
+     X, X, X, X,  X, X, X, X,  X, X, X, X,
+     X, X, X, X,  X, X, X, X,  X, X, X, X,
+     X, X, X, X,  X, X, X, X,  X, X, X, X,
+     X, X, X, X,  X, X, X, X,  X, X, X, X,
+
+     _, _, _, _,  X, X, X, X,  _, _, _, _,
+     _, _, _, _,  X, X, X, X,  _, _, _, _,
+     _, _, _, _,  X, X, X, X,  _, _, _, _,
+     _, _, _, _,  X, X, X, X,  _, _, _, _,
+  };
+  c=0;
+  for (int j=0; j<8; ++j)
+    for (int i=0; i<12; ++i)
+      EXPECT_EQ(expected2[c++], gridAlignedMask4.bitmap()->getPixel(i, j));
+
+  grid.origin(gfx::Point(2,1));
+  auto gridAlignedMask5 = make_aligned_mask(&grid, &mask);
+  bool expected3[8*8] = {
+     X, X, X, X,  X, X, X, X,
+     X, X, X, X,  X, X, X, X,
+     X, X, X, X,  X, X, X, X,
+     X, X, X, X,  X, X, X, X,
+
+     X, X, X, X,  _, _, _, _,
+     X, X, X, X,  _, _, _, _,
+     X, X, X, X,  _, _, _, _,
+     X, X, X, X,  _, _, _, _,
+  };
+  c=0;
+  for (int j=0; j<8; ++j)
+    for (int i=0; i<8; ++i)
+      EXPECT_EQ(expected3[c++], gridAlignedMask5.bitmap()->getPixel(i, j));
 }
 
 int main(int argc, char** argv)

--- a/src/doc/util.cpp
+++ b/src/doc/util.cpp
@@ -1,5 +1,5 @@
 // Aseprite Document Library
-// Copyright (c) 2020 Igara Studio S.A.
+// Copyright (c) 2020-2024 Igara Studio S.A.
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -8,6 +8,7 @@
 
 #include "doc/image.h"
 #include "doc/image_impl.h"
+#include "doc/mask.h"
 #include "doc/tileset.h"
 
 namespace doc {
@@ -49,6 +50,56 @@ void fix_old_tilemap(
         res = (c & tileFlagsMask) | ((c & tileIDMask)+delta);
       return res;
     });
+}
+
+Mask make_aligned_mask(
+  const Grid* grid,
+  const Mask* mask)
+{
+  // Fact: the newBounds will be always larger or equal than oldBounds
+  Mask maskOutput;
+  if (mask->isFrozen()) {
+    ASSERT(false);
+    return maskOutput;
+  }
+  const gfx::Rect& oldBounds(mask->bounds());
+  const gfx::Rect newBounds(grid->alignBounds(mask->bounds()));
+  ASSERT(newBounds.w > 0 && newBounds.h > 0);
+  ImageRef newBitmap;
+  if (!mask->bitmap()) {
+    maskOutput.replace(newBounds);
+    return maskOutput;
+  }
+
+  newBitmap.reset(Image::create(IMAGE_BITMAP, newBounds.w, newBounds.h));
+  maskOutput.freeze();
+  maskOutput.reserve(newBounds);
+
+  const LockImageBits<BitmapTraits> bits(mask->bitmap());
+  typename LockImageBits<BitmapTraits>::const_iterator it = bits.begin();
+  // We must travel thought the old bitmap and masking the new bitmap
+  gfx::Point previousPoint(std::numeric_limits<int>::max(),
+                           std::numeric_limits<int>::max());
+  for (int y=0; y < oldBounds.h; ++y) {
+    for (int x=0; x < oldBounds.w; ++x, ++it) {
+      ASSERT(it != bits.end());
+      if (*it) {
+        const gfx::Rect newBoundsTile =
+          grid->alignBounds(gfx::Rect(oldBounds.x + x, oldBounds.y + y, 1, 1));
+        if (previousPoint != newBoundsTile.origin()) {
+          // Fill a tile region in the newBitmap
+          fill_rect(maskOutput.bitmap(),
+                    gfx::Rect(newBoundsTile.x - newBounds.x,
+                              newBoundsTile.y - newBounds.y,
+                              grid->tileSize().w, grid->tileSize().h),
+                    1);
+          previousPoint = newBoundsTile.origin();
+        }
+      }
+    }
+  }
+  maskOutput.unfreeze();
+  return maskOutput;
 }
 
 } // namespace dooc

--- a/src/doc/util.h
+++ b/src/doc/util.h
@@ -1,5 +1,5 @@
 // Aseprite Document Library
-// Copyright (c) 2020 Igara Studio S.A.
+// Copyright (c) 2020-2024 Igara Studio S.A.
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -11,6 +11,8 @@
 #include "doc/tile.h"
 
 namespace doc {
+  class Grid;
+  class Mask;
   class Image;
   class Tileset;
 
@@ -28,6 +30,10 @@ namespace doc {
     const Tileset* tileset,
     const tile_t tileIDMask,
     const tile_t tileFlagsMask);
+
+  // Returns a mask aligned with a given grid, starting from another
+  // mask not aligned with the grid.
+  Mask make_aligned_mask(const Grid* grid, const Mask* mask);
 
 } // namespace doc
 


### PR DESCRIPTION
Before this fix, a multi-layer mask movement/scaling (with mixed layer types: normal layer and tilemap layers with different grids) caused loss of drawing areas. The heart of this solution is to correctly align the 'selection mask' and 'transform data' according to the layer's grid, and also, forcing 'site' TilemapMode/TilesetMode before each reproduceAllTransformationsWithInnerCmds() iteration.

Additionally arrow keys now work to move a selected area in TilemapMode::Tiles.

fix aseprite/aseprite#3144