### PR TITLE
Fix Improve UX to recover files (fix #4130)

### DIFF
--- a/src/app/crash/session.cpp
+++ b/src/app/crash/session.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2023  Igara Studio S.A.
+// Copyright (C) 2019-2024  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -127,10 +127,8 @@ const Session::Backups& Session::backups()
 bool Session::isRunning()
 {
   loadPid();
-  if (m_pid)
-    return base::is_process_running(m_pid);
-  else
-    return false;
+  return base::get_process_name(m_pid) ==
+    base::get_process_name(base::get_current_process_id());
 }
 
 bool Session::isCrashedSession()


### PR DESCRIPTION
To implement this fix is needed https://github.com/aseprite/laf/pull/75 first

I think this solution can be improved on Windows since each session 'pid' is checked by iteratively searching all running processes in the operating system.

The best thing to do would be to create an array of 'pid' numbers belonging to running processes whose process name is 'aseprite.exe', then check to see if the 'pids' of each session match any element of the 'pid' array.

fix #4130