### PR TITLE
Fix nested tag with "Ping-Pong" repeat mode causes to skip the first frame of the parent tag (fix #4271)

### DIFF
--- a/src/doc/playback.cpp
+++ b/src/doc/playback.cpp
@@ -1,5 +1,5 @@
 // Aseprite Document Library
-// Copyright (C) 2021-2022  Igara Studio S.A.
+// Copyright (C) 2021-2024  Igara Studio S.A.
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -167,7 +167,7 @@ void Playback::handleEnterFrame(const frame_t frameDelta, const bool firstTime)
     case PlayAll:
     case PlayInLoop: {
       const Tag* tag = this->tag();
-      const frame_t frame = m_frame;
+      frame_t frame = m_frame;
       const int forward = getParentForward();
 
       for (const Tag* t : m_tags) {
@@ -185,8 +185,15 @@ void Playback::handleEnterFrame(const frame_t frameDelta, const bool firstTime)
           }
           else {
             addTag(t, false, forward);
-            if (!firstTime)
+            if (!firstTime) {
               goToFirstTagFrame(t);
+              // Consideration for tests:
+              // Playback.OnePingPongInsidePingPongReverse
+              // Playback.OneReverseInsidePingPongReverse
+              // Playback.OnePingPongReverseInsideReverse
+              if (frame != m_frame)
+                handleEnterFrame(m_frame, firstTime);
+            }
           }
         }
       }
@@ -461,6 +468,7 @@ bool Playback::decrementRepeat(const frame_t frameDelta)
         newFrame = firstTagFrame(m_playing.back()->tag);
       }
       else {
+        // Note that 'tag' means 'the last tag removed from m_playing'
         newFrame = (frameDelta * forward < 0 ? tag->fromFrame()-1: tag->toFrame()+1);
       }
 
@@ -473,10 +481,96 @@ bool Playback::decrementRepeat(const frame_t frameDelta)
           stop();
           return false;
         }
-        if (newFrame < 0)
-          newFrame = m_sprite->lastFrame();
-        else if (newFrame > m_sprite->lastFrame())
-          newFrame = 0;
+        if (newFrame < 0) {
+          if (m_playing.empty() ||
+              m_playing.back()->tag->fromFrame() != 0 ||
+              m_playing.back()->tag->aniDir() == AniDir::REVERSE) {
+            m_frame = m_sprite->lastFrame();
+            return false;
+          }
+          // Special cases arise with PING_PONG_REVERSE aniDir and when
+          // the begining of the tag range matches with the first frame of
+          // the sprite.
+          // Consideration for tests inside:
+          // Playback.OnePingPongInsideOther
+          //     A            A
+          // >-------<    >-------<
+          //   B            B
+          // <--->        >---<
+          // 0 1 2 3 4    0 1 2 3 4
+          PlayTag* parentPlaying = m_playing.back().get();
+          // When parentPlaying is PING_PONG_REVERSE
+          // the next frame will be defined according:
+          // 1. The playloop has more repetitions to decrement
+          //    --> go to the next frame of the 'tag'
+          // 2. The playloop has no more repetitions to decrement
+          //    --> Start all the playloop again.
+          if (parentPlaying->repeat > 1) {
+            if (parentPlaying->tag->aniDir() == AniDir::PING_PONG_REVERSE)
+              parentPlaying->invertForward();
+            --parentPlaying->repeat;
+            newFrame = tag->toFrame() + 1;
+          }
+          else
+            continue;
+        }
+        else if (newFrame > m_sprite->lastFrame()) {
+          // If all the tags were played and
+          // the 'tag' range  ==  timeline range and
+          // the 'tag' is PING_PONG_REVERSE -->
+          // The playloop has to start on the last frame of
+          // the timeline, or the first frame of the most nested
+          // tag (on reverse direction).
+          // Consideration for tests:
+          // Playback.WithTagRepetitions
+          // Playback.OnePingPongInsideOther
+          // Playback.OnePingPongInsideOther14, 15, 18 and 19
+          //    A      <-- last tag removed from 'm_playing', i.e. 'tag'
+          // >-----<
+          //    B      <-- most nested tag
+          // ***-***
+          // 0 1 2 3
+          if (m_playing.empty() &&
+              tag->aniDir() == AniDir::PING_PONG_REVERSE &&
+              tag->fromFrame() == 0 &&
+              tag->toFrame() == m_sprite->lastFrame()) {
+            m_frame = m_sprite->lastFrame();
+            handleEnterFrame(frameDelta, false);
+            if (m_playing.size() > 1) {
+              m_playing.back()->invertForward();
+              goToFirstTagFrame(m_playing.back()->tag);
+            }
+            return false;
+          }
+
+          // 'tag' is contained by other tag and the last frame of each tag
+          // matches in the last frame of the sprite
+          if (!m_playing.empty() &&
+              tag->toFrame() == m_playing.back()->tag->toFrame()) {
+            PlayTag* parentPlaying = m_playing.back().get();
+            // The parentPlaying has no more repetitions to decrement
+            //    --> continue to remove the 'parentTag'
+            if (parentPlaying->repeat <= 1)
+              continue;
+            // Consideration for test:
+            // Playback.OnePingPongInsideOther
+            if (parentPlaying->tag->aniDir() == AniDir::PING_PONG ||
+                parentPlaying->tag->aniDir() == AniDir::PING_PONG_REVERSE) {
+              parentPlaying->invertForward();
+              newFrame = tag->fromFrame() - 1;
+            }
+            // Consideration for test:
+            // Playback.OnePingPongInsideForward2
+            else if (parentPlaying->tag->aniDir() == AniDir::FORWARD) {
+              --parentPlaying->repeat;
+              newFrame = parentPlaying->tag->fromFrame();
+            }
+            else
+              newFrame = 0;
+          }
+          else
+            newFrame = 0;
+        }
       }
 
       m_frame = newFrame;

--- a/src/doc/playback_tests.cpp
+++ b/src/doc/playback_tests.cpp
@@ -506,29 +506,27 @@ TEST(Playback, PingPongWithInnerReverse)
 }
 
 // OnePingPongInsideOther series
-std::vector<int> goRight(std::vector<int> range) {
+static std::vector<int> goRight(const int a, const int b) {
   std::vector<int> out;
-  if (range[0] > range[1])
+  if (a > b)
     return out;
-  for (int i=range[0]; i<range[1]+1 ; ++i)
+  for (int i=a; i<=b ; ++i)
     out.push_back(i);
   return out;
 }
 
-std::vector<int> goLeft(std::vector<int> range) {
+std::vector<int> goLeft(const int a, const int b) {
   std::vector<int> out;
-  if (range[0] > range[1])
+  if (a > b)
     return out;
-  for (int i=range[1]; i>range[0]-1 ; --i)
+  for (int i=b; i>=a ; --i)
     out.push_back(i);
   return out;
 }
 
-void concat(std::vector<int>& a, std::vector<int>& b)
+static void concat(std::vector<int>& a, const std::vector<int>& b)
 {
-  if (b.empty())
-    return;
-  for (int i=0; i<b.size(); ++i)
+  for (size_t i=0; i<b.size(); ++i)
     a.push_back(b[i]);
 }
 
@@ -564,7 +562,7 @@ TEST(Playback, OnePingPongInsideOther)
         if (A_aniDir == doc::AniDir::PING_PONG) {
 
           // Start
-          temp = goRight({0, B_Range[0]-1});
+          temp = goRight(0, B_Range[0]-1);
           concat(expected, temp);
 
           // Tag B playback
@@ -576,9 +574,9 @@ TEST(Playback, OnePingPongInsideOther)
             concat(expected, B_aniDir == doc::AniDir::PING_PONG ? pingPongSeq3[0] : pingPongSeq3[1]);
 
           // Reproduce right side of the tag A
-          temp = goRight({B_Range[1]+1, lastFrame});
+          temp = goRight(B_Range[1]+1, lastFrame);
           concat(expected, temp);
-          temp = goLeft({B_Range[1]+1, lastFrame-1});
+          temp = goLeft(B_Range[1]+1, lastFrame-1);
           concat(expected, temp);
 
           // Tag B playback (only if tag B last frame doesn't match with the tag A last frame
@@ -590,7 +588,7 @@ TEST(Playback, OnePingPongInsideOther)
           }
 
           // Reproduce right side of the tag A
-          temp = goLeft({0, B_Range[0]-1});
+          temp = goLeft(0, B_Range[0]-1);
           concat(expected, temp);
           // Sequence end
         }
@@ -602,7 +600,7 @@ TEST(Playback, OnePingPongInsideOther)
         else {
 
           // Start
-          temp = goRight({0, B_Range[0]-1});
+          temp = goRight(0, B_Range[0]-1);
           concat(expected, temp);
 
           // Tag B playback
@@ -614,12 +612,12 @@ TEST(Playback, OnePingPongInsideOther)
             concat(expected, B_aniDir == doc::AniDir::PING_PONG ? pingPongSeq3[0] : pingPongSeq3[1]);
 
           // Reproduce right side of the tag A
-          temp = goRight({B_Range[1]+1, lastFrame});
+          temp = goRight(B_Range[1]+1, lastFrame);
           concat(expected, temp);
           // Sequence end
 
           // New Start
-          temp = goLeft({B_Range[1]+1, lastFrame});
+          temp = goLeft(B_Range[1]+1, lastFrame);
           concat(expected, temp);
 
           // Tag B playback
@@ -631,9 +629,9 @@ TEST(Playback, OnePingPongInsideOther)
             concat(expected, B_aniDir == doc::AniDir::PING_PONG ? pingPongSeq1[1] : pingPongSeq1[0]);
 
           // Reproduce left side of the tag A
-          temp = goLeft({0, B_Range[0]-1});
+          temp = goLeft(0, B_Range[0]-1);
           concat(expected, temp);
-          temp = goRight({1, B_Range[0]-1});
+          temp = goRight(1, B_Range[0]-1);
           concat(expected, temp);
 
           // Tag B playback (only if tag B first frame doesn't match with the tag A first frame
@@ -644,7 +642,7 @@ TEST(Playback, OnePingPongInsideOther)
 
 
           // Reproduce right side of the tag A
-          temp = goRight({B_Range[1]+1, lastFrame});
+          temp = goRight(B_Range[1]+1, lastFrame);
           concat(expected, temp);
           // Sequence end
         }
@@ -694,7 +692,7 @@ TEST(Playback, OnePingPongInsideOther1Repeat)
         if (A_aniDir == doc::AniDir::PING_PONG) {
 
           // Start
-          temp = goRight({0, B_Range[0]-1});
+          temp = goRight(0, B_Range[0]-1);
           concat(expected, temp);
           // Tag B playback
           if (B_Range[0] == 0) {
@@ -706,12 +704,12 @@ TEST(Playback, OnePingPongInsideOther1Repeat)
           else if (B_Range[0] == 2)
             concat(expected, B_aniDir == doc::AniDir::PING_PONG ? pingPongSeq3[0] : pingPongSeq3[1]);
           // Reproduce right side of the tag A
-          temp = goRight({B_Range[1]+1, lastFrame});
+          temp = goRight(B_Range[1]+1, lastFrame);
           concat(expected, temp);
           // Sequence end
 
           // Fresh sequence start
-          temp = goRight({0, B_Range[0]-1});
+          temp = goRight(0, B_Range[0]-1);
           concat(expected, temp);
           // Tag B playback
           if (B_Range[0] == 0)
@@ -721,7 +719,7 @@ TEST(Playback, OnePingPongInsideOther1Repeat)
           else if (B_Range[0] == 2)
             concat(expected, B_aniDir == doc::AniDir::PING_PONG ? pingPongSeq3[0] : pingPongSeq3[1]);
           // Reproduce right side of the tag A
-          temp = goRight({B_Range[1]+1, lastFrame});
+          temp = goRight(B_Range[1]+1, lastFrame);
           concat(expected, temp);
           // Sequence end
 
@@ -743,7 +741,7 @@ TEST(Playback, OnePingPongInsideOther1Repeat)
 
           // Fresh sequence start
           // Reproduce right side of the tag A
-          temp = goLeft({B_Range[1]+1, lastFrame});
+          temp = goLeft(B_Range[1]+1, lastFrame);
           concat(expected, temp);
 
           // Tag B playback
@@ -755,7 +753,7 @@ TEST(Playback, OnePingPongInsideOther1Repeat)
             concat(expected, B_aniDir == doc::AniDir::PING_PONG ? pingPongSeq1[1] : pingPongSeq1[0]);
 
           // Reproduce left side of the tag A
-          temp = goLeft({0, B_Range[0]-1});
+          temp = goLeft(0, B_Range[0]-1);
           concat(expected, temp);
           // Sequence end
         }


### PR DESCRIPTION
Issue #4271 has two issues (solved):
1. The nested tag with repeat mode "Ping-Pong" causes it to skip the first frame of the parent tag when it has to repeat the playback sequence.
2. Nested tag with "Ping-Pong" repeat mode causes to cancel the "Ping-Pong" sequence on its parent tag when it has to repeat the playback sequence.
And I found others (solved too):
3. Tag starting on frame 1 + "Ping-Pong Reverse" stops repeting the sequence on frame 1 when repeat = 1.
4. Tag starting on frame 1 + "Ping-Pong Reverse"  skips at least a sequence. For example: when repeat = 2 and aniDir = "Ping-Pong Reverse" the sequence is like aniDir = "Forward".