### PR TITLE
Unified menu indication text, add double quotation marks

### DIFF
--- a/data/strings/en.ini
+++ b/data/strings/en.ini
@@ -1058,7 +1058,7 @@ update_link = Update Aseprite
 [inks]
 simple_ink = Simple Ink
 alpha_compositing = Alpha Compositing
-copy_color = Copy Alpha+Color
+copy_color = Copy Alpha + Color
 lock_alpha = Lock Alpha
 shading = Shading
 

--- a/data/strings/en.ini
+++ b/data/strings/en.ini
@@ -1564,7 +1564,7 @@ keep_closed_sprite_on_memory = Keep closed sprite on memory for
 keep_closed_sprite_on_memory_tooltip = <<<END
 When you close a sprite, it will be kept on memory just in case if you
 have closed the sprite by mistake, so you can "undo" the close action
-using "File > Reopen Closed File" menu option.
+using "File > Open Recent > Reopen Closed File" menu option.
 END
 default_extension_for = Default extension for:
 save_default_extension = File > Save:

--- a/data/strings/en.ini
+++ b/data/strings/en.ini
@@ -832,7 +832,7 @@ borders_tooltip = Add or trim borders from each sprite in the sprite sheet
 expand_all_sections_tooltip = <<<END
 Show all sections
 
-Use Ctrl+click to display multiple sections at the same time
+Use Ctrl + Click to display multiple sections at the same time
 END
 layout = Layout
 layout_tooltip = Arrangement of sprites in the final result
@@ -1591,7 +1591,7 @@ auto_fit = Auto-fit on screen when a sprite is opened
 straight_line_preview = Preview straight line immediately on Pencil tool
 straight_line_preview_tooltip = <<<END
 On Pencil tool you can draw straight lines
-using Shift+click, with this option checked
+using Shift + Click, with this option checked
 you will see the preview immediately when
 the Shift key is pressed.
 END
@@ -1673,7 +1673,7 @@ select_on_click_tooltip = <<<END
 Enable the selected range of layers/frames/cels
 when we press the mouse button.
 END
-select_on_click_with_key = Select on Click + Shift
+select_on_click_with_key = Select on Shift + Click
 select_on_click_with_key_tooltip = <<<END
 Enable the selected range of layers/frames/cels
 when we press the mouse button with the Shift key.

--- a/data/strings/en.ini
+++ b/data/strings/en.ini
@@ -50,7 +50,7 @@ not_enough_transform_memory = Not enough memory to transform the selection
 not_enough_rotsprite_memory = Not enough memory for RotSprite
 cannot_modify_readonly_sprite = <<<END
 Cannot modify a read-only sprite.
-Use File > Save menu for more information.
+Use "File > Save" menu for more information.
 END
 
 [alerts]
@@ -78,7 +78,7 @@ END
 cannot_file_overwrite_on_export = <<<END
 Overwrite Warning
 <<You cannot Export with the same name (overwrite the original file).
-<<Use File > Save As menu option in that case.
+<<Use "File > Save As" menu option in that case.
 ||&OK
 END
 cannot_open_file = Problem<<Cannot open file:<<{0}||&OK
@@ -1618,9 +1618,9 @@ after deleting it.
 END
 auto_show_selection_edges = Show selection edges automatically when the selection is modified
 auto_show_selection_edges_tooltip = <<<END
-When checked, the View > Show > Selection Edges option will be enabled
+When checked, the "View > Show > Selection Edges" option will be enabled
 each time we modify the selection. Uncheck this in case that you want
-to keep selection edges hidden when View > Show > Selection Edges
+to keep selection edges hidden when "View > Show > Selection Edges"
 option is disabled, e.g. to avoid visual noise or performance issues.
 END
 move_edges = Allow moving selection edges
@@ -1750,7 +1750,7 @@ open_sequence_alert_no = No
 open_sequence_alert_yes = Yes
 file_format_doesnt_support_alert = Show warning when saving a file with unsupported features
 export_animation_in_sequence_alert = Show warning when saving an animation as a sequence of static images
-overwrite_files_on_export_alert = Show warning when overwriting files on File > Export
+overwrite_files_on_export_alert = Show warning when overwriting files on "File > Export"
 overwrite_files_on_export_sprite_sheet_alert = Show warning when overwriting files on Export Sprite Sheet
 delete_tilemap_delete_unused_tileset_alert = Show warning when deleting a tilemap will delete its unused tileset
 image_format_alerts = Show options when saving files:


### PR DESCRIPTION
Currently, there are two situations:

One is:
 https://github.com/aseprite/aseprite/blob/046b68061af92cd9918f98305923e3efa97df47a/data/strings/en.ini#L53
The other is:
https://github.com/aseprite/aseprite/blob/046b68061af92cd9918f98305923e3efa97df47a/data/strings/en.ini#L1053

The second seems more clear.


I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing
