### PR TITLE
Fixed unnecessary X dimension scrollbar for dithering selector (fix #4001)

### DIFF
--- a/src/app/ui/dithering_selector.cpp
+++ b/src/app/ui/dithering_selector.cpp
@@ -194,8 +194,11 @@ DitheringSelector::DitheringSelector(Type type)
 void DitheringSelector::onInitTheme(ui::InitThemeEvent& ev)
 {
   ComboBox::onInitTheme(ev);
-  if (getItem(0))
-    setSizeHint(getItem(0)->sizeHint());
+  if (getItem(0)){
+    gfx::Size selectorSz = getItem(0)->sizeHint();
+    selectorSz.w += 8 * guiscale(); // Added offset to prevent unnecessary scrollbar in X dimension
+    setSizeHint(selectorSz);
+  }
 }
 
 void DitheringSelector::setSelectedItemByName(const std::string& name)
@@ -264,7 +267,9 @@ void DitheringSelector::regenerate(int selectedItemIndex)
   }
   selectedItemIndex = std::clamp(selectedItemIndex, 0, std::max(0, getItemCount()-1));
   setSelectedItemIndex(selectedItemIndex);
-  setSizeHint(getItem(selectedItemIndex)->sizeHint());
+  gfx::Size selectorSz = getItem(selectedItemIndex)->sizeHint();
+  selectorSz.w += 8 * guiscale(); // Added offset to prevent unnecessary scrollbar in X dimension
+  setSizeHint(selectorSz);
 }
 
 render::DitheringAlgorithm DitheringSelector::ditheringAlgorithm()


### PR DESCRIPTION


Added offset to dithering selector dropdown width to avoid X dimension scrollbar obscuring the bottom of the dropdown. This also removes the need for a vertical scrollbar for the generic number of dithering options. Related to Issue #4001
This contribution is done as a part of a university project, though I do hope it will be of use to you too :)

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the Individual Contributor License Agreement V4.0. -->
<!-- If you're a first-time contributor, please sign the CLA
     as indicated in https://github.com/igarastudio/cla#signing
     and acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing
