### PR TITLE
Fix F6 shortcut to show the timeline thumbnail by default (fix #4020)

### DIFF
--- a/src/app/commands/cmd_toggle_timeline_thumbnails.cpp
+++ b/src/app/commands/cmd_toggle_timeline_thumbnails.cpp
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2023  Igara Studio S.A.
 // Copyright (C) 2017  David Capello
 // Copyright (C) 2016  Carlo Caputo
 //
@@ -33,6 +34,11 @@ protected:
 
   void onExecute(Context* context) override {
     DocumentPreferences& docPref = Preferences::instance().document(context->activeDocument());
+
+    // Loading default zoom when activating thumbnail
+    if (docPref.thumbnails.zoom() <= 1 && !docPref.thumbnails.enabled())
+      docPref.thumbnails.zoom(2);
+
     docPref.thumbnails.enabled(!docPref.thumbnails.enabled());
   }
 };


### PR DESCRIPTION
Before this fix, when the thumbnail size was 1, the "Toggle Timeline Thumbnails" command (F6 key) seemed to not work until we changed the timeline thumbnail size to 2 or more.

fix #4020 