### PR TITLE
Fix recovering of old crashed sessions having sprites containing slices

### DIFF
--- a/src/app/crash/read_document.cpp
+++ b/src/app/crash/read_document.cpp
@@ -521,7 +521,7 @@ private:
   }
 
   Slice* readSlice(std::ifstream& s) {
-    return read_slice(s, false);
+    return read_slice(s, false, m_docFormatVer);
   }
 
   // Fix issues that the restoration process could produce.


### PR DESCRIPTION
Without this fix a recovering thread could get stuck in an infinite loop when reading the slices of a sprite created with a doc format version lesser than 2.

This is something I missed when I did https://github.com/aseprite/aseprite/pull/3752

So this issue happens when recovering a sprite from a crashed session in Aseprite v1.3-rc2 (or later) that:
1. Was created in an Aseprite version prior to v1.3-rc2.
2. Contains slices.

