### PR TITLE
Add snap line to more angles (fix #1641)

### DIFF
--- a/src/app/tools/intertwine.cpp
+++ b/src/app/tools/intertwine.cpp
@@ -151,16 +151,18 @@ doc::AlgoLineWithAlgoPixel Intertwine::getLineAlgo(ToolLoop* loop,
     }
   }
 
-  if (// When "Snap Angle" in being used or...
-      (int(loop->getModifiers()) & int(ToolLoopModifiers::kSquareAspect)) ||
-      // "Snap to Grid" is enabled
-      (loop->getController()->canSnapToGrid() && loop->getSnapToGrid())) {
-    // We prefer the perfect pixel lines that matches grid tiles
+  if (loop->getController()->canSnapToGrid() && loop->getSnapToGrid()) {
+    // "Snap to Grid" is enabled. Has precedence over other modifiers.
     return (needsFixForLineBrush ? algo_line_perfect_with_fix_for_line_brush:
                                    algo_line_perfect);
   }
+  else if (int(loop->getModifiers()) & int(ToolLoopModifiers::kSquareAspect)) {
+    // When "Snap Angle" in being used.
+    return (needsFixForLineBrush ? algo_line_perfect_with_fix_for_line_brush:
+                                   algo_line_snap);
+  }
   else {
-    // In other case we use the regular algorithm that is useful to
+    // Otherwise use the regular algorithm that is useful to
     // draw continuous lines/strokes.
     return (needsFixForLineBrush ? algo_line_continuous_with_fix_for_line_brush:
                                    algo_line_continuous);

--- a/src/doc/algo.cpp
+++ b/src/doc/algo.cpp
@@ -20,6 +20,82 @@
 
 namespace doc {
 
+int algo_line_snap_endpoint(int* x_out, int* y_out, int x1, int y1, int x2, int y2)
+{
+  constexpr int MAX_M = 8;
+
+  int dx = x2 - x1;
+  int dy = y2 - y1;
+  const bool swapxy = std::abs(dy) > std::abs(dx);
+  if (swapxy) {
+    std::swap(dx, dy);
+  }
+
+  const int m_limit = std::min(MAX_M, std::max(1, std::abs(dx) / 2));
+  int m = dy != 0 ? (std::abs(dx) + std::abs(dy)/2) / std::abs(dy) : INT_MAX;
+  if (m > 2 * m_limit) m = INT_MAX;
+  else if (m > m_limit) m = m_limit;
+
+  if (!x_out || !y_out) {
+    return m;
+  }
+
+  if (m != INT_MAX) {
+    const int v2 = m*m + 1;
+    dx = SGN(dx) * (m * (std::abs(dx*m) + std::abs(dy)) + v2/2) / v2;
+    dy = SGN(dy) * std::abs(dx) / m;
+
+    if (swapxy) {
+      std::swap(dx, dy);
+    }
+    *x_out = x1 + dx;
+    *y_out = y1 + dy;
+  }
+  else {
+    if (swapxy) {
+      *x_out = x1;
+      *y_out = y2;
+    }
+    else {
+      *x_out = x2;
+      *y_out = y1;
+    }
+  }
+
+  return m;
+}
+
+void algo_line_snap(int x1, int y1, int x2, int y2, void* data, AlgoPixel proc)
+{
+  const int m = algo_line_snap_endpoint(nullptr, nullptr, x1, y1, x2, y2);
+
+  const bool swapxy = std::abs(y2-y1) > std::abs(x2-x1);
+  if (swapxy) {
+    std::swap(x1, y1);
+    std::swap(x2, y2);
+  }
+
+  const int dx = SGN(x2-x1);
+  const int dy = SGN(y2-y1);
+
+  x2 += dx;
+
+  int e = m;
+  int y = y1;
+  for (int x=x1; x!=x2; x+=dx) {
+    if (swapxy)
+      proc(y, x, data);
+    else
+      proc(x, y, data);
+
+    e--;
+    if (!e) {
+      y += dy;
+      e = m;
+    }
+  }
+}
+
 void algo_line_perfect(int x1, int y1, int x2, int y2, void* data, AlgoPixel proc)
 {
   bool yaxis;

--- a/src/doc/algo.h
+++ b/src/doc/algo.h
@@ -28,6 +28,10 @@ namespace doc {
   void algo_line_perfect(int x1, int y1, int x2, int y2, void* data, AlgoPixel proc);
   void algo_line_perfect_with_fix_for_line_brush(int x1, int y1, int x2, int y2, void *data, AlgoPixel proc);
 
+  // For lines with constant integer pixel runs throughout the line.
+  void algo_line_snap(int x1, int y1, int x2, int y2, void* data, AlgoPixel proc);
+  int algo_line_snap_endpoint(int* x_out, int* y_out, int x1, int y1, int x2, int y2);
+
   // Useful to create continuous lines (you can draw from one point to
   // another, and continue from that point to another in the same
   // angle and the line will look continous).


### PR DESCRIPTION
Here's a small Christmas gift. More angles to snap lines. Issue #1641.

Added the drawing routine `algo_line_snap()` because existing `algo_line_perfect()` didn't seem to work. In fact, for best results, the line pixel run length (`m`), of the snapping done in `controllers.h`, should be passed somehow to `algo_line_snap()`. I notice `data` parameter in the function, but I don't know if you'd like me to add something in `data` just for this feature?

Longest pixel run of the snapped lines are currently hard-coded to 8 px limit. If you're interested, I could add a feature that dynamically changes this limit based on the line length. For example, 12 px runs could work for a line of 24 px or longer (or, max run = line length / 2). I experimented this but didn't yet find a good formula for this max run. Let me know if you're interested in this. Note, the tool feel of this dynamic snapping may be a bit random to users, so if you like me to pursue this I need feedback about the feel.

Todo:

- [ ] Line brush drawing routine in `algo`.
- [ ] (Optional) Dynamic line pixel run length.
- [x] Line tool "Draw from center" (Ctrl) mode.

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing
