### PR TITLE
Fix: Key event not being converted properly if there's a modifier

### DIFF
--- a/src/ui/accelerator.cpp
+++ b/src/ui/accelerator.cpp
@@ -330,6 +330,7 @@ std::string Accelerator::toString() const
 bool Accelerator::isPressed(KeyModifiers modifiers, KeyScancode scancode, int unicodeChar) const
 {
   return ((scancode && *this == Accelerator(modifiers, scancode, 0)) ||
+          (scancode && *this == Accelerator(kKeyNoneModifier, scancode, 0)) ||
           (unicodeChar && *this == Accelerator(modifiers, kKeyNil, unicodeChar)));
 }
 


### PR DESCRIPTION
Currently, if we map a key to LMB and we try to press for example shift key - which adds a modifier on top of the mapped key to LMB, then if the user stops pressing the key which is mapped to LMB - Aseprite won't register it as kMouseUpMessage event, and if we try to draw a rectangle with aspect ratio (by pressing shift for example), and then we stop holding the mapped key to LMB, drawing will not stop.

This is because Accelerator class doesn't recognize the mapped key with the shift modifier the same as if it was pressed without the shift modifier. For example, if the key mapped to LMB is 'V', then if we use Rectangle Tool, and then press Shift + V and then stop holding V - it should stop drawing current rectangle, since we stopped holding the key mapped to LMB. But this doesn't happen, because of the key event coming with a modifier. Accelerator class sees the event as Shift+V, not just 'V' as the key which is mapped to LMB, thus it is not converting it to "MouseUp" event in doc_view.cpp:onProcessMessage method, and because of that drawing is not stopping.

The solution for that is to simply add a second check to Accelerator::isPressed method, it simply compares currently checked object to the scancode without the modifier, allowing for the key event to be converted.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the Individual Contributor License Agreement V4.0. -->
<!-- If you're a first-time contributor, please sign the CLA
     as indicated in https://github.com/igarastudio/cla#signing
     and acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing
