### PR TITLE
Add configuration files for automatic CLion support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,13 @@
 .vs
 tests/_test*
 build
+
+# CLion
+# https://www.jetbrains.com/help/idea/run-debug-configuration.html#templates
+/.idea/*
+!/.idea/runConfigurations
+!/.idea/fileTemplates
+!/.idea/fileColors.xml
+!/.idea/cmake.xml
+!/.idea/shelf
+/.idea/shelf/Uncommitted*

--- a/.idea/cmake.xml
+++ b/.idea/cmake.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CMakeSharedSettings">
+    <configurations>
+      <configuration PROFILE_NAME="Release" ENABLED="true" CONFIG_NAME="RelWithDebInfo" GENERATION_OPTIONS="-DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 -DLAF_BACKEND=skia -DSKIA_DIR=~/deps/skia -DSKIA_LIBRARY_DIR=~/deps/skia/out/Release-arm64 -DSKIA_LIBRARY=~/deps/skia/out/Release-arm64/libskia.a -DPNG_ARM_NEON:STRING=on" />
+      <configuration PROFILE_NAME="Debug" ENABLED="true" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 -DLAF_BACKEND=skia -DSKIA_DIR=~/deps/skia -DSKIA_LIBRARY_DIR=~/deps/skia/out/Release-arm64 -DSKIA_LIBRARY=~/deps/skia/out/Release-arm64/libskia.a -DPNG_ARM_NEON:STRING=on" />
+    </configurations>
+  </component>
+</project>

--- a/.idea/runConfigurations/aseprite.xml
+++ b/.idea/runConfigurations/aseprite.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="aseprite" type="CMakeRunConfiguration" factoryName="Application" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" PASS_PARENT_ENVS_2="true" CONFIG_NAME="Release" RUN_TARGET_PROJECT_NAME="aseprite" RUN_TARGET_NAME="aseprite" EXPLICIT_BUILD_TARGET_NAME="all">
+    <method v="2">
+      <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
+    </method>
+  </configuration>
+</component>


### PR DESCRIPTION
This PR makes it simple for developers to open, build, and debug Aseprite in [CLion](https://www.jetbrains.com/clion/) on Apple Silicon.

Basically, they can clone the repository, cd into it, then type `clion .` and press `Build -> Build Project`, and they're done:

<img width="1624" alt="image" src="https://github.com/aseprite/aseprite/assets/59632/6fd1e062-3cac-40eb-8c3e-8d8b1678bfaf">

Without this, you'd have to manually configure a bunch of CMake variables, which is a big chore in CLion's GUI.


<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the Individual Contributor License Agreement V4.0. -->
<!-- If you're a first-time contributor, please sign the CLA
     as indicated in https://github.com/igarastudio/cla#signing
     and acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing
