### PR TITLE
Prevent crash when moving pixels from tilemap with inexistent tiles

### DIFF
--- a/src/app/util/cel_ops.cpp
+++ b/src/app/util/cel_ops.cpp
@@ -543,6 +543,9 @@ void modify_tilemap_cel_region(
       const doc::tile_t t = newTilemap->getPixel(u, v);
       const doc::tile_index ti = (t != doc::notile ? doc::tile_geti(t): doc::notile);
       const doc::ImageRef existentTileImage = tileset->get(ti);
+      if (!existentTileImage) {
+        continue;
+      }
 
       const gfx::Rect tileInCanvasRc(grid.tileToCanvas(tilePt), tileSize);
       ImageRef tileImage(getTileImage(existentTileImage, tileInCanvasRc));


### PR DESCRIPTION
Prevent crash when in Auto or Stack mode the user tries to move pixels from a tilemap with inexistent tiles. 
Fix #4071
