### PR TITLE
Prevent setting slider ranges with min > max 

### DIFF
--- a/src/ui/slider.cpp
+++ b/src/ui/slider.cpp
@@ -30,23 +30,30 @@ static bool slider_press_left;
 
 Slider::Slider(int min, int max, int value, SliderDelegate* delegate)
   : Widget(kSliderWidget)
-  , m_min(min)
-  , m_max(max)
-  , m_value(std::clamp(value, min, max))
+  , m_value(value)
   , m_readOnly(false)
   , m_delegate(delegate)
 {
+  enforceValidRange(min, max);
   setFocusStop(true);
   initTheme();
 }
 
 void Slider::setRange(int min, int max)
 {
+  enforceValidRange(min, max);
+  invalidate();
+}
+
+void Slider::enforceValidRange(int min, int max)
+{
+  // Do not allow min > max
+  if (min > max)
+    max = min;
+
   m_min = min;
   m_max = max;
   m_value = std::clamp(m_value, min, max);
-
-  invalidate();
 }
 
 void Slider::setValue(int value)

--- a/src/ui/slider.h
+++ b/src/ui/slider.h
@@ -55,6 +55,7 @@ namespace ui {
 
   private:
     void setupSliderCursor();
+    void enforceValidRange(int min, int max);
 
     int m_min;
     int m_max;


### PR DESCRIPTION
Fix #4191 by preventing setting a slider range with a min limit greater than the max limit.