### PR TITLE
Show, duplicate and delete tilesets in Sprite Properties dialog

### DIFF
--- a/data/strings/en.ini
+++ b/data/strings/en.ini
@@ -55,6 +55,12 @@ Automatic Remap
 ||&OK||&Cancel"
 END
 cannot_delete_all_layers = Error<<You cannot delete all layers.||&OK
+cannot_delete_used_tileset = <<<END
+Error
+<<Cannot delete tileset used by the following tilemaps:
+<<'{0}'
+||&OK
+END
 deleting_tilemaps_will_delete_tilesets = <<<END
 Warning
 <<Deleting the following layers will delete their tilesets:
@@ -600,6 +606,8 @@ TilesetMode = Tileset Mode: {}
 TilesetMode_Manual = Manual
 TilesetMode_Auto = Auto
 TilesetMode_Stack = Stack
+TilesetDelete = Delete Tileset
+TilesetDuplicate = Duplicate Tileset
 Undo = Undo
 UndoHistory = Undo History
 UnlinkCel = Unlink Cel
@@ -1960,6 +1968,9 @@ indexed_image_only = (only for indexed images)
 assign_color_profile = Assign Color Profile
 convert_color_profile = Convert Color Profile
 change_sprite_props = Change Sprite Properties
+tilesets = Tilesets
+delete_tileset = Delete
+duplicate_tileset = Duplicate
 
 [sprite_size]
 title = Sprite Size

--- a/data/widgets/sprite_properties.xml
+++ b/data/widgets/sprite_properties.xml
@@ -43,6 +43,14 @@
         </hbox>
       </hbox>
     </grid>
+
+    <vbox expansive="true" id="tilesets_placeholder">
+      <separator text="@.tilesets" horizontal="true" />
+      <view id="tilesets_view" expansive="true">
+        <listbox id="tilesets"></listbox>
+      </view>
+    </vbox>
+
     <separator horizontal="true" />
     <hbox>
       <boxfiller />

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -692,6 +692,7 @@ add_library(app-lib
   util/range_utils.cpp
   util/readable_time.cpp
   util/resize_image.cpp
+  util/tileset_utils.cpp
   util/wrap_point.cpp
   xml_document.cpp
   xml_exception.cpp

--- a/src/app/cmd/set_layer_tileset.cpp
+++ b/src/app/cmd/set_layer_tileset.cpp
@@ -10,6 +10,7 @@
 
 #include "app/cmd/set_layer_tileset.h"
 
+#include "app/app.h"
 #include "app/doc.h"
 #include "doc/layer_tilemap.h"
 #include "doc/sprite.h"
@@ -37,6 +38,13 @@ void SetLayerTileset::onUndo()
   auto layer = static_cast<LayerTilemap*>(this->layer());
   layer->setTilesetIndex(m_oldTsi);
   layer->incrementVersion();
+}
+
+void SetLayerTileset::onFireNotifications()
+{
+  auto layer = static_cast<LayerTilemap*>(this->layer());
+  Doc* doc = static_cast<Doc*>(layer->sprite()->document());
+  doc->notifyTilesetChanged(layer->tileset());
 }
 
 } // namespace cmd

--- a/src/app/cmd/set_layer_tileset.h
+++ b/src/app/cmd/set_layer_tileset.h
@@ -29,6 +29,8 @@ namespace cmd {
   protected:
     void onExecute() override;
     void onUndo() override;
+    void onFireNotifications() override;
+
     size_t onMemSize() const override {
       return sizeof(*this);
     }

--- a/src/app/commands/cmd_layer_properties.cpp
+++ b/src/app/commands/cmd_layer_properties.cpp
@@ -13,6 +13,7 @@
 #include "app/cmd/set_layer_blend_mode.h"
 #include "app/cmd/set_layer_name.h"
 #include "app/cmd/set_layer_opacity.h"
+#include "app/cmd/set_layer_tileset.h"
 #include "app/cmd/set_tileset_base_index.h"
 #include "app/cmd/set_tileset_name.h"
 #include "app/cmd/set_user_data.h"
@@ -36,6 +37,7 @@
 #include "doc/layer_tilemap.h"
 #include "doc/sprite.h"
 #include "doc/tileset.h"
+#include "doc/tilesets.h"
 #include "doc/user_data.h"
 #include "ui/ui.h"
 
@@ -355,7 +357,7 @@ private:
 
     // Information about the tileset to be used for new tilemaps
     TilesetSelector::Info tilesetInfo;
-    tilesetInfo.enabled = false;
+    tilesetInfo.allowNewTileset = false;
     tilesetInfo.newTileset = false;
     tilesetInfo.grid = tileset->grid();
     tilesetInfo.name = tileset->name();
@@ -373,9 +375,15 @@ private:
       tilesetInfo = tilesetSel.getInfo();
 
       if (tileset->name() != tilesetInfo.name ||
-          tileset->baseIndex() != tilesetInfo.baseIndex) {
+          tileset->baseIndex() != tilesetInfo.baseIndex ||
+          tilesetInfo.tsi != tilemap->tilesetIndex()) {
         ContextWriter writer(UIContext::instance());
         Tx tx(writer.context(), "Set Tileset Properties");
+        // User changed tilemap's tileset
+        if (tilesetInfo.tsi != tilemap->tilesetIndex()) {
+          tileset = tilemap->sprite()->tilesets()->get(tilesetInfo.tsi);
+          tx(new cmd::SetLayerTileset(tilemap, tilesetInfo.tsi));
+        }
         if (tileset->name() != tilesetInfo.name)
           tx(new cmd::SetTilesetName(tileset, tilesetInfo.name));
         if (tileset->baseIndex() != tilesetInfo.baseIndex)

--- a/src/app/ui/tileset_selector.h
+++ b/src/app/ui/tileset_selector.h
@@ -18,6 +18,7 @@
 namespace doc {
   class Sprite;
   class Tileset;
+  class Tilesets;
 }
 
 namespace app {
@@ -25,8 +26,14 @@ namespace app {
   class TilesetSelector : public app::gen::TilesetSelector {
   public:
     struct Info {
+      // Enables/disables the tileset selector combobox
       bool enabled = true;
-      bool newTileset = true;
+      // When false, removes the "New Tileset" option from the tileset selector combobox
+      bool allowNewTileset = true;
+
+      // Output members that are set when TilesetSelector.getInfo()
+      // is called.
+      bool newTileset = true;  // Set to true when the selected item is "New Tileset"
       std::string name;
       doc::Grid grid;
       int baseIndex = 1;
@@ -36,7 +43,18 @@ namespace app {
     TilesetSelector(const doc::Sprite* sprite,
                     const TilesetSelector::Info& info);
 
+    // Returns the data of this widget according to the user input
     Info getInfo();
+
+  private:
+    void updateControlsState(const doc::Tilesets* spriteTilesets);
+
+    // Returns the selected item index as if the combobox always has the "New Tileset"
+    // as its first item.
+    int getSelectedItemIndex();
+
+    // Holds the information used to create this widget
+    const TilesetSelector::Info m_info;
   };
 
 } // namespace app

--- a/src/app/util/tileset_utils.cpp
+++ b/src/app/util/tileset_utils.cpp
@@ -1,0 +1,45 @@
+// Aseprite
+// Copyright (C) 2023  Igara Studio S.A.
+//
+// This program is distributed under the terms of
+// the End-User License Agreement for Aseprite.
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "doc/layer_tilemap.h"
+#include "doc/sprite.h"
+#include "tileset_utils.h"
+
+#include <fmt/format.h>
+#include <string>
+
+namespace app {
+
+std::string tileset_label(const doc::Tileset* tileset, doc::tileset_index tsi)
+{
+  std::string tilemapsNames;
+  for (auto layer : tileset->sprite()->allTilemaps()) {
+    auto tilemap = static_cast<doc::LayerTilemap*>(layer);
+    if (tilemap->tilesetIndex() == tsi) {
+      tilemapsNames += tilemap->name() + ", ";
+    }
+  }
+  if (!tilemapsNames.empty()) {
+    tilemapsNames = tilemapsNames.substr(0, tilemapsNames.size()-2);
+  }
+
+  std::string name = tileset->name();
+  if (!tilemapsNames.empty()) {
+    name += " (" + tilemapsNames + ")";
+  }
+
+  return fmt::format("#{0} ({1}x{2}): {3}",
+    tsi,
+    tileset->grid().tileSize().w,
+    tileset->grid().tileSize().h,
+    name);
+}
+
+} // namespace app

--- a/src/app/util/tileset_utils.h
+++ b/src/app/util/tileset_utils.h
@@ -1,0 +1,23 @@
+// Aseprite
+// Copyright (C) 2023  Igara Studio S.A.
+//
+// This program is distributed under the terms of
+// the End-User License Agreement for Aseprite.
+
+#ifndef APP_TILESET_UTILS_H_INCLUDED
+#define APP_TILESET_UTILS_H_INCLUDED
+#pragma once
+
+#include "doc/tileset.h"
+
+#include <string>
+
+namespace app {
+
+  // Builds a string representation of a tileset for using in
+  // labels in the UI.
+  std::string tileset_label(const doc::Tileset* tileset, doc::tileset_index index);
+
+} // namespace app
+
+#endif

--- a/src/doc/tileset.h
+++ b/src/doc/tileset.h
@@ -33,6 +33,7 @@ namespace doc {
            const UserData& data) : image(image), data(data) { }
     };
     static UserData kNoUserData;
+
   public:
     typedef std::vector<Tile> Tiles;
     typedef Tiles::iterator iterator;

--- a/src/doc/tilesets.h
+++ b/src/doc/tilesets.h
@@ -35,7 +35,7 @@ namespace doc {
 
     tileset_index add(Tileset* tileset);
 
-    Tileset* get(const tileset_index tsi) {
+    Tileset* get(const tileset_index tsi) const {
       if (tsi < size())
         return m_tilesets[tsi];
       else

--- a/src/ui/listbox.cpp
+++ b/src/ui/listbox.cpp
@@ -249,9 +249,11 @@ bool ListBox::onProcessMessage(Message* msg)
           if (dynamic_cast<ui::Separator*>(picked))
             picked = nullptr;
 
-          // If the picked widget is a child of the list, select it
-          if (picked && hasChild(picked))
-            selectChild(picked, msg);
+          // If the picked widget has this list as an ancestor, select the item containing it.
+          if (picked && picked->hasAncestor(this)) {
+            ListItem *it = findParentListItem(picked);
+            selectChild(it, msg);
+          }
         }
       }
       return true;
@@ -461,6 +463,18 @@ int ListBox::advanceIndexThroughVisibleItems(
     }
   }
   return lastVisibleIndex;
+}
+
+ListItem* ListBox::findParentListItem(Widget* descendant)
+{
+  if (descendant->parent() == this)
+    return static_cast<ListItem*>(descendant);
+
+  for (Widget* widget=descendant->parent(); widget; widget=widget->parent()) {
+    return findParentListItem(widget);
+  }
+
+ return nullptr;
 }
 
 } // namespace ui

--- a/src/ui/listbox.h
+++ b/src/ui/listbox.h
@@ -66,6 +66,10 @@ namespace ui {
     // items in case that the user is Ctrl+clicking items several
     // items at the same time.
     std::vector<bool> m_states;
+
+  private:
+    // Finds the parent ListItem that contains the specified descendant.
+    ListItem* findParentListItem(Widget* descendant);
   };
 
 } // namespace ui


### PR DESCRIPTION
Fix #3875

And also adds the possibility of changing the tileset associated with a tilemap layer.