### PR TITLE
Fix in Save dialogs, current directory is not last visited (fix #3996)

### DIFF
--- a/src/app/ui/file_selector.cpp
+++ b/src/app/ui/file_selector.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2022  Igara Studio S.A.
+// Copyright (C) 2019-2023  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -411,13 +411,9 @@ bool FileSelector::show(
   fs->refresh();
 
   // We have to find where the user should begin to browse files
-  std::string start_folder_path;
-  if (initialPath.empty()) {
-    start_folder_path = get_initial_path_to_select_filename(initialPath);
-  }
-  else {
-    start_folder_path = base::get_file_path(initialPath);
-  }
+  std::string start_folder_path =
+    base::get_file_path(
+      get_initial_path_to_select_filename(initialPath));
 
   IFileItem* start_folder = fs->getFileItemFromPath(start_folder_path);
   if (!start_folder) {


### PR DESCRIPTION
This regression was added in 1.3rc5.
Every time you wanted to save a new sprite the dialog would start at the root path instead of the last used directory location.

fix #3996 