### PR TITLE
Fix unnecessary propagation of onProcessMessage across all open editors in kKeyDownMessage cases

### DIFF
--- a/src/app/ui/editor/editor.cpp
+++ b/src/app/ui/editor/editor.cpp
@@ -2078,13 +2078,13 @@ bool Editor::onProcessMessage(Message* msg)
       }
 #endif  // ENABLE_DEVMODE
 
-      if (m_sprite) {
+      if (m_sprite && (isActive() || hasMouse())) {
         EditorStatePtr holdState(m_state);
         bool used = m_state->onKeyDown(this, static_cast<KeyMessage*>(msg));
 
-        updateToolLoopModifiersIndicators();
-        updateAutoCelGuides(msg);
         if (hasMouse()) {
+          updateToolLoopModifiersIndicators();
+          updateAutoCelGuides(msg);
           updateQuicktool();
           setCursor(mousePosInDisplay());
         }
@@ -2095,13 +2095,13 @@ bool Editor::onProcessMessage(Message* msg)
       break;
 
     case kKeyUpMessage:
-      if (m_sprite) {
+      if (m_sprite && (isActive() || hasMouse())) {
         EditorStatePtr holdState(m_state);
         bool used = m_state->onKeyUp(this, static_cast<KeyMessage*>(msg));
 
-        updateToolLoopModifiersIndicators();
-        updateAutoCelGuides(msg);
         if (hasMouse()) {
+          updateToolLoopModifiersIndicators();
+          updateAutoCelGuides(msg);
           updateQuicktool();
           setCursor(mousePosInDisplay());
         }

--- a/src/app/ui/editor/standby_state.cpp
+++ b/src/app/ui/editor/standby_state.cpp
@@ -498,7 +498,7 @@ bool StandbyState::onKeyDown(Editor* editor, KeyMessage* msg)
 
   Keys keys = KeyboardShortcuts::instance()
     ->getDragActionsFromKeyMessage(KeyContext::MouseWheel, msg);
-  if (!keys.empty()) {
+  if (editor->hasMouse() && !keys.empty()) {
     // Don't enter DraggingValueState to change brush size if we are
     // in a selection-like tool
     if (keys.size() == 1 &&


### PR DESCRIPTION
The pressed key should work only in the active editor.

Also this fix solves ‘Brush preview issues entering on Drag Value' (fix #3884)