### PR TITLE
Fix numerical errors in gradient tool

### DIFF
--- a/src/render/gradient.cpp
+++ b/src/render/gradient.cpp
@@ -79,15 +79,15 @@ void render_rgba_linear_gradient(
     c1 = (c0 & doc::rgba_rgb_mask);
   }
 
-  const double r0 = double(doc::rgba_getr(c0)) / 255.0;
-  const double g0 = double(doc::rgba_getg(c0)) / 255.0;
-  const double b0 = double(doc::rgba_getb(c0)) / 255.0;
-  const double a0 = double(doc::rgba_geta(c0)) / 255.0;
+  const uint8_t r0 = doc::rgba_getr(c0);
+  const uint8_t g0 = doc::rgba_getg(c0);
+  const uint8_t b0 = doc::rgba_getb(c0);
+  const uint8_t a0 = doc::rgba_geta(c0);
 
-  const double r1 = double(doc::rgba_getr(c1)) / 255.0;
-  const double g1 = double(doc::rgba_getg(c1)) / 255.0;
-  const double b1 = double(doc::rgba_getb(c1)) / 255.0;
-  const double a1 = double(doc::rgba_geta(c1)) / 255.0;
+  const uint8_t r1 = doc::rgba_getr(c1);
+  const uint8_t g1 = doc::rgba_getg(c1);
+  const uint8_t b1 = doc::rgba_getb(c1);
+  const uint8_t a1 = doc::rgba_geta(c1);
 
   doc::LockImageBits<doc::RgbTraits> bits(img);
   auto it = bits.begin();
@@ -106,10 +106,10 @@ void render_rgba_linear_gradient(
         if (f < 0.0) c = c0;
         else if (f > 1.0) c = c1;
         else {
-          c = doc::rgba(int(255.0 * (r0 + f*(r1-r0))),
-                        int(255.0 * (g0 + f*(g1-g0))),
-                        int(255.0 * (b0 + f*(b1-b0))),
-                        int(255.0 * (a0 + f*(a1-a0))));
+          c = doc::rgba(int(r0 + f*(r1-r0) + 1e-7),
+                        int(g0 + f*(g1-g0) + 1e-7),
+                        int(b0 + f*(b1-b0) + 1e-7),
+                        int(a0 + f*(a1-a0) + 1e-7));
         }
 
         *it = c;
@@ -170,15 +170,15 @@ void render_rgba_radial_gradient(
     c1 = (c0 & doc::rgba_rgb_mask);
   }
 
-  const double r0 = double(doc::rgba_getr(c0)) / 255.0;
-  const double g0 = double(doc::rgba_getg(c0)) / 255.0;
-  const double b0 = double(doc::rgba_getb(c0)) / 255.0;
-  const double a0 = double(doc::rgba_geta(c0)) / 255.0;
+  const uint8_t r0 = doc::rgba_getr(c0);
+  const uint8_t g0 = doc::rgba_getg(c0);
+  const uint8_t b0 = doc::rgba_getb(c0);
+  const uint8_t a0 = doc::rgba_geta(c0);
 
-  const double r1 = double(doc::rgba_getr(c1)) / 255.0;
-  const double g1 = double(doc::rgba_getg(c1)) / 255.0;
-  const double b1 = double(doc::rgba_getb(c1)) / 255.0;
-  const double a1 = double(doc::rgba_geta(c1)) / 255.0;
+  const uint8_t r1 = doc::rgba_getr(c1);
+  const uint8_t g1 = doc::rgba_getg(c1);
+  const uint8_t b1 = doc::rgba_getb(c1);
+  const uint8_t a1 = doc::rgba_geta(c1);
 
   doc::LockImageBits<doc::RgbTraits> bits(img);
   auto it = bits.begin();
@@ -199,10 +199,10 @@ void render_rgba_radial_gradient(
         if (f < 0.0) c = c0;
         else if (f > 1.0) c = c1;
         else {
-          c = doc::rgba(int(255.0 * (r0 + f*(r1-r0))),
-                        int(255.0 * (g0 + f*(g1-g0))),
-                        int(255.0 * (b0 + f*(b1-b0))),
-                        int(255.0 * (a0 + f*(a1-a0))));
+          c = doc::rgba(int(r0 + f*(r1-r0) + 1e-7),
+                        int(g0 + f*(g1-g0) + 1e-7),
+                        int(b0 + f*(b1-b0) + 1e-7),
+                        int(a0 + f*(a1-a0) + 1e-7));
         }
 
         *it = c;


### PR DESCRIPTION
<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the Individual Contributor License Agreement V4.0. -->
<!-- If you're a first-time contributor, please sign the CLA
     as indicated in https://github.com/igarastudio/cla#signing
     and acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing

This PR aims to fix numerical issues with the gradient tool. To reproduce the issue, do the following:

1. Create a new sprite with width 57 and height 1.
2. Select #00e000 as primary colour and #000000 as secondary.
3. Select the gradient tool and drag starting from (57, 0) and ending at (0, 0)

Expectation: the green value of each pixel is equal to four times its x value.
Reality: some pixels have a green value equal to 4x-1

This is caused by numerical errors giving a green value of, say, 63.9999999999999 which, when cast to int, becomes 63.

I have done two things to try to fix this and applied my changes to both the linear and radial gradients.

1. Remove the unnecessary dividing, then later multiplying, by 255 and keep the colour values as ints.
2. Add a small value (1e7) to the calculated values to avoid errors caused by the division in `double f = (q * w) / wmag`

While I'm sure that almost no one else cares about such small errors in the produced colours, they have been very annoying for me as I have been using aseprite to generate position maps (images where RGB correspond to XYZ coordinates in 3D space). The gradient tool should be very useful for generating sequences of values but isn't due to this issue.
