### PR TITLE
Fix after dropping a selection via Copy (Selection + Ctrl), handlers are not positioned correctly (fix #3977)

### DIFF
--- a/src/app/ui/editor/pixels_movement.cpp
+++ b/src/app/ui/editor/pixels_movement.cpp
@@ -129,6 +129,7 @@ PixelsMovement::PixelsMovement(
   , m_canHandleFrameChange(false)
   , m_fastMode(false)
   , m_needsRotSpriteRedraw(false)
+  , m_fineModificationApplied(false)
 {
   double cornerThick = (m_site.tilemapMode() == TilemapMode::Tiles) ?
                           CORNER_THICK_FOR_TILEMAP_MODE :
@@ -375,11 +376,15 @@ void PixelsMovement::moveImage(const gfx::PointF& pos, MoveModifier moveModifier
   switch (m_handle) {
 
     case MovePixelsHandle: {
-      double dx = (pos.x - m_catchPos.x);
-      double dy = (pos.y - m_catchPos.y);
-      if ((moveModifier & FineControl) == 0) {
-        if (dx >= 0.0) { dx = std::floor(dx); } else { dx = std::ceil(dx); }
-        if (dy >= 0.0) { dy = std::floor(dy); } else { dy = std::ceil(dy); }
+      double dx, dy;
+
+      if (m_fineModificationApplied) {
+        dx = (pos.x - m_catchPos.x);
+        dy = (pos.y - m_catchPos.y);
+      }
+      else {
+        dx = (std::floor(pos.x) - std::floor(m_catchPos.x));
+        dy = (std::floor(pos.y) - std::floor(m_catchPos.y));
       }
 
       if ((moveModifier & LockAxisMovement) == LockAxisMovement) {
@@ -475,6 +480,8 @@ void PixelsMovement::moveImage(const gfx::PointF& pos, MoveModifier moveModifier
           if (dx >= 0.0) { dx = std::floor(dx); } else { dx = std::ceil(dx); }
           if (dy >= 0.0) { dy = std::floor(dy); } else { dy = std::ceil(dy); }
         }
+        else
+          m_fineModificationApplied = true;
 
         if (m_handle == ScaleNHandle || m_handle == ScaleSHandle) {
           dx = 0.0;
@@ -550,6 +557,7 @@ void PixelsMovement::moveImage(const gfx::PointF& pos, MoveModifier moveModifier
       }
 
       newTransformation.angle(newAngle);
+      m_fineModificationApplied = true;
       break;
     }
 
@@ -694,6 +702,7 @@ void PixelsMovement::moveImage(const gfx::PointF& pos, MoveModifier moveModifier
       double newSkew = std::atan2(AC.x*AC0.y - AC.y*AC0.x, AC * AC0);
       newSkew = std::clamp(newSkew, -PI*85.0/180.0, PI*85.0/180.0);
       newTransformation.skew(newSkew);
+      m_fineModificationApplied = true;
       break;
     }
 

--- a/src/app/ui/editor/pixels_movement.h
+++ b/src/app/ui/editor/pixels_movement.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2021  Igara Studio S.A.
+// Copyright (C) 2019-2023  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -189,6 +189,12 @@ namespace app {
     // avoiding RotSprite on each mouse movement.
     bool m_fastMode;
     bool m_needsRotSpriteRedraw;
+
+    // Flag to disable the fine control when the transformation doesn't
+    // include rotation or skew (so just translating doesn't allow fine
+    // control until we rotate or skew, this might change in the future
+    // if we add a new anti-aliasing rotation algorithm)
+    bool m_fineModificationApplied;
 
     // Commands used in the interaction with the transformed pixels.
     // This is used to re-create the whole interaction on each


### PR DESCRIPTION
This fix disables the fine control when the transformation doesn't
include rotation, skew and/or fine scaling (so just translating doesn't
allow fine control until we rotate/skew/scaling, this might change in
the future if we add a new anti-aliasing rotation algorithm).
Also this fix improves the regular movement of the selected image.
fix #3977