### PR TITLE
Add sprite user data when exporting documents

### DIFF
--- a/src/app/doc_exporter.cpp
+++ b/src/app/doc_exporter.cpp
@@ -1434,6 +1434,31 @@ void DocExporter::createDataFile(const Samples& samples,
      << "\"h\": " << texture->height() << " },\n"
      << "  \"scale\": \"1\"";
 
+  {
+    bool firstDoc = true;
+  
+    std::set<doc::ObjectId> includedSprites;
+
+    for (auto& item : m_documents) {
+      if (firstDoc)
+        firstDoc = false;
+      else
+        os << ",";
+  
+      Doc* doc = item.doc;
+      Sprite* sprite = doc->sprite();
+
+      // Avoid including the same document more than once
+      if (includedSprites.find(sprite->id()) != includedSprites.end())
+        continue;
+      includedSprites.insert(sprite->id());
+  
+      os << "\n   { \"name\": \"" << doc->name() << "\"" << sprite->userData() << " }";
+    }
+  
+    os << "\n  ]";
+  }
+
   // meta.frameTags
   if (m_listTags) {
     os << ",\n"


### PR DESCRIPTION
I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing

---

As discussed [here](https://discord.com/channels/324979738533822464/348146938530496513/1203072349398634547) on discord, sprite user data are not exported when creating the json file.
This PR adds them to the `"meta"` section, as in:
```json
 "meta": {
  "app": "https://www.aseprite.org/",
  "version": "1.x-dev",
  "image": "test.png",
  "format": "RGBA8888",
  "size": { "w": 64, "h": 64 },
  "scale": "1",
  "documents": [
   { "name": "test.aseprite", "data": "my data" }
  ],
  "frameTags": [ ... ],
  "layers": [ ... ],
  "slices": [ ... ]
 }
```
I've no idea if this is a _correct_ result for the spirit of this software but I had to start somewhere, right? 🙂 
Let me know if this doesn't meet your tastes and what I can do to have this data in the final json.
I find this data to be pointless otherwise since one cannot export and thus use them properly.