### PR TITLE
Scripting: window size

### DIFF
--- a/src/app/script/app_object.cpp
+++ b/src/app/script/app_object.cpp
@@ -37,6 +37,7 @@
 #include "app/ui/editor/editor.h"
 #include "app/ui/editor/tool_loop_impl.h"
 #include "app/ui/timeline/timeline.h"
+#include "app/ui/main_window.h"
 #include "app/ui_context.h"
 #include "base/fs.h"
 #include "base/replace_string.h"
@@ -700,6 +701,28 @@ int App_get_defaultPalette(lua_State* L)
   return 1;
 }
 
+int App_get_width(lua_State* L)
+{
+#if ENABLE_UI
+  App* app = App::instance();
+  lua_pushinteger(L, app->mainWindow()->bounds().w);
+  return 1;
+#endif
+  lua_pushinteger(L, 0);
+  return 1;
+}
+
+int App_get_height(lua_State* L)
+{
+#if ENABLE_UI
+  App* app = App::instance();
+  lua_pushinteger(L, app->mainWindow()->bounds().h);
+  return 1;
+#endif
+  lua_pushinteger(L, 0);
+  return 1;
+}
+
 int App_set_sprite(lua_State* L)
 {
   auto sprite = may_get_docobj<Sprite>(L, 2);
@@ -814,6 +837,8 @@ const Property App_properties[] = {
   { "range",          App_get_range,          nullptr },
   { "isUIAvailable",  App_get_isUIAvailable,  nullptr },
   { "defaultPalette", App_get_defaultPalette, App_set_defaultPalette },
+  { "width",          App_get_width,          nullptr },
+  { "height",         App_get_height,         nullptr },
   { "events",         App_get_events,         nullptr },
   { "theme",          App_get_theme,          nullptr },
   { "uiScale",        App_get_uiScale,        nullptr },

--- a/src/ui/window.cpp
+++ b/src/ui/window.cpp
@@ -653,6 +653,8 @@ void Window::onInvalidateRegion(const gfx::Region& region)
 void Window::onResize(ResizeEvent& ev)
 {
   windowSetPosition(ev.bounds());
+  // Fire Resize signal
+  Resize(ev);
 }
 
 void Window::onSizeHint(SizeHintEvent& ev)

--- a/src/ui/window.h
+++ b/src/ui/window.h
@@ -92,6 +92,7 @@ namespace ui {
     // Signals
     obs::signal<void (Event&)> Open;
     obs::signal<void (CloseEvent&)> Close;
+    obs::signal<void (ResizeEvent&)> Resize;
 
   protected:
     ButtonBase* closeButton() { return m_closeButton; }


### PR DESCRIPTION
Proposed changes to scripting API:
- `app.width`, `app.height` properties to access size of the client area of the window.
  It was sort of possible to retrieve those as `2*x+width` of a freshly created dialog, but not very intuitive or efficient.
- `"resize"` type of `app.events`, which is triggered after windows resize. Callback receives a table with `width` and `height` keys.

It will allow to keep dialogs centered, or positioned relative to right/bottom edge of the window; or limit size to show a scrollbar when they're taller that the window itself.

------------------------------------------------------
I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md