### PR TITLE
Fix Aseprite built-in file selector's file list layout to avoid horizontal scrolling

### DIFF
--- a/src/app/ui/file_selector.cpp
+++ b/src/app/ui/file_selector.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2023  Igara Studio S.A.
+// Copyright (C) 2019-2024  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -696,6 +696,12 @@ again:
   Preferences::instance().fileSelector.zoom(m_fileList->zoom());
 
   return (!output.empty());
+}
+
+void FileSelector::onOpen(Event& ev)
+{
+  app::gen::FileSelector::onOpen(ev);
+  onRefreshFolder();
 }
 
 bool FileSelector::onProcessMessage(ui::Message* msg)

--- a/src/app/ui/file_selector.h
+++ b/src/app/ui/file_selector.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2019-2024  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -46,6 +47,7 @@ namespace app {
               base::paths& output);
 
   private:
+    void onOpen(ui::Event& ev) override;
     bool onProcessMessage(ui::Message* msg) override;
 
     void updateLocation();


### PR DESCRIPTION
Fix #4183