### PR TITLE
Patch mnemonic processing to accept strings with a single '&' char

### DIFF
--- a/src/ui/widget.cpp
+++ b/src/ui/widget.cpp
@@ -1529,6 +1529,9 @@ void Widget::processMnemonicFromText(const int escapeChar,
       if (!chr) {
         break;    // Ill-formed string (it ends with escape character)
       }
+      else if (chr == ' ') {           // escape char is followed by a space,
+        newText.push_back(escapeChar); // leave it its place then.
+      }
       else if (chr != escapeChar) {
         setMnemonic(chr, requireModifiers);
       }


### PR DESCRIPTION
With this change we can use strings that contains single '&' chars when they are followed by a space. 
Useful when one has to use an existing en.ini string that doesn't have their '&' escaped because they were used in a context without mnemonics enabled.
