### PR TITLE
Fix undo after inserting tiles in a tilemap containing tiles indexes that were removed from its tileset

### DIFF
--- a/src/doc/algorithm/shrink_bounds.cpp
+++ b/src/doc/algorithm/shrink_bounds.cpp
@@ -262,10 +262,7 @@ bool shrink_bounds_tilemap(const Image* image,
     shrink = true;
     for (v=bounds.y; v<bounds.y+bounds.h; ++v) {
       const tile_t tile = get_pixel_fast<TilemapTraits>(image, u, v);
-      const tile_t tileIndex = tile_geti(tile);
-      const ImageRef tileImg = tileset->get(tileIndex);
-
-      if (tileImg && !is_plain_image(tileImg.get(), refpixel)) {
+      if (tile != refpixel) {
         shrink = false;
         break;
       }
@@ -281,10 +278,7 @@ bool shrink_bounds_tilemap(const Image* image,
     shrink = true;
     for (v=bounds.y; v<bounds.y+bounds.h; ++v) {
       const tile_t tile = get_pixel_fast<TilemapTraits>(image, u, v);
-      const tile_t tileIndex = tile_geti(tile);
-      const ImageRef tileImg = tileset->get(tileIndex);
-
-      if (tileImg && !is_plain_image(tileImg.get(), refpixel)) {
+      if (tile != refpixel) {
         shrink = false;
         break;
       }
@@ -299,10 +293,7 @@ bool shrink_bounds_tilemap(const Image* image,
     shrink = true;
     for (u=bounds.x; u<bounds.x+bounds.w; ++u) {
       const tile_t tile = get_pixel_fast<TilemapTraits>(image, u, v);
-      const tile_t tileIndex = tile_geti(tile);
-      const ImageRef tileImg = tileset->get(tileIndex);
-
-      if (tileImg && !is_plain_image(tileImg.get(), refpixel)) {
+      if (tile != refpixel) {
         shrink = false;
         break;
       }
@@ -318,10 +309,7 @@ bool shrink_bounds_tilemap(const Image* image,
     shrink = true;
     for (u=bounds.x; u<bounds.x+bounds.w; ++u) {
       const tile_t tile = get_pixel_fast<TilemapTraits>(image, u, v);
-      const tile_t tileIndex = tile_geti(tile);
-      const ImageRef tileImg = tileset->get(tileIndex);
-
-      if (tileImg && !is_plain_image(tileImg.get(), refpixel)) {
+      if (tile != refpixel) {
         shrink = false;
         break;
       }


### PR DESCRIPTION
This PR fixes this bug I found:

https://github.com/aseprite/aseprite/assets/5520828/bc2e731c-4939-416c-8298-2c08dcecd05b

Steps to reproduce it:
1) Create a new sprite and add a tilemap layer.
2) Draw some random stuff to generate some tiles.
3) Reduce tileset size.
4) Pick a tile and put it on top of one of the empty indices in the tilemap. This will shrink the tilemap, removing the tiles that are pointing to indexes that are no longer present in the tilemap.
5) Try to undo and you will see that you cannot go back to the initial tilemap you had created.


