### PR TITLE
Update INSTALL.md for windows compilation such that a misleading arch…

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -129,9 +129,9 @@ On SUSE:
 
 Open a command prompt window (`cmd.exe`) and call:
 
-    call "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\VsDevCmd.bat" -arch=x64
+    call "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\VsDevCmd.bat" -arch=<target architecture>
 
-The command above is required while using the 64-bit version of skia. When compiling with the 32-bit version, it is possible to open a [developer command prompt](https://docs.microsoft.com/en-us/dotnet/framework/tools/developer-command-prompt-for-vs) instead.
+The command above is required while using the 64-bit version of skia. When compiling with the 32-bit version, it is possible to open a [developer command prompt](https://docs.microsoft.com/en-us/dotnet/framework/tools/developer-command-prompt-for-vs) instead. See this section to specify the correct [target architecture](https://learn.microsoft.com/en-us/visualstudio/ide/reference/command-prompt-powershell?view=vs-2022#target-architecture-and-host-architecture).
 
 And then
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -129,9 +129,9 @@ On SUSE:
 
 Open a command prompt window (`cmd.exe`) and call:
 
-    call "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\VsDevCmd.bat" -arch=<target architecture>
+    call "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\VsDevCmd.bat" -arch=amd64
 
-The command above is required while using the 64-bit version of skia. When compiling with the 32-bit version, it is possible to open a [developer command prompt](https://docs.microsoft.com/en-us/dotnet/framework/tools/developer-command-prompt-for-vs) instead. See this section to specify the correct [target architecture](https://learn.microsoft.com/en-us/visualstudio/ide/reference/command-prompt-powershell?view=vs-2022#target-architecture-and-host-architecture).
+The command above is required while using the 64-bit version of skia. When compiling with the 32-bit version, it is possible to open a [developer command prompt](https://docs.microsoft.com/en-us/dotnet/framework/tools/developer-command-prompt-for-vs) instead. Note the target architecture argument in the above command is set to a value of amd64. If you are compiling in an environment with a different architecture, you can specify it by using one of the values in the [target architecture](https://learn.microsoft.com/en-us/visualstudio/ide/reference/command-prompt-powershell?view=vs-2022#target-architecture-and-host-architecture) section.
 
 And then
 


### PR DESCRIPTION
…itecture option is avoided when calling the developer command prompt

As it exists today, the provided `call "...VsDevCmd.bat" -arch=x64` command will output the developer command prompt at startup then close itself after a few seconds. What's going on, is the command prompt is silently failing, because it doesn't recognize the "x64" value for the -arch argument. 

This change makes the example `call` have a generic value for target architecutre, and links to the documentation where the valid values can be reviewed.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the Individual Contributor License Agreement V4.0. -->
<!-- If you're a first-time contributor, please sign the CLA
     as indicated in https://github.com/igarastudio/cla#signing
     and acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing
