### PR TITLE
Avoid showing an alert when asking if the clipboard has a native bitmap

### DIFF
--- a/src/app/util/clipboard_native.cpp
+++ b/src/app/util/clipboard_native.cpp
@@ -84,6 +84,7 @@ void Clipboard::registerNativeFormats()
 
 bool Clipboard::hasNativeBitmap() const
 {
+  InhibitClipErrors ice;
   return clip::has(clip::image_format());
 }
 


### PR DESCRIPTION
Fix #4016
