### PR TITLE
Fix exporting one tag without "play subtags/repeats" and changing itsanidir

### DIFF
--- a/src/app/ui/layer_frame_comboboxes.cpp
+++ b/src/app/ui/layer_frame_comboboxes.cpp
@@ -195,6 +195,18 @@ doc::Tag* calculate_frames_sequence(const Site& site,
     SelectedFrames selFrames;
     tag = calculate_selected_frames(site, framesValue, selFrames);
     framesSeq = FramesSequence(selFrames);
+    switch (aniDir) {
+      case AniDir::REVERSE:
+        framesSeq = framesSeq.makeReverse();
+        break;
+      case AniDir::PING_PONG:
+        framesSeq = framesSeq.makePingPong();
+        break;
+      case AniDir::PING_PONG_REVERSE:
+        framesSeq = framesSeq.makeReverse();
+        framesSeq = framesSeq.makePingPong();
+        break;
+    }
   }
   else {
     frame_t start = 0;

--- a/src/doc/frames_sequence.cpp
+++ b/src/doc/frames_sequence.cpp
@@ -171,7 +171,7 @@ FramesSequence FramesSequence::makePingPong() const
     if (i == 0) reversedRange.toFrame+=step;
     if (j == 0) reversedRange.fromFrame-=step;
 
-    if (reversedRange.fromFrame != reversedRange.toFrame)
+    if (reversedRange != range)
       newFrames.m_ranges.insert(
         newFrames.m_ranges.begin() + n,
         reversedRange);

--- a/src/doc/frames_sequence_tests.cpp
+++ b/src/doc/frames_sequence_tests.cpp
@@ -196,6 +196,33 @@ TEST(FramesSequence, MakeReverse)
   EXPECT_EQ(1, res[13]);
 }
 
+TEST(FramesSequence, MakePingPong)
+{
+  FramesSequence f;
+  f.insert(1, 3);
+  EXPECT_EQ(3, f.size());
+  EXPECT_EQ(1, f.ranges());
+  f = f.makePingPong();
+  EXPECT_EQ(4, f.size());
+  EXPECT_EQ(2, f.ranges());
+
+  FramesSequence f2;
+  f2.insert(1, 2);
+  EXPECT_EQ(2, f2.size());
+  EXPECT_EQ(1, f2.ranges());
+  f2 = f2.makePingPong();
+  EXPECT_EQ(2, f2.size());
+  EXPECT_EQ(1, f2.ranges());
+
+  FramesSequence f3;
+  f3.insert(1, 1);
+  EXPECT_EQ(1, f3.size());
+  EXPECT_EQ(1, f3.ranges());
+  f3 = f3.makePingPong();
+  EXPECT_EQ(1, f3.size());
+  EXPECT_EQ(1, f3.ranges());
+}
+
 TEST(FramesSequence, MakePingPongAndFilter)
 {
   FramesSequence f;


### PR DESCRIPTION
Fix #4297

This PR just fixes one of the issues mentioned in #4297. It also fixes some issues in the FramesSequence class: when the sequence had 1 range with 2 or 3 frames it would behave incorrectly. New tests were added because of this.