### PR TITLE
Fix 'Bad substitution' in Linux thumbnailer

### DIFF
--- a/src/desktop/linux/aseprite-thumbnailer
+++ b/src/desktop/linux/aseprite-thumbnailer
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/usr/bin/bash
 
 # Aseprite Desktop Integration Module
 # Copyright (C) 2016  Gabriel Rauter


### PR DESCRIPTION
[aseprite-thumbnailer](https://github.com/aseprite/aseprite/tree/0d5075f/src/desktop/linux/aseprite-thumbnailer) was failing (on Ubuntu 23.10) due to `Bad substitution` on this line:
https://github.com/aseprite/aseprite/blob/0d5075ff9363c3d7d7c1918458b5aea3bc876100/src/desktop/linux/aseprite-thumbnailer#L10

I think the script was written in an environment where `sh` linked to `bash`, whereas some distributions link it to something else (`dash` in my case). Changing the shebang line to `#!/usr/bin/bash` fixes it in my case.

I'm not very familiar with shell scripting, so I'd appreciate if someone could confirm this works on their system as well before merging.