### PR TITLE
Fix crashes with SpriteJob(s) that weren't locking the doc correctly

### DIFF
--- a/src/app/job.cpp
+++ b/src/app/job.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2021  Igara Studio S.A.
+// Copyright (C) 2021-2024  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -33,7 +33,7 @@ int Job::runningJobs()
   return g_runningJobs;
 }
 
-Job::Job(const char* jobName)
+Job::Job(const std::string& jobName)
 {
   m_last_progress = 0.0;
   m_done_flag = false;

--- a/src/app/job.h
+++ b/src/app/job.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2021  Igara Studio S.A.
+// Copyright (C) 2021-2024  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -15,6 +15,7 @@
 #include <atomic>
 #include <exception>
 #include <mutex>
+#include <string>
 #include <thread>
 
 namespace app {
@@ -23,7 +24,7 @@ namespace app {
   public:
     static int runningJobs();
 
-    Job(const char* jobName);
+    Job(const std::string& jobName);
     virtual ~Job();
 
     // Starts the job calling onJob() event in another thread and

--- a/src/app/sprite_job.cpp
+++ b/src/app/sprite_job.cpp
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2024  Igara Studio S.A.
 // Copyright (C) 2017  David Capello
 //
 // This program is distributed under the terms of
@@ -10,26 +11,49 @@
 
 #include "app/sprite_job.h"
 
+#include "base/log.h"
+
 namespace app {
 
-SpriteJob::SpriteJob(const ContextReader& reader, const char* jobName)
+SpriteJob::SpriteJob(Context* ctx, Doc* doc,
+                     const std::string& jobName)
   : Job(jobName)
-  , m_writer(reader, 500)
-  , m_document(m_writer.document())
-  , m_sprite(m_writer.sprite())
-  , m_tx(m_writer, jobName, ModifyDocument)
+  , m_doc(doc)
+  , m_sprite(doc->sprite())
+  , m_tx(Tx::DontLockDoc, ctx, doc, jobName, ModifyDocument)
+  , m_lockAction(Tx::LockDoc)
 {
+  // Try to write-lock the document to see if we have to lock the
+  // document in the background thread.
+  auto lockResult = m_doc->writeLock(500);
+  if (lockResult != Doc::LockResult::Fail) {
+    if (lockResult == Doc::LockResult::Reentrant)
+      m_lockAction = Tx::DontLockDoc;
+    m_doc->unlock(lockResult);
+  }
 }
 
 SpriteJob::~SpriteJob()
 {
-  if (!isCanceled())
-    m_tx.commit();
+  try {
+    if (!isCanceled())
+      m_tx.commit();
+  }
+  catch (const std::exception& ex) {
+    LOG(ERROR, "Error committing changes: %s\n", ex.what());
+  }
+}
+
+void SpriteJob::onSpriteJob(Tx& tx)
+{
+  if (m_callback)
+    m_callback(tx);
 }
 
 void SpriteJob::onJob()
 {
-  m_callback();
+  Tx subtx(m_lockAction, m_ctx, m_doc);
+  onSpriteJob(subtx);
 }
 
 bool SpriteJob::continueTask()

--- a/src/app/sprite_job.h
+++ b/src/app/sprite_job.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2024  Igara Studio S.A.
 // Copyright (C) 2017-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -15,19 +16,32 @@
 #include "render/task_delegate.h"
 
 #include <functional>
+#include <memory>
+#include <string>
 
 namespace app {
 
+class Context;
+
+// Creates a Job to run a task in a background thread. At the same
+// time it creates a new Tx in the main thread (to group all sub-Txs)
+// without locking the sprite. You have to lock the sprite with a sub
+// Tx (the onSpriteJob(Tx) already has the sprite locked for write
+// access).
+//
+// This class takes care to lock the sprite in the background thread
+// for write access, or to avoid re-locking the sprite in case it's
+// already locked from the main thread (where SpriteJob was created,
+// generally true when we're running a script).
 class SpriteJob : public Job,
                   public render::TaskDelegate {
 public:
-  SpriteJob(const ContextReader& reader, const char* jobName);
+  SpriteJob(Context* ctx, Doc* doc,
+            const std::string& jobName);
   ~SpriteJob();
 
-  ContextWriter& writer() { return m_writer; }
-  Doc* document() const { return m_document; }
+  Doc* document() const { return m_doc; }
   Sprite* sprite() const { return m_sprite; }
-  Tx& tx() { return m_tx; }
 
   template<typename T>
   void startJobWithCallback(T&& callback) {
@@ -36,6 +50,8 @@ public:
   }
 
 private:
+  virtual void onSpriteJob(Tx& tx);
+
   // Job impl
   void onJob() override;
 
@@ -44,15 +60,21 @@ private:
   bool continueTask() override;
   void notifyTaskProgress(double progress) override;
 
-  ContextWriter m_writer;
-  Doc* m_document;
+  Context* m_ctx;
+  Doc* m_doc;
   Sprite* m_sprite;
   Tx m_tx;
+
+  // What action to do with the sub-Tx inside the background thread.
+  // This is required to check if the sprite is already locked for
+  // write access in the main thread, in that case we don't need to
+  // lock it again from the background thread.
+  Tx::LockAction m_lockAction;
 
   // Default implementation calls the given function in
   // startJob(). Anyway you can just extended the SpriteJob and
   // override onJob().
-  std::function<void()> m_callback;
+  std::function<void(Tx&)> m_callback;
 };
 
 } // namespace app


### PR DESCRIPTION
This fixes #4315.