### PR TITLE
Fix crash accessing theme dimensions/info in a plugin's init() function (fix #3913)

### DIFF
--- a/src/app/script/app_theme_object.cpp
+++ b/src/app/script/app_theme_object.cpp
@@ -49,12 +49,8 @@ private:
 };
 
 struct ThemeDimension {
-  Theme* theme;
-
-  ThemeDimension(Theme* theme) : theme(theme) { }
-
   int getById(const std::string& id) const {
-    return theme->getDimensionById(id);
+    return skin::SkinTheme::instance()->getDimensionById(id);
   }
 };
 
@@ -129,7 +125,7 @@ int Theme_styleMetrics(lua_State* L)
 int Theme_get_dimension(lua_State* L)
 {
   auto theme = get_obj<Theme>(L, 1);
-  push_new<ThemeDimension>(L, theme);
+  push_new<ThemeDimension>(L);
   return 1;
 }
 


### PR DESCRIPTION
fix #3913