### PR TITLE
Respect slice keys frame number on ase file format (fix #4062)

### DIFF
--- a/src/app/file/ase_format.cpp
+++ b/src/app/file/ase_format.cpp
@@ -1252,7 +1252,8 @@ static void ase_file_write_slice_chunk(FILE* f, dio::AsepriteFrameHeader* frame_
 {
   ChunkWriter chunk(f, frame_header, ASE_FILE_CHUNK_SLICE);
 
-  auto range = slice->range(fromFrame, toFrame);
+  frame_t firstFromFrame = slice->empty() ? fromFrame : slice->fromFrame();
+  auto range = slice->range(firstFromFrame, toFrame);
   ASSERT(!range.empty());
 
   int flags = 0;
@@ -1268,10 +1269,10 @@ static void ase_file_write_slice_chunk(FILE* f, dio::AsepriteFrameHeader* frame_
   fputl(0, f);                             // 4 bytes reserved
   ase_file_write_string(f, slice->name()); // slice name
 
-  frame_t frame = fromFrame;
+  frame_t frame = firstFromFrame;
   const SliceKey* oldKey = nullptr;
   for (auto key : range) {
-    if (frame == fromFrame || key != oldKey) {
+    if (frame == firstFromFrame || key != oldKey) {
       fputl(frame, f);
       fputl((int32_t)(key ? key->bounds().x: 0), f);
       fputl((int32_t)(key ? key->bounds().y: 0), f);


### PR DESCRIPTION
When saving slices on the ASE file format, the starting frame of the slice was not respected and always try to save the slice on frame 0 (`fromFrame`). Now it takes the fromFrame from the slice if the keys are not empty.
Fixes #4062.

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing
