### PR TITLE
Avoid div by zero by preventing returning a grid bounds with zero width or height 

### DIFF
--- a/src/app/site.cpp
+++ b/src/app/site.cpp
@@ -98,25 +98,29 @@ Grid Site::grid() const
 
 gfx::Rect Site::gridBounds() const
 {
+  gfx::Rect bounds;
   if (m_layer && m_layer->isTilemap()) {
     const Grid& grid = static_cast<LayerTilemap*>(m_layer)->tileset()->grid();
     gfx::Point offset = grid.tileOffset();
     if (const Cel* cel = m_layer->cel(m_frame))
       offset += cel->bounds().origin();
-    return gfx::Rect(offset, grid.tileSize());
+    bounds = gfx::Rect(offset, grid.tileSize());
+    if (!bounds.isEmpty())
+      return bounds;
+  }
+  else {
+    if (m_sprite) {
+      bounds = m_sprite->gridBounds();
+      if (!bounds.isEmpty())
+        return bounds;
+    }
+    if (ui::is_ui_thread()) {
+      bounds = Preferences::instance().document(m_document).grid.bounds();
+      if (!bounds.isEmpty())
+        return bounds;
+    }
   }
 
-  gfx::Rect bounds;
-  if (m_sprite) {
-    bounds = m_sprite->gridBounds();
-    if (!bounds.isEmpty())
-      return bounds;
-  }
-  if (ui::is_ui_thread()) {
-    bounds = Preferences::instance().document(m_document).grid.bounds();
-    if (!bounds.isEmpty())
-      return bounds;
-  }
   return doc::Sprite::DefaultGridBounds();
 }
 


### PR DESCRIPTION
This PR is not an actual fix (it tries to fix #4146 by avoiding it) because I wasn't able to reproduce the issue, but I believe it can avoid the crash. 

Some context of the issue:
```c++
  gfx::Rect rc = gridBounds();
  doc::Grid grid = Grid(rc.size());
  grid.origin(gfx::Point(rc.x % rc.w, rc.y % rc.h));  // <-- div by zero can happen here
  return grid;
}
```
By looking at what the `gridBounds()` code does, seems that the only chance that some of the grid's dimension be zero could happen when a tilemap's tileset has a grid (for some reason I couldn't figure out) with width or height set to zero.
Then, to avoid returning a grid with zero size, I have added an if to check the grid size before returning it. If it is zero, then return the default grid bounds.

