### PR TITLE
Update INSTALL.md for Apple Silicon without Xcode.app installed

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -196,7 +196,6 @@ steps as above but when we call `cmake`, we have some differences:
       -DCMAKE_BUILD_TYPE=RelWithDebInfo \
       -DCMAKE_OSX_ARCHITECTURES=arm64 \
       -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 \
-      -DCMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk \
       -DLAF_BACKEND=skia \
       -DSKIA_DIR=$HOME/deps/skia \
       -DSKIA_LIBRARY_DIR=$HOME/deps/skia/out/Release-arm64 \


### PR DESCRIPTION
This PR updates [INSTALL.md](https://github.com/aseprite/aseprite/blob/main/INSTALL.md) so that the build instructions work even for people without Xcode.app installed. Xcode isn't a requirement; the command-line tools are enough, and a surprising number of people refuse to install Xcode. So I've tried to avoid installing it for as long as possible on my new M2 to simulate this stubbornness, precisely so that I can go around and fix issues like this in other projects. :)



<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the Individual Contributor License Agreement V4.0. -->
<!-- If you're a first-time contributor, please sign the CLA
     as indicated in https://github.com/igarastudio/cla#signing
     and acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing
