### PR TITLE
Limit windows positions and introduction of `autoscrollbars` flag

### DIFF
--- a/src/ui/fit_bounds.cpp
+++ b/src/ui/fit_bounds.cpp
@@ -132,7 +132,8 @@ void fit_bounds(const Display* parentDisplay,
     frame.y = std::clamp(frame.y, workarea.y, std::max(workarea.y, workarea.y2() - frame.h));
 
     // Set frame bounds directly
-    window->setBounds(gfx::Rect(0, 0, frame.w / scale, frame.h / scale));
+    pos = nativeWindow->pointFromScreen(frame.origin());
+    window->setBounds(gfx::Rect(pos.x, pos.y, frame.w / scale, frame.h / scale));
     window->loadNativeFrame(frame);
 
     if (window->isVisible()) {

--- a/src/ui/window.h
+++ b/src/ui/window.h
@@ -117,7 +117,8 @@ namespace ui {
   private:
     void windowSetPosition(const gfx::Rect& rect);
     int getAction(int x, int y);
-    void limitSize(int* w, int* h);
+    void limitSize(gfx::Size& size);
+    void limitPosition(gfx::Rect& rect);
     void moveWindow(const gfx::Rect& rect, bool use_blit);
 
     Display* m_parentDisplay = nullptr;


### PR DESCRIPTION
This PR fixes #3839 by implementing the following:
- Limit windows positions to avoid hiding title bars when using single-window UI.
- Add a new `autoscrollbars` parameter to the Dialog:show function of Aseprite's Lua API.
- ~~Introduction of the Tab widget into the Lua API.~~
- ~~Introduction of the View widget into the Lua API.~~

EDIT: I will work on the crossed out items in another pull request to reduce the scope of this one.
EDIT2: Created https://github.com/aseprite/aseprite/issues/3991.

