### PR TITLE
Fix several sync issues locking the sprite correctly on each script Tx

### DIFF
--- a/src/app/commands/cmd_add_color.cpp
+++ b/src/app/commands/cmd_add_color.cpp
@@ -130,7 +130,7 @@ void AddColorCommand::onExecute(Context* ctx)
     if (document) {
       frame_t frame = writer.frame();
 
-      Tx tx(writer.context(), friendlyName(), ModifyDocument);
+      Tx tx(writer, friendlyName(), ModifyDocument);
       tx(new cmd::SetPalette(sprite, frame, newPalette.get()));
       tx.commit();
     }

--- a/src/app/commands/cmd_background_from_layer.cpp
+++ b/src/app/commands/cmd_background_from_layer.cpp
@@ -55,7 +55,7 @@ void BackgroundFromLayerCommand::onExecute(Context* context)
   Doc* document(writer.document());
 
   {
-    Tx tx(writer.context(), friendlyName());
+    Tx tx(writer, friendlyName());
     tx(new cmd::BackgroundFromLayer(static_cast<LayerImage*>(writer.layer())));
     tx.commit();
   }

--- a/src/app/commands/cmd_canvas_size.cpp
+++ b/src/app/commands/cmd_canvas_size.cpp
@@ -385,7 +385,7 @@ void CanvasSizeCommand::onExecute(Context* context)
     ContextWriter writer(reader);
     Doc* doc = writer.document();
     Sprite* sprite = writer.sprite();
-    Tx tx(writer.context(), "Canvas Size");
+    Tx tx(writer, "Canvas Size");
     DocApi api = doc->getApi(tx);
     api.cropSprite(sprite, bounds, params.trimOutside());
     tx.commit();

--- a/src/app/commands/cmd_cel_opacity.cpp
+++ b/src/app/commands/cmd_cel_opacity.cpp
@@ -73,7 +73,7 @@ void CelOpacityCommand::onExecute(Context* context)
     return;
 
   {
-    Tx tx(writer.context(), "Set Cel Opacity");
+    Tx tx(writer, "Set Cel Opacity");
 
     // TODO the range of selected cels should be in app::Site.
     DocRange range;

--- a/src/app/commands/cmd_cel_properties.cpp
+++ b/src/app/commands/cmd_cel_properties.cpp
@@ -218,7 +218,7 @@ private:
                                  newUserData != m_cel->data()->userData()))) {
       try {
         ContextWriter writer(UIContext::instance());
-        Tx tx(writer.context(), "Set Cel Properties");
+        Tx tx(writer, "Set Cel Properties");
 
         DocRange range;
         if (m_range.enabled()) {

--- a/src/app/commands/cmd_clear_cel.cpp
+++ b/src/app/commands/cmd_clear_cel.cpp
@@ -48,7 +48,7 @@ void ClearCelCommand::onExecute(Context* context)
   Doc* document(writer.document());
   bool nonEditableLayers = false;
   {
-    Tx tx(writer.context(), "Clear Cel");
+    Tx tx(writer, "Clear Cel");
 
     const Site* site = writer.site();
     if (site->inTimeline() &&

--- a/src/app/commands/cmd_crop.cpp
+++ b/src/app/commands/cmd_crop.cpp
@@ -72,7 +72,7 @@ void CropSpriteCommand::onExecute(Context* context)
     bounds = m_bounds;
 
   {
-    Tx tx(writer.context(), "Sprite Crop");
+    Tx tx(writer, "Sprite Crop");
     document->getApi(tx).cropSprite(sprite, bounds);
     tx.commit();
   }
@@ -119,7 +119,7 @@ void AutocropSpriteCommand::onExecute(Context* context)
   Doc* document(writer.document());
   Sprite* sprite(writer.sprite());
   {
-    Tx tx(writer.context(), onGetFriendlyName());
+    Tx tx(writer, onGetFriendlyName());
     document->getApi(tx).trimSprite(sprite, m_byGrid);
     tx.commit();
   }

--- a/src/app/commands/cmd_deselect_mask.cpp
+++ b/src/app/commands/cmd_deselect_mask.cpp
@@ -44,7 +44,7 @@ void DeselectMaskCommand::onExecute(Context* context)
   ContextWriter writer(context);
   Doc* document(writer.document());
   {
-    Tx tx(writer.context(), "Deselect", DoesntModifyDocument);
+    Tx tx(writer, "Deselect", DoesntModifyDocument);
     tx(new cmd::DeselectMask(document));
     tx.commit();
   }

--- a/src/app/commands/cmd_duplicate_layer.cpp
+++ b/src/app/commands/cmd_duplicate_layer.cpp
@@ -49,7 +49,7 @@ void DuplicateLayerCommand::onExecute(Context* context)
   Doc* document = writer.document();
 
   {
-    Tx tx(writer.context(), "Layer Duplication");
+    Tx tx(writer, "Layer Duplication");
     LayerImage* sourceLayer = static_cast<LayerImage*>(writer.layer());
     DocApi api = document->getApi(tx);
     api.duplicateLayerAfter(sourceLayer,

--- a/src/app/commands/cmd_fill_and_stroke.cpp
+++ b/src/app/commands/cmd_fill_and_stroke.cpp
@@ -81,7 +81,7 @@ void FillCommand::onExecute(Context* ctx)
     color = color_utils::color_for_layer(pref.colorBar.fgColor(), layer);
 
   {
-    Tx tx(writer.context(), "Fill Selection with Foreground Color");
+    Tx tx(writer, "Fill Selection with Foreground Color");
     {
       ExpandCelCanvas expand(
         site, layer,

--- a/src/app/commands/cmd_flatten_layers.cpp
+++ b/src/app/commands/cmd_flatten_layers.cpp
@@ -57,7 +57,7 @@ void FlattenLayersCommand::onExecute(Context* context)
   ContextWriter writer(context);
   Sprite* sprite = writer.sprite();
   {
-    Tx tx(writer.context(), "Flatten Layers");
+    Tx tx(writer, "Flatten Layers");
 
     // TODO the range of selected layers should be in app::Site.
     DocRange range;

--- a/src/app/commands/cmd_flip.cpp
+++ b/src/app/commands/cmd_flip.cpp
@@ -120,7 +120,7 @@ void FlipCommand::onExecute(Context* ctx)
   ContextWriter writer(ctx);
   Doc* document = writer.document();
   Sprite* sprite = writer.sprite();
-  Tx tx(ctx, friendlyName());
+  Tx tx(writer, friendlyName());
   DocApi api = document->getApi(tx);
 
   Mask* mask = document->mask();

--- a/src/app/commands/cmd_frame_properties.cpp
+++ b/src/app/commands/cmd_frame_properties.cpp
@@ -127,7 +127,7 @@ void FramePropertiesCommand::onExecute(Context* context)
     int newMsecs = window.frlen()->textInt();
 
     ContextWriter writer(reader);
-    Tx tx(writer.context(), "Frame Duration");
+    Tx tx(writer, "Frame Duration");
     DocApi api = writer.document()->getApi(tx);
 
     for (frame_t frame : selFrames)

--- a/src/app/commands/cmd_frame_tag_properties.cpp
+++ b/src/app/commands/cmd_frame_tag_properties.cpp
@@ -91,7 +91,7 @@ void FrameTagPropertiesCommand::onExecute(Context* context)
     return;
 
   ContextWriter writer(reader);
-  Tx tx(writer.context(), friendlyName());
+  Tx tx(writer, friendlyName());
   Tag* tag = const_cast<Tag*>(foundTag);
 
   std::string name = window.nameValue();

--- a/src/app/commands/cmd_grid.cpp
+++ b/src/app/commands/cmd_grid.cpp
@@ -73,7 +73,7 @@ protected:
     const Mask* mask = doc->mask();
     gfx::Rect newGrid = mask->bounds();
 
-    Tx tx(writer.context(), friendlyName(), ModifyDocument);
+    Tx tx(writer, friendlyName(), ModifyDocument);
     tx(new cmd::SetGridBounds(writer.sprite(), newGrid));
     tx.commit();
 
@@ -125,7 +125,7 @@ void GridSettingsCommand::onExecute(Context* context)
     bounds.h = std::max(bounds.h, 1);
 
     ContextWriter writer(context);
-    Tx tx(context, friendlyName(), ModifyDocument);
+    Tx tx(writer, friendlyName(), ModifyDocument);
     tx(new cmd::SetGridBounds(site.sprite(), bounds));
     tx.commit();
 

--- a/src/app/commands/cmd_import_sprite_sheet.cpp
+++ b/src/app/commands/cmd_import_sprite_sheet.cpp
@@ -512,8 +512,9 @@ void ImportSpriteSheetCommand::onExecute(Context* context)
     // The following steps modify the sprite, so we wrap all
     // operations in a undo-transaction.
     ContextWriter writer(context);
-    Tx tx(
-      writer.context(), Strings::import_sprite_sheet_title(), ModifyDocument);
+    Tx tx(writer,
+          Strings::import_sprite_sheet_title(),
+          ModifyDocument);
     DocApi api = document->getApi(tx);
 
     // Add the layer in the sprite.

--- a/src/app/commands/cmd_invert_mask.cpp
+++ b/src/app/commands/cmd_invert_mask.cpp
@@ -93,7 +93,7 @@ void InvertMaskCommand::onExecute(Context* context)
     mask->intersect(sprite->bounds());
 
     // Set the new mask
-    Tx tx(writer.context(), "Mask Invert", DoesntModifyDocument);
+    Tx tx(writer, "Mask Invert", DoesntModifyDocument);
     tx(new cmd::SetMask(document, mask.get()));
     tx.commit();
 

--- a/src/app/commands/cmd_layer_from_background.cpp
+++ b/src/app/commands/cmd_layer_from_background.cpp
@@ -51,7 +51,7 @@ void LayerFromBackgroundCommand::onExecute(Context* context)
   ContextWriter writer(context);
   Doc* document(writer.document());
   {
-    Tx tx(writer.context(), friendlyName());
+    Tx tx(writer, friendlyName());
     tx(new cmd::LayerFromBackground(writer.layer()));
     tx.commit();
   }

--- a/src/app/commands/cmd_layer_opacity.cpp
+++ b/src/app/commands/cmd_layer_opacity.cpp
@@ -69,7 +69,7 @@ void LayerOpacityCommand::onExecute(Context* context)
     return;
 
   {
-    Tx tx(writer.context(), "Set Layer Opacity");
+    Tx tx(writer, "Set Layer Opacity");
 
     // TODO the range of selected frames should be in app::Site.
     SelectedLayers selLayers;

--- a/src/app/commands/cmd_layer_properties.cpp
+++ b/src/app/commands/cmd_layer_properties.cpp
@@ -265,7 +265,7 @@ private:
                                      newBlendMode != static_cast<LayerImage*>(m_layer)->blendMode()))))) {
       try {
         ContextWriter writer(UIContext::instance());
-        Tx tx(writer.context(), "Set Layer Properties");
+        Tx tx(writer, "Set Layer Properties");
 
         DocRange range;
         if (m_range.enabled())
@@ -395,7 +395,7 @@ private:
           tileset->matchFlags() != tilesetInfo.matchFlags ||
           tilesetInfo.tsi != tilemap->tilesetIndex()) {
         ContextWriter writer(UIContext::instance());
-        Tx tx(writer.context(), "Set Tileset Properties");
+        Tx tx(writer, "Set Tileset Properties");
         // User changed tilemap's tileset
         if (tilesetInfo.tsi != tilemap->tilesetIndex()) {
           tileset = tilemap->sprite()->tilesets()->get(tilesetInfo.tsi);

--- a/src/app/commands/cmd_link_cels.cpp
+++ b/src/app/commands/cmd_link_cels.cpp
@@ -57,7 +57,7 @@ void LinkCelsCommand::onExecute(Context* context)
     if (!site.inTimeline())
       return;
 
-    Tx tx(writer.context(), friendlyName());
+    Tx tx(writer, friendlyName());
 
     for (Layer* layer : site.selectedLayers()) {
       if (!layer->isImage())

--- a/src/app/commands/cmd_load_mask.cpp
+++ b/src/app/commands/cmd_load_mask.cpp
@@ -77,7 +77,7 @@ void LoadMaskCommand::onExecute(Context* context)
   {
     ContextWriter writer(reader);
     Doc* document = writer.document();
-    Tx tx(writer.context(),
+    Tx tx(writer,
           Strings::load_selection_title(),
           DoesntModifyDocument);
     tx(new cmd::SetMask(document, mask.get()));

--- a/src/app/commands/cmd_mask_all.cpp
+++ b/src/app/commands/cmd_mask_all.cpp
@@ -49,7 +49,7 @@ void MaskAllCommand::onExecute(Context* context)
   Mask newMask;
   newMask.replace(sprite->bounds());
 
-  Tx tx(writer.context(), "Select All", DoesntModifyDocument);
+  Tx tx(writer, "Select All", DoesntModifyDocument);
   tx(new cmd::SetMask(document, &newMask));
   document->resetTransformation();
   tx.commit();

--- a/src/app/commands/cmd_mask_by_color.cpp
+++ b/src/app/commands/cmd_mask_by_color.cpp
@@ -187,7 +187,7 @@ void MaskByColorCommand::onExecute(Context* context)
   Doc* document(writer.document());
 
   if (apply) {
-    Tx tx(writer.context(), "Mask by Color", DoesntModifyDocument);
+    Tx tx(writer, "Mask by Color", DoesntModifyDocument);
     std::unique_ptr<Mask> mask(generateMask(*document->mask(),
                                             sprite, image, xpos, ypos,
                                             m_selMode->selectionMode()));

--- a/src/app/commands/cmd_mask_content.cpp
+++ b/src/app/commands/cmd_mask_content.cpp
@@ -81,7 +81,7 @@ void MaskContentCommand::onExecute(Context* context)
       newMask.replace(cel->bounds());
     }
 
-    Tx tx(writer.context(), "Select Content", DoesntModifyDocument);
+    Tx tx(writer, "Select Content", DoesntModifyDocument);
     tx(new cmd::SetMask(document, &newMask));
     document->resetTransformation();
     tx.commit();

--- a/src/app/commands/cmd_merge_down_layer.cpp
+++ b/src/app/commands/cmd_merge_down_layer.cpp
@@ -79,7 +79,7 @@ void MergeDownLayerCommand::onExecute(Context* context)
   LayerImage* src_layer = static_cast<LayerImage*>(writer.layer());
   Layer* dst_layer = src_layer->getPrevious();
 
-  Tx tx(writer.context(), friendlyName(), ModifyDocument);
+  Tx tx(writer, friendlyName(), ModifyDocument);
 
   for (frame_t frpos = 0; frpos<sprite->totalFrames(); ++frpos) {
     // Get frames

--- a/src/app/commands/cmd_modify_selection.cpp
+++ b/src/app/commands/cmd_modify_selection.cpp
@@ -138,7 +138,7 @@ void ModifySelectionCommand::onExecute(Context* context)
   }
 
   // Set the new mask
-  Tx tx(writer.context(),
+  Tx tx(writer,
         friendlyName(),
         DoesntModifyDocument);
   tx(new cmd::SetMask(document, mask.get()));

--- a/src/app/commands/cmd_move_mask.cpp
+++ b/src/app/commands/cmd_move_mask.cpp
@@ -87,7 +87,7 @@ void MoveMaskCommand::onExecute(Context* context)
       ContextWriter writer(context);
       Doc* document(writer.document());
       {
-        Tx tx(writer.context(), "Move Selection", DoesntModifyDocument);
+        Tx tx(writer, "Move Selection", DoesntModifyDocument);
         gfx::Point pt = document->mask()->bounds().origin();
         document->getApi(tx).setMaskPosition(pt.x+delta.x, pt.y+delta.y);
         tx.commit();
@@ -102,7 +102,7 @@ void MoveMaskCommand::onExecute(Context* context)
         ContextWriter writer(context);
         if (writer.cel()) {
           // Rotate content
-          Tx tx(writer.context(), "Shift Pixels");
+          Tx tx(writer, "Shift Pixels");
           tx(new cmd::ShiftMaskedCel(writer.cel(), delta.x, delta.y));
           tx.commit();
         }

--- a/src/app/commands/cmd_new_brush.cpp
+++ b/src/app/commands/cmd_new_brush.cpp
@@ -117,7 +117,7 @@ void NewBrushCommand::onQuickboxEnd(Editor* editor, const gfx::Rect& rect, ui::M
       if (writer.cel()) {
         gfx::Rect canvasRect = (rect & writer.cel()->bounds());
         if (!canvasRect.isEmpty()) {
-          Tx tx(writer.context(), "Clear");
+          Tx tx(writer, "Clear");
           tx(new cmd::ClearRect(writer.cel(), canvasRect));
           tx.commit();
         }

--- a/src/app/commands/cmd_new_frame.cpp
+++ b/src/app/commands/cmd_new_frame.cpp
@@ -102,7 +102,7 @@ void NewFrameCommand::onExecute(Context* context)
 #endif
 
   {
-    Tx tx(writer.context(), friendlyName());
+    Tx tx(writer, friendlyName());
     DocApi api = document->getApi(tx);
 
     switch (m_content) {

--- a/src/app/commands/cmd_new_frame_tag.cpp
+++ b/src/app/commands/cmd_new_frame_tag.cpp
@@ -74,7 +74,7 @@ void NewFrameTagCommand::onExecute(Context* context)
 
   {
     ContextWriter writer(reader);
-    Tx tx(writer.context(), friendlyName());
+    Tx tx(writer, friendlyName());
     tx(new cmd::AddTag(writer.sprite(), tag.get()));
     tag.release();
     tx.commit();

--- a/src/app/commands/cmd_new_layer.cpp
+++ b/src/app/commands/cmd_new_layer.cpp
@@ -274,9 +274,8 @@ void NewLayerCommand::onExecute(Context* context)
 
   Layer* layer = nullptr;
   {
-    Tx tx(
-      writer.context(),
-      fmt::format(Strings::commands_NewLayer(), layerPrefix()));
+    Tx tx(writer,
+          fmt::format(Strings::commands_NewLayer(), layerPrefix()));
     DocApi api = document->getApi(tx);
     bool afterBackground = false;
 
@@ -428,7 +427,7 @@ void NewLayerCommand::onExecute(Context* context)
 #ifdef ENABLE_UI
     // Paste new layer from clipboard
     else if (params().fromClipboard() && layer->isImage()) {
-      context->clipboard()->paste(context, false);
+      context->clipboard()->paste(writer, false);
 
       if (layer->isReference()) {
         if (Cel* cel = layer->cel(site.frame())) {

--- a/src/app/commands/cmd_options.cpp
+++ b/src/app/commands/cmd_options.cpp
@@ -782,7 +782,7 @@ public:
         m_context->activeDocument()->sprite() &&
         m_context->activeDocument()->sprite()->gridBounds() != gridBounds()) {
       ContextWriter writer(m_context);
-      Tx tx(m_context, Strings::commands_GridSettings(), ModifyDocument);
+      Tx tx(writer, Strings::commands_GridSettings(), ModifyDocument);
       tx(new cmd::SetGridBounds(writer.sprite(), gridBounds()));
       tx.commit();
     }

--- a/src/app/commands/cmd_palette_size.cpp
+++ b/src/app/commands/cmd_palette_size.cpp
@@ -78,7 +78,7 @@ void PaletteSizeCommand::onExecute(Context* context)
   palette.resize(std::clamp(ncolors, 1, std::numeric_limits<int>::max()));
 
   ContextWriter writer(reader);
-  Tx tx(context, "Palette Size", ModifyDocument);
+  Tx tx(writer, "Palette Size", ModifyDocument);
   tx(new cmd::SetPalette(writer.sprite(), frame, &palette));
   tx.commit();
 }

--- a/src/app/commands/cmd_remove_frame.cpp
+++ b/src/app/commands/cmd_remove_frame.cpp
@@ -53,7 +53,7 @@ void RemoveFrameCommand::onExecute(Context* context)
   Doc* document(writer.document());
   Sprite* sprite(writer.sprite());
   {
-    Tx tx(writer.context(), "Remove Frame");
+    Tx tx(writer, "Remove Frame");
     DocApi api = document->getApi(tx);
     const Site* site = writer.site();
     if (site->inTimeline() &&

--- a/src/app/commands/cmd_remove_frame_tag.cpp
+++ b/src/app/commands/cmd_remove_frame_tag.cpp
@@ -77,7 +77,7 @@ void RemoveFrameTagCommand::onExecute(Context* context)
   if (!foundTag)
     return;
 
-  Tx tx(writer.context(), friendlyName());
+  Tx tx(writer, friendlyName());
   tx(new cmd::RemoveTag(sprite, foundTag));
   tx.commit();
 

--- a/src/app/commands/cmd_remove_layer.cpp
+++ b/src/app/commands/cmd_remove_layer.cpp
@@ -139,7 +139,7 @@ void RemoveLayerCommand::onExecute(Context* context)
   Doc* document(writer.document());
   Sprite* sprite(writer.sprite());
   {
-    Tx tx(writer.context(), "Remove Layer");
+    Tx tx(writer, "Remove Layer");
     DocApi api = document->getApi(tx);
     // We need to remove all the tilesets after the tilemaps are deleted
     // and in descending tileset index order, otherwise the tileset indexes

--- a/src/app/commands/cmd_remove_slice.cpp
+++ b/src/app/commands/cmd_remove_slice.cpp
@@ -101,7 +101,7 @@ void RemoveSliceCommand::onExecute(Context* context)
     ContextWriter writer(reader);
     Doc* document(writer.document());
     Sprite* sprite(writer.sprite());
-    Tx tx(writer.context(), "Remove Slice");
+    Tx tx(writer, "Remove Slice");
 
     for (auto slice : slicesToDelete.iterateAs<Slice>()) {
       ASSERT(slice);

--- a/src/app/commands/cmd_reselect_mask.cpp
+++ b/src/app/commands/cmd_reselect_mask.cpp
@@ -53,7 +53,7 @@ void ReselectMaskCommand::onExecute(Context* context)
   ContextWriter writer(context);
   Doc* document(writer.document());
   {
-    Tx tx(writer.context(), "Reselect", DoesntModifyDocument);
+    Tx tx(writer, "Reselect", DoesntModifyDocument);
     tx(new cmd::ReselectMask(document));
     tx.commit();
   }

--- a/src/app/commands/cmd_select_tile.cpp
+++ b/src/app/commands/cmd_select_tile.cpp
@@ -101,7 +101,7 @@ void SelectTileCommand::onExecute(Context* ctx)
   }
 
   // Set the new mask
-  Tx tx(writer.context(),
+  Tx tx(writer,
         friendlyName(),
         DoesntModifyDocument);
   tx(new cmd::SetMask(doc, mask.get()));

--- a/src/app/commands/cmd_set_loop_section.cpp
+++ b/src/app/commands/cmd_set_loop_section.cpp
@@ -107,14 +107,14 @@ void SetLoopSectionCommand::onExecute(Context* ctx)
       loopTag = create_loop_tag(begin, end);
 
       ContextWriter writer(ctx);
-      Tx tx(writer.context(), "Add Loop");
+      Tx tx(writer, "Add Loop");
       tx(new cmd::AddTag(sprite, loopTag));
       tx.commit();
     }
     else if (loopTag->fromFrame() != begin ||
              loopTag->toFrame() != end) {
       ContextWriter writer(ctx);
-      Tx tx(writer.context(), "Set Loop Range");
+      Tx tx(writer, "Set Loop Range");
       tx(new cmd::SetTagRange(loopTag, begin, end));
       tx.commit();
     }
@@ -126,7 +126,7 @@ void SetLoopSectionCommand::onExecute(Context* ctx)
   else {
     if (loopTag) {
       ContextWriter writer(ctx);
-      Tx tx(writer.context(), "Remove Loop");
+      Tx tx(writer, "Remove Loop");
       tx(new cmd::RemoveTag(sprite, loopTag));
       tx.commit();
     }

--- a/src/app/commands/cmd_set_palette.cpp
+++ b/src/app/commands/cmd_set_palette.cpp
@@ -37,7 +37,7 @@ void SetPaletteCommand::onExecute(Context* context)
 
   ContextWriter writer(context);
   if (writer.document()) {
-    Tx tx(writer.context(), "Set Palette");
+    Tx tx(writer, "Set Palette");
     writer.document()->getApi(tx)
       .setPalette(writer.sprite(), writer.frame(), m_palette);
     tx.commit();

--- a/src/app/commands/cmd_slice_properties.cpp
+++ b/src/app/commands/cmd_slice_properties.cpp
@@ -91,7 +91,7 @@ void SlicePropertiesCommand::onExecute(Context* context)
   {
     const SliceWindow::Mods mods = window.modifiedFields();
     ContextWriter writer(reader);
-    Tx tx(writer.context(), "Slice Properties");
+    Tx tx(writer, "Slice Properties");
 
     for (Slice* slice : slices.iterateAs<Slice>()) {
       // Change name

--- a/src/app/commands/cmd_sprite_properties.cpp
+++ b/src/app/commands/cmd_sprite_properties.cpp
@@ -96,10 +96,11 @@ public:
 private:
    void onDuplicate(const doc::Tileset* tileset)
    {
+     auto sprite = tileset->sprite();
      auto tilesetClone = Tileset::MakeCopyCopyingImages(tileset);
 
-     Tx tx(fmt::format(Strings::commands_TilesetDuplicate()));
-     tx(new cmd::AddTileset(tileset->sprite(), tilesetClone));
+     Tx tx(sprite, fmt::format(Strings::commands_TilesetDuplicate()));
+     tx(new cmd::AddTileset(sprite, tilesetClone));
      tx.commit();
 
      TilesetDuplicated(tilesetClone);
@@ -121,8 +122,9 @@ private:
       return;
     }
 
-    Tx tx(fmt::format(Strings::commands_TilesetDelete()));
-    tx(new cmd::RemoveTileset(tileset->sprite(), tsi));
+    auto sprite = tileset->sprite();
+    Tx tx(sprite, fmt::format(Strings::commands_TilesetDelete()));
+    tx(new cmd::RemoveTileset(sprite, tsi));
     tx.commit();
 
     TilesetDeleted(this);
@@ -351,7 +353,7 @@ void SpritePropertiesCommand::onExecute(Context* context)
 
         ContextWriter writer(context);
         Sprite* sprite(writer.sprite());
-        Tx tx(writer.context(), Strings::sprite_properties_assign_color_profile());
+        Tx tx(writer, Strings::sprite_properties_assign_color_profile());
         tx(new cmd::AssignColorProfile(
              sprite, colorSpaces[selectedColorProfile]->gfxColorSpace()));
         tx.commit();
@@ -364,7 +366,7 @@ void SpritePropertiesCommand::onExecute(Context* context)
 
         ContextWriter writer(context);
         Sprite* sprite(writer.sprite());
-        Tx tx(writer.context(), Strings::sprite_properties_convert_color_profile());
+        Tx tx(writer, Strings::sprite_properties_convert_color_profile());
         tx(new cmd::ConvertColorProfile(
              sprite, colorSpaces[selectedColorProfile]->gfxColorSpace()));
         tx.commit();
@@ -394,7 +396,7 @@ void SpritePropertiesCommand::onExecute(Context* context)
     if (index != sprite->transparentColor() ||
         pixelRatio != sprite->pixelRatio() ||
         newUserData != sprite->userData()) {
-      Tx tx(writer.context(), Strings::sprite_properties_change_sprite_props());
+      Tx tx(writer, Strings::sprite_properties_change_sprite_props());
       DocApi api = writer.document()->getApi(tx);
 
       if (index != sprite->transparentColor())

--- a/src/app/commands/cmd_unlink_cel.cpp
+++ b/src/app/commands/cmd_unlink_cel.cpp
@@ -47,7 +47,7 @@ void UnlinkCelCommand::onExecute(Context* context)
   Doc* document(writer.document());
   bool nonEditableLayers = false;
   {
-    Tx tx(writer.context(), "Unlink Cel");
+    Tx tx(writer, "Unlink Cel");
 
     const Site* site = writer.site();
     if (site->inTimeline() &&

--- a/src/app/commands/convert_layer.cpp
+++ b/src/app/commands/convert_layer.cpp
@@ -180,7 +180,7 @@ void ConvertLayerCommand::onExecute(Context* ctx)
   ContextWriter writer(ctx);
   Doc* document(writer.document());
   {
-    Tx tx(ctx, friendlyName());
+    Tx tx(writer, friendlyName());
 
     switch (params().to()) {
 

--- a/src/app/commands/filters/filter_manager_impl.cpp
+++ b/src/app/commands/filters/filter_manager_impl.cpp
@@ -353,7 +353,7 @@ void FilterManagerImpl::initTransaction()
 {
   ASSERT(!m_tx);
   m_writer.reset(new ContextWriter(m_reader));
-  m_tx.reset(new Tx(m_writer->context(),
+  m_tx.reset(new Tx(*m_writer,
                     m_filter->getName(),
                     ModifyDocument));
 }

--- a/src/app/commands/move_colors_command.cpp
+++ b/src/app/commands/move_colors_command.cpp
@@ -55,7 +55,7 @@ protected:
     if (!writer.palette())
       return;
 
-    Tx tx(writer.context(), friendlyName(), ModifyDocument);
+    Tx tx(writer, friendlyName(), ModifyDocument);
     const int beforeIndex = params().before();
     int currentEntry = picks.firstPick();
 

--- a/src/app/commands/move_tiles_command.cpp
+++ b/src/app/commands/move_tiles_command.cpp
@@ -57,7 +57,7 @@ protected:
     if (picks.picks() == 0)
       return;
 
-    Tx tx(writer.context(), onGetFriendlyName(), ModifyDocument);
+    Tx tx(writer, onGetFriendlyName(), ModifyDocument);
     const int beforeIndex = params().before();
     int currentEntry = picks.firstPick();
 

--- a/src/app/context_flags.cpp
+++ b/src/app/context_flags.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2022  Igara Studio S.A.
+// Copyright (C) 2019-2023  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -36,7 +36,8 @@ void ContextFlags::update(Context* context)
   if (document) {
     m_flags |= HasActiveDocument;
 
-    if (document->readLock(0)) {
+    Doc::LockResult res = document->readLock(0);
+    if (res != Doc::LockResult::Fail) {
       m_flags |= ActiveDocumentIsReadable;
 
       if (document->isMaskVisible())
@@ -47,7 +48,7 @@ void ContextFlags::update(Context* context)
       if (document->canWriteLockFromRead() && !document->isReadOnly())
         m_flags |= ActiveDocumentIsWritable;
 
-      document->unlock();
+      document->unlock(res);
     }
 
 #ifdef ENABLE_UI

--- a/src/app/doc.cpp
+++ b/src/app/doc.cpp
@@ -41,7 +41,7 @@
 #include <limits>
 #include <map>
 
-#define DOC_TRACE(...) // TRACEARGS
+#define DOC_TRACE(...) // TRACEARGS(__VA_ARGS__)
 
 namespace app {
 
@@ -102,38 +102,50 @@ bool Doc::canWriteLockFromRead() const
   return m_rwLock.canWriteLockFromRead();
 }
 
-bool Doc::readLock(int timeout)
+Doc::LockResult Doc::readLock(int timeout)
 {
-  return m_rwLock.lock(base::RWLock::ReadLock, timeout);
+  auto res = m_rwLock.lock(base::RWLock::ReadLock, timeout);
+  DOC_TRACE("DOC: readLock", this, (int)res);
+  return res;
 }
 
-bool Doc::writeLock(int timeout)
+Doc::LockResult Doc::writeLock(int timeout)
 {
-  return m_rwLock.lock(base::RWLock::WriteLock, timeout);
+  auto res = m_rwLock.lock(base::RWLock::WriteLock, timeout);
+  DOC_TRACE("DOC: writeLock", this, (int)res);
+  return res;
 }
 
-bool Doc::upgradeToWrite(int timeout)
+Doc::LockResult Doc::upgradeToWrite(int timeout)
 {
-  return m_rwLock.upgradeToWrite(timeout);
+  auto res = m_rwLock.upgradeToWrite(timeout);
+  DOC_TRACE("DOC: upgradeToWrite", this, (int)res);
+  return res;
 }
 
-void Doc::downgradeToRead()
+void Doc::downgradeToRead(LockResult lockResult)
 {
-  m_rwLock.downgradeToRead();
+  DOC_TRACE("DOC: downgradeToRead", this, (int)lockResult);
+  m_rwLock.downgradeToRead(lockResult);
 }
 
-void Doc::unlock()
+void Doc::unlock(LockResult lockResult)
 {
-  m_rwLock.unlock();
+  ASSERT(lockResult != base::RWLock::LockResult::Fail);
+  DOC_TRACE("DOC: unlock", this, (int)lockResult);
+  m_rwLock.unlock(lockResult);
 }
 
 bool Doc::weakLock(std::atomic<base::RWLock::WeakLock>* weak_lock_flag)
 {
-  return m_rwLock.weakLock(weak_lock_flag);
+  bool res = m_rwLock.weakLock(weak_lock_flag);
+  DOC_TRACE("DOC: weakLock", this, (int)res);
+  return res;
 }
 
 void Doc::weakUnlock()
 {
+  DOC_TRACE("DOC: weakUnlock", this);
   m_rwLock.weakUnlock();
 }
 

--- a/src/app/doc.h
+++ b/src/app/doc.h
@@ -68,6 +68,8 @@ namespace app {
       kReadOnly         = 16,// This document is read-only
     };
   public:
+    using LockResult = base::RWLock::LockResult;
+
     Doc(Sprite* sprite);
     ~Doc();
 
@@ -76,11 +78,11 @@ namespace app {
 
     // Lock/unlock API (RWLock wrapper)
     bool canWriteLockFromRead() const;
-    bool readLock(int timeout);
-    bool writeLock(int timeout);
-    bool upgradeToWrite(int timeout);
-    void downgradeToRead();
-    void unlock();
+    LockResult readLock(int timeout);
+    LockResult writeLock(int timeout);
+    LockResult upgradeToWrite(int timeout);
+    void downgradeToRead(LockResult lockResult);
+    void unlock(LockResult lockResult);
 
     bool weakLock(std::atomic<base::RWLock::WeakLock>* weak_lock_flag);
     void weakUnlock();

--- a/src/app/doc_api_tests.cpp
+++ b/src/app/doc_api_tests.cpp
@@ -52,7 +52,7 @@ TEST_F(BasicDocApiTest, RestackLayerBefore)
 {
   EXPECT_EQ(layer1, root->firstLayer());
   {
-    Tx tx(&ctx, "");
+    Tx tx(sprite, "");
     // Do nothing
     doc->getApi(tx).restackLayerBefore(layer1, layer1->parent(), layer1);
     EXPECT_EQ(layer1, root->firstLayer());
@@ -63,7 +63,7 @@ TEST_F(BasicDocApiTest, RestackLayerBefore)
 
   EXPECT_EQ(layer1, root->firstLayer());
   {
-    Tx tx(&ctx, "");
+    Tx tx(sprite, "");
     doc->getApi(tx).restackLayerBefore(layer1, layer3->parent(), layer3);
     EXPECT_EQ(layer2, root->firstLayer());
     EXPECT_EQ(layer1, root->firstLayer()->getNext());
@@ -73,7 +73,7 @@ TEST_F(BasicDocApiTest, RestackLayerBefore)
 
   EXPECT_EQ(layer1, root->firstLayer());
   {
-    Tx tx(&ctx, "");
+    Tx tx(sprite, "");
     doc->getApi(tx).restackLayerBefore(layer1, layer1->parent(), nullptr);
     EXPECT_EQ(layer2, root->firstLayer());
     EXPECT_EQ(layer3, root->firstLayer()->getNext());
@@ -86,7 +86,7 @@ TEST_F(BasicDocApiTest, RestackLayerAfter)
 {
   EXPECT_EQ(layer1, root->firstLayer());
   {
-    Tx tx(&ctx, "");
+    Tx tx(sprite, "");
     // Do nothing
     doc->getApi(tx).restackLayerAfter(layer1, layer1->parent(), layer1);
     EXPECT_EQ(layer1, root->firstLayer());
@@ -97,7 +97,7 @@ TEST_F(BasicDocApiTest, RestackLayerAfter)
 
   EXPECT_EQ(layer1, root->firstLayer());
   {
-    Tx tx(&ctx, "");
+    Tx tx(sprite, "");
     doc->getApi(tx).restackLayerAfter(layer1, layer3->parent(), layer3);
     EXPECT_EQ(layer2, root->firstLayer());
     EXPECT_EQ(layer3, root->firstLayer()->getNext());
@@ -107,7 +107,7 @@ TEST_F(BasicDocApiTest, RestackLayerAfter)
 
   EXPECT_EQ(layer1, root->firstLayer());
   {
-    Tx tx(&ctx, "");
+    Tx tx(sprite, "");
     doc->getApi(tx).restackLayerAfter(layer3, layer3->parent(), nullptr);
     EXPECT_EQ(layer3, root->firstLayer());
     EXPECT_EQ(layer1, root->firstLayer()->getNext());
@@ -132,7 +132,7 @@ TEST_F(BasicDocApiTest, MoveCel)
   // Create a copy for later comparison.
   std::unique_ptr<Image> expectedImage(Image::createCopy(image1));
 
-  Tx tx(&ctx, "");
+  Tx tx(sprite, "");
   doc->getApi(tx).moveCel(
     layer1, frame_t(0),
     layer2, frame_t(1));

--- a/src/app/doc_range_ops.cpp
+++ b/src/app/doc_range_ops.cpp
@@ -333,7 +333,7 @@ static DocRange drop_range_op(
     const app::Context* context = static_cast<app::Context*>(doc->context());
     const ContextReader reader(context);
     ContextWriter writer(reader);
-    Tx tx(writer.context(), undoLabel, ModifyDocument);
+    Tx tx(writer, undoLabel, ModifyDocument);
     DocApi api = doc->getApi(tx);
 
     // TODO Try to add the range with just one call to DocApi
@@ -490,7 +490,7 @@ void reverse_frames(Doc* doc, const DocRange& range)
   const app::Context* context = static_cast<app::Context*>(doc->context());
   const ContextReader reader(context);
   ContextWriter writer(reader);
-  Tx tx(writer.context(), "Reverse Frames");
+  Tx tx(writer, "Reverse Frames");
   DocApi api = doc->getApi(tx);
   Sprite* sprite = doc->sprite();
   LayerList layers;

--- a/src/app/script/cel_class.cpp
+++ b/src/app/script/cel_class.cpp
@@ -110,8 +110,8 @@ int Cel_set_frame(lua_State* L)
   if (cel->frame() == frame)
     return 0;
 
-  Tx tx;
   Doc* doc = static_cast<Doc*>(cel->document());
+  Tx tx(doc);
   DocApi api = doc->getApi(tx);
   api.moveCel(cel->layer(), cel->frame(),
               cel->layer(), frame);
@@ -125,7 +125,7 @@ int Cel_set_image(lua_State* L)
   auto srcImage = get_image_from_arg(L, 2);
   ImageRef newImage(Image::createCopy(srcImage));
 
-  Tx tx;
+  Tx tx(cel->sprite());
   tx(new cmd::ReplaceImage(cel->sprite(),
                            cel->imageRef(),
                            newImage));
@@ -137,7 +137,7 @@ int Cel_set_position(lua_State* L)
 {
   auto cel = get_docobj<Cel>(L, 1);
   const gfx::Point pos = convert_args_into_point(L, 2);
-  Tx tx;
+  Tx tx(cel->sprite());
   tx(new cmd::SetCelPosition(cel, pos.x, pos.y));
   tx.commit();
   return 0;
@@ -146,7 +146,7 @@ int Cel_set_position(lua_State* L)
 int Cel_set_opacity(lua_State* L)
 {
   auto cel = get_docobj<Cel>(L, 1);
-  Tx tx;
+  Tx tx(cel->sprite());
   tx(new cmd::SetCelOpacity(cel, lua_tointeger(L, 2)));
   tx.commit();
   return 0;
@@ -155,7 +155,7 @@ int Cel_set_opacity(lua_State* L)
 int Cel_set_zIndex(lua_State* L)
 {
   auto cel = get_docobj<Cel>(L, 1);
-  Tx tx;
+  Tx tx(cel->sprite());
   tx(new cmd::SetCelZIndex(cel, lua_tointeger(L, 2)));
   tx.commit();
   return 0;

--- a/src/app/script/frame_class.cpp
+++ b/src/app/script/frame_class.cpp
@@ -104,7 +104,7 @@ int Frame_set_duration(lua_State* L)
   auto obj = get_obj<FrameObj>(L, 1);
   auto sprite = obj->sprite(L);
   double duration = lua_tonumber(L, 2) * 1000.0;
-  Tx tx;
+  Tx tx(sprite);
   tx(new cmd::SetFrameDuration(sprite, obj->frame, int(duration)));
   tx.commit();
   return 1;

--- a/src/app/script/layer_class.cpp
+++ b/src/app/script/layer_class.cpp
@@ -250,7 +250,7 @@ int Layer_set_name(lua_State* L)
   auto layer = get_docobj<Layer>(L, 1);
   const char* name = lua_tostring(L, 2);
   if (name) {
-    Tx tx;
+    Tx tx(layer->sprite());
     tx(new cmd::SetLayerName(layer, name));
     tx.commit();
   }
@@ -262,7 +262,7 @@ int Layer_set_opacity(lua_State* L)
   auto layer = get_docobj<Layer>(L, 1);
   const int opacity = lua_tointeger(L, 2);
   if (layer->isImage()) {
-    Tx tx;
+    Tx tx(layer->sprite());
     tx(new cmd::SetLayerOpacity(static_cast<LayerImage*>(layer), opacity));
     tx.commit();
   }
@@ -274,7 +274,7 @@ int Layer_set_blendMode(lua_State* L)
   auto layer = get_docobj<Layer>(L, 1);
   auto blendMode = app::script::BlendMode(lua_tointeger(L, 2));
   if (layer->isImage()) {
-    Tx tx;
+    Tx tx(layer->sprite());
     tx(new cmd::SetLayerBlendMode(static_cast<LayerImage*>(layer),
                                   base::convert_to<doc::BlendMode>(blendMode)));
     tx.commit();
@@ -313,7 +313,7 @@ int Layer_set_stackIndex(lua_State* L)
     return 0;
 
   Doc* doc = static_cast<Doc*>(layer->sprite()->document());
-  Tx tx;
+  Tx tx(doc);
   DocApi(doc, tx).restackLayerBefore(layer, parent, beforeThis);
   tx.commit();
   return 0;
@@ -381,7 +381,7 @@ int Layer_set_parent(lua_State* L)
 
   if (parent) {
     Doc* doc = static_cast<Doc*>(layer->sprite()->document());
-    Tx tx;
+    Tx tx(doc);
     DocApi(doc, tx).restackLayerAfter(
       layer, parent, parent->lastLayer());
     tx.commit();
@@ -402,7 +402,7 @@ int Layer_set_tileset(lua_State* L)
       tsi = lua_tointeger(L, 2);
 
     if (tsi != tilemap->tilesetIndex()) {
-      Tx tx;
+      Tx tx(layer->sprite());
       tx(new cmd::SetLayerTileset(tilemap, tsi));
       tx.commit();
     }

--- a/src/app/script/palette_class.cpp
+++ b/src/app/script/palette_class.cpp
@@ -165,7 +165,7 @@ int Palette_resize(lua_State* L)
     newPal.resize(ncolors);
 
     if (*pal != newPal) {
-      Tx tx;
+      Tx tx(sprite);
       tx(new cmd::SetPalette(sprite, pal->frame(), &newPal));
       tx.commit();
     }
@@ -212,7 +212,7 @@ int Palette_setColor(lua_State* L)
     Palette newPal(*pal);
     newPal.setEntry(i, docColor);
 
-    Tx tx;
+    Tx tx(sprite);
     tx(new cmd::SetPalette(sprite, pal->frame(), &newPal));
     tx.commit();
   }

--- a/src/app/script/properties_class.cpp
+++ b/src/app/script/properties_class.cpp
@@ -126,8 +126,8 @@ int Properties_newindex(lua_State* L)
 
   // TODO add Object::sprite() member function
   //if (obj->sprite()) {
-  if (App::instance()->context()->activeDocument()) {
-    Tx tx;
+  if (auto doc = App::instance()->context()->activeDocument()) {
+    Tx tx(doc);                 // TODO propObj might not be member of "doc"
     if (propObj->ti != doc::notile) {
       tx(new cmd::SetTileDataProperty(static_cast<doc::Tileset*>(obj),
                                       propObj->ti, propObj->extID, field,
@@ -165,8 +165,8 @@ int Properties_call(lua_State* L)
 
     // TODO add Object::sprite() member function
     //if (obj->sprite()) {
-    if (App::instance()->context()->activeDocument()) {
-      Tx tx;
+    if (auto doc = App::instance()->context()->activeDocument()) {
+      Tx tx(doc);                 // TODO propObj might not be member of "doc"
       if (propObj->ti != doc::notile) {
         tx(new cmd::SetTileDataProperties(static_cast<doc::Tileset*>(obj),
                                           propObj->ti, extID, std::move(newProperties)));

--- a/src/app/script/selection_class.cpp
+++ b/src/app/script/selection_class.cpp
@@ -117,7 +117,7 @@ int Selection_deselect(lua_State* L)
     ASSERT(doc);
 
     if (doc->isMaskVisible()) {
-      Tx tx;
+      Tx tx(doc);
       tx(new cmd::DeselectMask(doc));
       tx.commit();
     }
@@ -180,7 +180,7 @@ int Selection_op(lua_State* L, OpMask opMask, OpRect opRect)
       Mask newMask;
       opMask(newMask, *mask, *otherMask);
 
-      Tx tx;
+      Tx tx(sprite);
       tx(new cmd::SetMask(doc, &newMask));
       tx.commit();
     }
@@ -198,7 +198,7 @@ int Selection_op(lua_State* L, OpMask opMask, OpRect opRect)
       Mask newMask;
       opRect(newMask, *mask, bounds);
 
-      Tx tx;
+      Tx tx(sprite);
       tx(new cmd::SetMask(doc, &newMask));
       tx.commit();
     }
@@ -223,7 +223,7 @@ int Selection_selectAll(lua_State* L)
     Mask newMask;
     newMask.replace(sprite->bounds());
 
-    Tx tx;
+    Tx tx(doc);
     tx(new cmd::SetMask(doc, &newMask));
     tx.commit();
   }
@@ -290,7 +290,7 @@ int Selection_set_origin(lua_State* L)
   if (auto sprite = obj->sprite(L)) {
     Doc* doc = static_cast<Doc*>(sprite->document());
     if (doc->isMaskVisible()) {
-      Tx tx;
+      Tx tx(doc);
       doc->getApi(tx).setMaskPosition(pt.x, pt.y);
       tx.commit();
     }

--- a/src/app/script/slice_class.cpp
+++ b/src/app/script/slice_class.cpp
@@ -83,7 +83,7 @@ int Slice_set_name(lua_State* L)
   auto slice = get_docobj<Slice>(L, 1);
   const char* name = lua_tostring(L, 2);
   if (name) {
-    Tx tx;
+    Tx tx(slice->sprite());
     tx(new cmd::SetSliceName(slice, name));
     tx.commit();
   }
@@ -98,7 +98,7 @@ int Slice_set_bounds(lua_State* L)
   if (const SliceKey* srcKey = slice->getByFrame(0))
     key = *srcKey;
   key.setBounds(bounds);
-  Tx tx;
+  Tx tx(slice->sprite());
   tx(new cmd::SetSliceKey(slice, 0, key));
   tx.commit();
   return 0;
@@ -112,7 +112,7 @@ int Slice_set_center(lua_State* L)
   if (const SliceKey* srcKey = slice->getByFrame(0))
     key = *srcKey;
   key.setCenter(center);
-  Tx tx;
+  Tx tx(slice->sprite());
   tx(new cmd::SetSliceKey(slice, 0, key));
   tx.commit();
   return 0;
@@ -126,7 +126,7 @@ int Slice_set_pivot(lua_State* L)
   if (const SliceKey* srcKey = slice->getByFrame(0))
     key = *srcKey;
   key.setPivot(pivot);
-  Tx tx;
+  Tx tx(slice->sprite());
   tx(new cmd::SetSliceKey(slice, 0, key));
   tx.commit();
   return 0;

--- a/src/app/script/tag_class.cpp
+++ b/src/app/script/tag_class.cpp
@@ -96,7 +96,7 @@ int Tag_set_fromFrame(lua_State* L)
 {
   auto tag = get_docobj<Tag>(L, 1);
   const auto fromFrame = get_frame_number_from_arg(L, 2);
-  Tx tx;
+  Tx tx(tag->sprite());
   tx(new cmd::SetTagRange(tag, fromFrame,
                           std::max(fromFrame, tag->toFrame())));
   tx.commit();
@@ -107,7 +107,7 @@ int Tag_set_toFrame(lua_State* L)
 {
   auto tag = get_docobj<Tag>(L, 1);
   const auto toFrame = get_frame_number_from_arg(L, 2);
-  Tx tx;
+  Tx tx(tag->sprite());
   tx(new cmd::SetTagRange(tag,
                                std::min(tag->fromFrame(), toFrame),
                                toFrame));
@@ -120,7 +120,7 @@ int Tag_set_name(lua_State* L)
   auto tag = get_docobj<Tag>(L, 1);
   const char* name = lua_tostring(L, 2);
   if (name) {
-    Tx tx;
+    Tx tx(tag->sprite());
     tx(new cmd::SetTagName(tag, name));
     tx.commit();
   }
@@ -131,7 +131,7 @@ int Tag_set_aniDir(lua_State* L)
 {
   auto tag = get_docobj<Tag>(L, 1);
   const int aniDir = lua_tointeger(L, 2);
-  Tx tx;
+  Tx tx(tag->sprite());
   tx(new cmd::SetTagAniDir(tag, (doc::AniDir)aniDir));
   tx.commit();
   return 0;
@@ -141,7 +141,7 @@ int Tag_set_repeats(lua_State* L)
 {
   auto tag = get_docobj<Tag>(L, 1);
   const int repeat = lua_tointeger(L, 2);
-  Tx tx;
+  Tx tx(tag->sprite());
   tx(new cmd::SetTagRepeat(tag, repeat));
   tx.commit();
   return 0;

--- a/src/app/script/tile_class.cpp
+++ b/src/app/script/tile_class.cpp
@@ -60,7 +60,7 @@ int Tile_set_image(lua_State* L)
   ImageRef newImage(Image::createCopy(srcImage));
 
   if (ts && ts->sprite()) {
-    Tx tx;
+    Tx tx(ts->sprite());
     tx(new cmd::ReplaceImage(ts->sprite(),
                              ts->get(tile->ti),
                              newImage));
@@ -125,8 +125,8 @@ int Tile_set_data(lua_State* L)
   doc::UserData ud = ts->getTileData(tile->ti);
   ud.setText(text);
 
-  if (ts->sprite()) {           // TODO use transaction in this sprite
-    Tx tx;
+  if (ts->sprite()) {
+    Tx tx(ts->sprite());
     tx(new cmd::SetTileData(ts, tile->ti, ud));
     tx.commit();
   }
@@ -148,8 +148,8 @@ int Tile_set_color(lua_State* L)
   doc::UserData ud = ts->getTileData(tile->ti);
   ud.setColor(docColor);
 
-  if (ts->sprite()) {           // TODO use transaction in this sprite
-    Tx tx;
+  if (ts->sprite()) {
+    Tx tx(ts->sprite());
     tx(new cmd::SetTileData(ts, tile->ti, ud));
     tx.commit();
   }
@@ -168,7 +168,7 @@ int Tile_set_properties(lua_State* L)
 
   auto newProperties = get_value_from_lua<doc::UserData::Properties>(L, 2);
   if (ts->sprite()) {
-    Tx tx;
+    Tx tx(ts->sprite());
     tx(new cmd::SetTileDataProperties(ts, tile->ti,
                                       std::string(),
                                       std::move(newProperties)));

--- a/src/app/script/tileset_class.cpp
+++ b/src/app/script/tileset_class.cpp
@@ -68,7 +68,7 @@ int Tileset_set_name(lua_State* L)
 {
   auto tileset = get_docobj<Tileset>(L, 1);
   if (const char* newName = lua_tostring(L, 2)) {
-    Tx tx;
+    Tx tx(tileset->sprite());
     tx(new cmd::SetTilesetName(tileset, newName));
     tx.commit();
   }
@@ -93,7 +93,7 @@ int Tileset_set_baseIndex(lua_State* L)
 {
   auto tileset = get_docobj<Tileset>(L, 1);
   int i = lua_tointeger(L, 2);
-  Tx tx;
+  Tx tx(tileset->sprite());
   tx(new cmd::SetTilesetBaseIndex(tileset, i));
   tx.commit();
   return 0;

--- a/src/app/script/userdata.h
+++ b/src/app/script/userdata.h
@@ -63,13 +63,12 @@ int UserData_get_properties(lua_State* L) {
 template<typename T>
 int UserData_set_text(lua_State* L) {
   auto obj = get_docobj<T>(L, 1);
-  auto spr = obj->sprite();
   const char* text = lua_tostring(L, 2);
   auto wud = get_WithUserData<T>(obj);
   UserData ud = wud->userData();
   ud.setText(text ? std::string(text): std::string());
-  if (spr) {
-    Tx tx;
+  if (auto spr = obj->sprite()) {
+    Tx tx(spr);
     tx(new cmd::SetUserData(wud, ud, static_cast<Doc*>(spr->document())));
     tx.commit();
   }
@@ -82,13 +81,12 @@ int UserData_set_text(lua_State* L) {
 template<typename T>
 int UserData_set_color(lua_State* L) {
   auto obj = get_docobj<T>(L, 1);
-  auto spr = obj->sprite();
   doc::color_t docColor = convert_args_into_pixel_color(L, 2, doc::IMAGE_RGB);
   auto wud = get_WithUserData<T>(obj);
   UserData ud = wud->userData();
   ud.setColor(docColor);
-  if (spr) {
-    Tx tx;
+  if (auto spr = obj->sprite()) {
+    Tx tx(spr);
     tx(new cmd::SetUserData(wud, ud, static_cast<Doc*>(spr->document())));
     tx.commit();
   }
@@ -103,8 +101,8 @@ int UserData_set_properties(lua_State* L) {
   auto obj = get_docobj<T>(L, 1);
   auto wud = get_WithUserData<T>(obj);
   auto newProperties = get_value_from_lua<doc::UserData::Properties>(L, 2);
-  if (obj->sprite()) {
-    Tx tx;
+  if (auto spr = obj->sprite()) {
+    Tx tx(spr);
     tx(new cmd::SetUserDataProperties(wud,
                                       std::string(),
                                       std::move(newProperties)));

--- a/src/app/sprite_job.cpp
+++ b/src/app/sprite_job.cpp
@@ -17,7 +17,7 @@ SpriteJob::SpriteJob(const ContextReader& reader, const char* jobName)
   , m_writer(reader, 500)
   , m_document(m_writer.document())
   , m_sprite(m_writer.sprite())
-  , m_tx(m_writer.context(), jobName, ModifyDocument)
+  , m_tx(m_writer, jobName, ModifyDocument)
 {
 }
 

--- a/src/app/ui/color_bar.cpp
+++ b/src/app/ui/color_bar.cpp
@@ -892,7 +892,7 @@ void ColorBar::onRemapPalButtonClick()
     if (sprite) {
       ASSERT(sprite->pixelFormat() == IMAGE_INDEXED);
 
-      Tx tx(writer.context(), "Remap Colors", ModifyDocument);
+      Tx tx(writer, "Remap Colors", ModifyDocument);
       bool remapPixels = true;
 
       std::vector<ImageRef> images;
@@ -1003,7 +1003,7 @@ void ColorBar::onRemapTilesButtonClick()
       return;
     }
 
-    Tx tx(writer.context(), Strings::color_bar_remap_tiles(), ModifyDocument);
+    Tx tx(writer, Strings::color_bar_remap_tiles(), ModifyDocument);
     if (!existMapToEmpty &&
         remap.isInvertible(usedTiles)) {
       tx(new cmd::RemapTilemaps(tileset, remap));
@@ -1090,7 +1090,7 @@ void ColorBar::setPalette(const doc::Palette* newPalette, const std::string& act
     frame_t frame = writer.frame();
     if (sprite &&
         newPalette->countDiff(sprite->palette(frame), nullptr, nullptr)) {
-      Tx tx(writer.context(), actionText, ModifyDocument);
+      Tx tx(writer, actionText, ModifyDocument);
       tx(new cmd::SetPalette(sprite, frame, newPalette));
       tx.commit();
     }
@@ -1110,7 +1110,7 @@ void ColorBar::setTransparentIndex(int index)
         sprite->pixelFormat() == IMAGE_INDEXED &&
         int(sprite->transparentColor()) != index) {
       // TODO merge this code with SpritePropertiesCommand
-      Tx tx(writer.context(), "Set Transparent Color");
+      Tx tx(writer, "Set Transparent Color");
       DocApi api = writer.document()->getApi(tx);
       api.setSpriteTransparentColor(sprite, index);
       tx.commit();
@@ -1209,7 +1209,7 @@ void ColorBar::onTilesViewClearTiles(const doc::PalettePicks& _picks)
     if (sprite) {
       auto tileset = m_tilesView.tileset();
 
-      Tx tx(writer.context(), "Clear Tiles", ModifyDocument);
+      Tx tx(writer, "Clear Tiles", ModifyDocument);
       for (int ti=int(picks.size())-1; ti>=0; --ti) {
         if (picks[ti])
           tx(new cmd::RemoveTile(tileset, ti));
@@ -1240,7 +1240,7 @@ void ColorBar::onTilesViewResize(const int newSize)
     if (sprite) {
       auto tileset = m_tilesView.tileset();
 
-      Tx tx(writer.context(), Strings::color_bar_resize_tiles(), ModifyDocument);
+      Tx tx(writer, Strings::color_bar_resize_tiles(), ModifyDocument);
       if (tileset->size() < newSize) {
         for (doc::tile_index ti=tileset->size(); ti<newSize; ++ti) {
           ImageRef img = tileset->makeEmptyTile();
@@ -1281,7 +1281,7 @@ void ColorBar::onTilesViewDragAndDrop(doc::Tileset* tileset,
     Context* ctx = UIContext::instance();
     InlineCommandExecution inlineCmd(ctx);
     ContextWriter writer(ctx, 500);
-    Tx tx(writer.context(), Strings::color_bar_drag_and_drop_tiles(), ModifyDocument);
+    Tx tx(writer, Strings::color_bar_drag_and_drop_tiles(), ModifyDocument);
     if (isCopy)
       copy_tiles_in_tileset(tx, tileset, picks, currentEntry, beforeIndex);
     else
@@ -1880,7 +1880,7 @@ void ColorBar::updateCurrentSpritePalette(const char* operationName)
           cmd.release()->execute(UIContext::instance());
         }
         else {
-          Tx tx(writer.context(), operationName, ModifyDocument);
+          Tx tx(writer, operationName, ModifyDocument);
           // If tx() fails it will delete the cmd anyway, so we can
           // release the unique pointer here.
           tx(cmd.release());

--- a/src/app/ui/doc_view.cpp
+++ b/src/app/ui/doc_view.cpp
@@ -594,7 +594,8 @@ bool DocView::onPaste(Context* ctx)
   auto clipboard = ctx->clipboard();
   if (clipboard->format() == ClipboardFormat::Image ||
       clipboard->format() == ClipboardFormat::Tilemap) {
-    clipboard->paste(ctx, true);
+    ContextWriter writer(ctx);
+    clipboard->paste(writer, true);
     return true;
   }
   else
@@ -630,7 +631,7 @@ bool DocView::onClear(Context* ctx)
 
   // TODO This code is similar to clipboard::cut()
   {
-    Tx tx(writer.context(), "Clear");
+    Tx tx(writer, "Clear");
     const bool deselectMask =
       (visibleMask &&
        !Preferences::instance().selection.keepSelectionAfterClear());

--- a/src/app/ui/editor/moving_cel_state.cpp
+++ b/src/app/ui/editor/moving_cel_state.cpp
@@ -153,7 +153,7 @@ bool MovingCelState::onMouseUp(Editor* editor, MouseMessage* msg)
   if (modified) {
     {
       ContextWriter writer(m_reader, 1000);
-      Tx tx(writer.context(), "Cel Movement", ModifyDocument);
+      Tx tx(writer, "Cel Movement", ModifyDocument);
       DocApi api = document->getApi(tx);
       gfx::Point intOffset = intCelOffset();
 

--- a/src/app/ui/editor/moving_selection_state.cpp
+++ b/src/app/ui/editor/moving_selection_state.cpp
@@ -82,7 +82,7 @@ EditorState::LeaveAction MovingSelectionState::onLeaveState(Editor* editor, Edit
   else {
     {
       ContextWriter writer(UIContext::instance(), 1000);
-      Tx tx(writer.context(), "Move Selection Edges", DoesntModifyDocument);
+      Tx tx(writer, "Move Selection Edges", DoesntModifyDocument);
       tx(new cmd::SetMaskPosition(doc, newOrigin));
       tx.commit();
     }

--- a/src/app/ui/editor/moving_slice_state.cpp
+++ b/src/app/ui/editor/moving_slice_state.cpp
@@ -55,7 +55,7 @@ bool MovingSliceState::onMouseUp(Editor* editor, MouseMessage* msg)
 {
   {
     ContextWriter writer(UIContext::instance(), 1000);
-    Tx tx(writer.context(), "Slice Movement", ModifyDocument);
+    Tx tx(writer, "Slice Movement", ModifyDocument);
 
     for (const auto& item : m_items) {
       item.slice->insert(m_frame, item.oldKey);

--- a/src/app/ui/editor/pixels_movement.cpp
+++ b/src/app/ui/editor/pixels_movement.cpp
@@ -119,7 +119,8 @@ PixelsMovement::PixelsMovement(
   : m_reader(context)
   , m_site(site)
   , m_document(site.document())
-  , m_tx(context, operationName)
+  , m_tx(Tx::DontLockDoc, context,
+         context->activeDocument(), operationName)
   , m_isDragging(false)
   , m_adjustPivot(false)
   , m_handle(NoHandle)

--- a/src/app/ui/editor/tool_loop_impl.cpp
+++ b/src/app/ui/editor/tool_loop_impl.cpp
@@ -477,7 +477,9 @@ public:
                const bool saveLastPoint)
     : ToolLoopBase(editor, site, grid, params)
     , m_context(context)
-    , m_tx(m_context,
+    , m_tx(Tx::DontLockDoc,
+           m_context,
+           m_context->activeDocument(),
            m_tool->getText().c_str(),
            ((m_ink->isSelection() ||
              m_ink->isEyedropper() ||

--- a/src/app/ui/timeline/timeline.cpp
+++ b/src/app/ui/timeline/timeline.cpp
@@ -1387,7 +1387,8 @@ bool Timeline::onProcessMessage(Message* msg)
             if (tag) {
               if ((m_state == STATE_RESIZING_TAG_LEFT && tag->fromFrame() != m_resizeTagData.from) ||
                   (m_state == STATE_RESIZING_TAG_RIGHT && tag->toFrame() != m_resizeTagData.to)) {
-                Tx tx(UIContext::instance(), Strings::commands_FrameTagProperties());
+                ContextWriter writer(UIContext::instance());
+                Tx tx(writer, Strings::commands_FrameTagProperties());
                 tx(new cmd::SetTagRange(
                      tag,
                      (m_state == STATE_RESIZING_TAG_LEFT ? m_resizeTagData.from: tag->fromFrame()),
@@ -4389,7 +4390,9 @@ bool Timeline::onPaste(Context* ctx)
       m_redrawMarchingAntsOnly = false;
       invalidate();
     }
-    clipboard->paste(ctx, true);
+
+    ContextWriter writer(ctx);
+    clipboard->paste(writer, true);
     return true;
   }
   else

--- a/src/app/util/clipboard.cpp
+++ b/src/app/util/clipboard.cpp
@@ -362,7 +362,7 @@ void Clipboard::cut(ContextWriter& writer)
   else {
     // TODO This code is similar to DocView::onClear()
     {
-      Tx tx(writer.context(), "Cut");
+      Tx tx(writer, "Cut");
       Site site = writer.context()->activeSite();
       CelList cels;
       if (site.range().enabled()) {
@@ -461,10 +461,10 @@ void Clipboard::copyPalette(const Palette* palette,
   m_data->picks = picks;
 }
 
-void Clipboard::paste(Context* ctx,
+void Clipboard::paste(ContextWriter& writer,
                       const bool interactive)
 {
-  Site site = ctx->activeSite();
+  const Site site = *writer.site();
   Doc* dstDoc = site.document();
   if (!dstDoc)
     return;
@@ -531,7 +531,7 @@ void Clipboard::paste(Context* ctx,
         if (!dstLayer || !dstLayer->isImage())
           return;
 
-        Tx tx(ctx, "Paste Image");
+        Tx tx(writer, "Paste Image");
         DocApi api = dstDoc->getApi(tx);
         Cel* dstCel = api.addCel(
           static_cast<LayerImage*>(dstLayer), site.frame(),
@@ -611,7 +611,7 @@ void Clipboard::paste(Context* ctx,
             break;
           }
 
-          Tx tx(ctx, "Paste Cels");
+          Tx tx(writer, "Paste Cels");
           DocApi api = dstDoc->getApi(tx);
 
           // Add extra frames if needed
@@ -671,7 +671,7 @@ void Clipboard::paste(Context* ctx,
             break;
           }
 
-          Tx tx(ctx, "Paste Frames");
+          Tx tx(writer, "Paste Frames");
           DocApi api = dstDoc->getApi(tx);
 
           auto srcLayers = srcSpr->allBrowsableLayers();
@@ -714,7 +714,7 @@ void Clipboard::paste(Context* ctx,
           if (srcDoc->colorMode() != dstDoc->colorMode())
             throw std::runtime_error("You cannot copy layers of document with different color modes");
 
-          Tx tx(ctx, "Paste Layers");
+          Tx tx(writer, "Paste Layers");
           DocApi api = dstDoc->getApi(tx);
 
           // Remove children if their parent is selected so we only

--- a/src/app/util/clipboard.h
+++ b/src/app/util/clipboard.h
@@ -74,7 +74,8 @@ namespace app {
                      const doc::Tileset* tileset);
     void copyPalette(const doc::Palette* palette,
                      const doc::PalettePicks& picks);
-    void paste(Context* ctx, const bool interactive);
+    void paste(ContextWriter& writer,
+               const bool interactive);
 
     doc::ImageRef getImage(doc::Palette* palette);
 

--- a/src/app/util/layer_boundaries.cpp
+++ b/src/app/util/layer_boundaries.cpp
@@ -121,7 +121,7 @@ void select_layer_boundaries(Layer* layer,
       }
     }
 
-    Tx tx(writer.context(), "Select Layer Boundaries", DoesntModifyDocument);
+    Tx tx(writer, "Select Layer Boundaries", DoesntModifyDocument);
     tx(new cmd::SetMask(doc, &newMask));
     tx.commit();
 

--- a/src/doc/sprite.h
+++ b/src/doc/sprite.h
@@ -105,7 +105,7 @@ namespace doc {
     void setColorSpace(const gfx::ColorSpaceRef& colorSpace);
 
     // This method is only required/used for the template functions app::script::UserData_set_text/color.
-    const Sprite* sprite() const { return this; }
+    Sprite* sprite() const { return const_cast<Sprite*>(this); }
 
     // Returns true if the sprite has a background layer and it's visible
     bool isOpaque() const;


### PR DESCRIPTION
This is a work in progress for a minor refactoring to fix several sync issues (#2430) between the backup thread and the main thread when a script is modifying something of the sprite and the backup thread is working.