### PR TITLE
Add tab widget to lua api

### DIFF
--- a/src/app/script/engine.cpp
+++ b/src/app/script/engine.cpp
@@ -32,6 +32,7 @@
 #include "doc/anidir.h"
 #include "doc/color_mode.h"
 #include "filters/target.h"
+#include "ui/base.h"
 #include "ui/cursor_type.h"
 #include "ui/mouse_button.h"
 
@@ -465,6 +466,14 @@ Engine::Engine()
   lua_setglobal(L, "FlipType");
   setfield_integer(L, "HORIZONTAL", doc::algorithm::FlipType::FlipHorizontal);
   setfield_integer(L, "VERTICAL",   doc::algorithm::FlipType::FlipVertical);
+  lua_pop(L, 1);
+
+  lua_newtable(L);
+  lua_pushvalue(L, -1);
+  lua_setglobal(L, "Align");
+  setfield_integer(L, "LEFT",   ui::LEFT);
+  setfield_integer(L, "CENTER", ui::CENTER);
+  setfield_integer(L, "RIGHT",  ui::RIGHT);
   lua_pop(L, 1);
 
   // Register classes/prototypes


### PR DESCRIPTION
Fix #3991

This PR adds a new :tab() function to allow adding tabs to the Lua API Dialogs.
Example of use:
```lua
dlg = Dialog()
  :entry   { label="Label 1:" }
  :tab     { text="Tab 1" }
  :check   { text="Some checkbox" }
  :button  { text="Press me"}
  :tab     { text="Tab 2" }
  :entry   { label="Label 2:" }
  :endtabs { selected="Tab 2", align=Align.RIGHT}
  :entry   { label="Label 3:" }
  :check   { text="Another checkbox" }
  :button  { text="Done"}

dlg:show{wait=false, autoscrollbars=true}
```

Some improvements for a next version maybe:
- Add possibility to change the position of the tabs selector to the bottom.
- Add selected flag to each tab? Currently the selected attribute of the endtabs() parameter is used to set the initial selected tab.
- Add onclick event handlers to each tab() or ontabchange event handler to endtabs(). Maybe both?
