### PR TITLE
Improve script engine's exception handling

### DIFF
--- a/src/app/script/docobj.h
+++ b/src/app/script/docobj.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018  Igara Studio S.A.
+// Copyright (C) 2018-2023  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -10,6 +10,7 @@
 
 #include "app/script/luacpp.h"
 #include "doc/object.h"
+#include "fmt/format.h"
 
 namespace app {
 namespace script {
@@ -41,11 +42,10 @@ template <typename T> T* check_docobj(lua_State* L, T* obj) {
   if (obj)
     return obj;
   else {
-    luaL_traceback(L, L, nullptr, 1);
+    luaL_traceback(L, L, fmt::format("Tried to access a deleted '{}'",
+                   get_mtname<T>()).c_str(), 1);
     const char* traceback = lua_tostring(L, -1);
-    luaL_error(L, "%s: Tried to access a deleted '%s'",
-               traceback ? traceback: "",
-               get_mtname<T>());
+    luaL_error(L, traceback ? traceback: "");
     ASSERT(false);              // unreachable code
     return nullptr;
   }

--- a/src/app/script/engine.cpp
+++ b/src/app/script/engine.cpp
@@ -32,6 +32,7 @@
 #include "doc/anidir.h"
 #include "doc/color_mode.h"
 #include "filters/target.h"
+#include "fmt/format.h"
 #include "ui/base.h"
 #include "ui/cursor_type.h"
 #include "ui/mouse_button.h"
@@ -584,7 +585,7 @@ bool Engine::evalCode(const std::string& code,
     lua_pop(L, 1);
   }
   catch (const std::exception& ex) {
-    onConsoleError(ex.what());
+    handleException(ex);
     ok = false;
     m_returnCode = -1;
   }
@@ -592,6 +593,18 @@ bool Engine::evalCode(const std::string& code,
   // Collect script garbage.
   lua_gc(L, LUA_GCCOLLECT);
   return ok;
+}
+
+void Engine::handleException(const std::exception& ex)
+{
+  luaL_where(L, 1);
+  const char* where = lua_tostring(L, -1);
+  luaL_traceback(L, L, ex.what(), 1);
+  const char* traceback = lua_tostring(L, -1);
+  std::string msg(fmt::format("{}{}", where, traceback));
+  lua_pop(L, 2);
+
+  onConsoleError(msg.c_str());
 }
 
 bool Engine::evalFile(const std::string& filename,

--- a/src/app/script/engine.h
+++ b/src/app/script/engine.h
@@ -105,6 +105,8 @@ namespace app {
     bool evalUserFile(const std::string& filename,
                       const Params& params = Params());
 
+    void handleException(const std::exception& ex);
+
     void consolePrint(const char* text) {
       onConsolePrint(text);
     }


### PR DESCRIPTION
This PR contains some changes on how we were treating unhandled exceptions:
1) Removes the try..catch clauses from the signal handler to let the engine's try..catch block to take care of any unhandled exception.
2) Outputs stack trace information for all unhandled exceptions. For instance, let's say some Lua script called an API function that for any reason threw an std::exception from its C++ implementation with the message "Some error occurred", then on the console the output would read:
   Before this change:
   ```
   Some error occurred
   ```
   After this change:
   ```
   /path/to/script.lua:99: Some error occurred
   stack traceback:
    /path/to/script.lua:99: in main chunk
   ```

3) Fixes how luaL_traceback and luaL_error were receiving their message parameters to show the error message at the top of the stack trace when trying to access a deleted object. 
   Before this change:
   ```
   /path/to/script.lua:99: stack traceback:
    /path/to/script.lua:99: in main chunk: Tried to access a deleted 'doc::Sprite'
   ```
   After this change:
   ```
   /path/to/script.lua:99: Tried to access a deleted 'doc::Sprite'
   stack traceback:
    /path/to/script.lua:99: in main chunk
   ```
