### PR TITLE
Enable websocket SSL/TLS support

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -767,6 +767,8 @@ if(ENABLE_SCRIPTING)
 
   if(ENABLE_WEBSOCKET)
     target_link_libraries(app-lib ixwebsocket)
+
+    target_compile_definitions(app-lib PUBLIC USE_TLS=1)
   endif()
 endif()
 


### PR DESCRIPTION
Just creating this to show that it should be relatively easy to support. Will close it. I expect there may be more considerations of course.

Compiled with this setup: https://github.com/nilsve/docker-aseprite-linux