### PR TITLE
Add constrain angle modifier during polygonal tools (fix #1933)

### DIFF
--- a/src/app/tools/intertwiners.h
+++ b/src/app/tools/intertwiners.h
@@ -1,11 +1,12 @@
 // Aseprite
-// Copyright (C) 2018-2022  Igara Studio S.A.
+// Copyright (C) 2018-2023  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
 
 #include "base/pi.h"
+#include "doc/algo.h"
 #include "doc/layer_tilemap.h"
 
 namespace app {
@@ -143,7 +144,8 @@ public:
       // When this is missing, we have problems previewing the stroke of
       // contour tool, with brush type = kImageBrush with alpha content and
       // with not Pixel Perfect pencil mode.
-      if (loop->getFilled() && !loop->getController()->isFreehand()) {
+      if (loop->getFilled() && !loop->getController()->isFreehand() &&
+          stroke.size() > 2) {
         doPointshapeLine(stroke[stroke.size()-1], stroke[0], loop);
       }
     }
@@ -171,11 +173,14 @@ public:
 
     // Fill content
     auto v = stroke.toXYInts();
+
+    auto algoLine = algo_line_continuous;
+    if (int(loop->getModifiers()) & int(ToolLoopModifiers::kSquareAspect))
+      algoLine = algo_line_perfect;
     doc::algorithm::polygon(
       v.size()/2, &v[0],
-      loop, (AlgoHLine)doPointshapeHline);
+      loop, (AlgoHLine)doPointshapeHline, algoLine);
   }
-
 };
 
 class IntertwineAsRectangles : public Intertwine {

--- a/src/app/ui/editor/editor.cpp
+++ b/src/app/ui/editor/editor.cpp
@@ -1688,6 +1688,13 @@ void Editor::updateToolLoopModifiersIndicators(const bool firstFromMouseDown)
       tools::Controller* controller = (tool ? tool->getController(0): nullptr);
       tools::Ink* ink = (tool ? tool->getInk(0): nullptr);
 
+      if (controller == App::instance()->toolBox()->getControllerById(
+            tools::WellKnownControllers::PointByPoint)) {
+        action = m_customizationDelegate->getPressedKeyAction(KeyContext::ShapeTool);
+        if (int(action & KeyAction::DrawFromCenter))
+          modifiers |= int(tools::ToolLoopModifiers::kSquareAspect);
+      }
+
       // Shape tools modifiers (line, curves, rectangles, etc.)
       if (controller && controller->isTwoPoints()) {
         action = m_customizationDelegate->getPressedKeyAction(KeyContext::ShapeTool);

--- a/src/doc/algorithm/polygon.cpp
+++ b/src/doc/algorithm/polygon.cpp
@@ -1,5 +1,5 @@
 // Aseprite Document Library
-// Copyright (c) 2019-2020 Igara Studio S.A.
+// Copyright (c) 2019-2023 Igara Studio S.A.
 // Copyright (c) 2001-2014 David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -10,7 +10,6 @@
 #endif
 
 #include "base/debug.h"
-#include "doc/algo.h"
 #include "doc/algorithm/polygon.h"
 
 #include "gfx/point.h"
@@ -105,7 +104,9 @@ bool algorithm::createUnion(std::vector<int>& pairs,
   return false;
 }
 
-void algorithm::polygon(int vertices, const int* points, void* data, AlgoHLine proc)
+void algorithm::polygon(int vertices, const int* points,
+                        void* data, AlgoHLine proc,
+                        AlgoLineWithAlgoPixel algoLine)
 {
   if (!vertices)
     return;
@@ -138,12 +139,9 @@ void algorithm::polygon(int vertices, const int* points, void* data, AlgoHLine p
   std::vector<gfx::Point> pts;
   for (int c=0; c < verts.size(); ++c) {
     if (c == verts.size() - 1) {
-      algo_line_continuous(verts[verts.size()-1].x,
-                           verts[verts.size()-1].y,
-                           verts[0].x,
-                           verts[0].y,
-                           (void*)&pts,
-                           (AlgoPixel)&addPointsWithoutDuplicatingLastOne);
+      algoLine(verts[verts.size()-1].x, verts[verts.size()-1].y,
+               verts[0].x, verts[0].y, (void*)&pts,
+               (AlgoPixel)&addPointsWithoutDuplicatingLastOne);
       // Consideration when we want to draw a simple pixel with contour tool
       // dragging the cursor inside of a pixel (in this case pts contains
       // just one element, which want to preserve).
@@ -153,12 +151,9 @@ void algorithm::polygon(int vertices, const int* points, void* data, AlgoHLine p
         pts.pop_back();
     }
     else {
-      algo_line_continuous(verts[c].x,
-                           verts[c].y,
-                           verts[c+1].x,
-                           verts[c+1].y,
-                           (void*)&pts,
-                           (AlgoPixel)&addPointsWithoutDuplicatingLastOne);
+      algoLine(verts[c].x, verts[c].y,
+               verts[c+1].x, verts[c+1].y,
+               (void*)&pts, (AlgoPixel)&addPointsWithoutDuplicatingLastOne);
     }
   }
 

--- a/src/doc/algorithm/polygon.h
+++ b/src/doc/algorithm/polygon.h
@@ -1,4 +1,5 @@
 // Aseprite Document Library
+// Copyright (c) 2023 Igara Studio S.A.
 // Copyright (c) 2001-2014 David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -8,6 +9,7 @@
 #define DOC_ALGORITHM_POLYGON_H_INCLUDED
 #pragma once
 
+#include "doc/algo.h"
 #include "doc/algorithm/hline.h"
 #include "gfx/fwd.h"
 
@@ -16,7 +18,9 @@
 namespace doc {
   namespace algorithm {
 
-    void polygon(int vertices, const int* points, void* data, AlgoHLine proc);
+    void polygon(int vertices, const int* points,
+                 void* data, AlgoHLine proc,
+                 AlgoLineWithAlgoPixel algoLine = algo_line_continuous);
     bool createUnion(std::vector<int>& pairs, const int x, int& ints);
   }
 }


### PR DESCRIPTION
First approach.

It may be better to add the algorithm used at each new point of a stroke, to allow mixed strokes to be drawn with or without constraint. I need an opinion on this.

The "Ctrl" key is better than "Shift", because "Shift" is already used for the Polygonal Lasso tool.

fix #1933