### PR TITLE
Show format within filename when exporting file

### DIFF
--- a/src/app/ui/export_file_window.cpp
+++ b/src/app/ui/export_file_window.cpp
@@ -192,8 +192,14 @@ void ExportFileWindow::setAniDir(const doc::AniDir aniDir)
 
 void ExportFileWindow::setOutputFilename(const std::string& pathAndFilename)
 {
-  m_outputPath = base::get_file_path(pathAndFilename);
-  m_outputFilename = base::get_file_name(pathAndFilename);
+  if (base::get_file_path(m_doc->filename()).empty()) {
+    m_outputPath = base::get_file_path(pathAndFilename);
+    m_outputFilename = base::get_file_name(pathAndFilename);
+  }
+  else {
+    m_outputPath = base::get_file_path(m_doc->filename());
+    m_outputFilename = base::get_relative_path(pathAndFilename, base::get_file_path(m_doc->filename()));
+  }
 
   updateOutputFilenameEntry();
 }


### PR DESCRIPTION
### Bug Description
The `export_file_window` was displaying only the filename instead of the entire path, leading to confusion for users, especially when including dynamic placeholders such as {tag} in the file path.

### Cause of the Bug
Within the `ExportFileWindow` class, the method `setOutputFilename` split the provided path into `m_outputPath` and `m_outputFilename`, causing the window to display only the filename. Consequently, dynamic placeholders like {tag} were omitted from the displayed path, leading to ambiguity for users.

### Impact
This behavior caused confusion and made it difficult for users to accurately discern the file's destination, particularly when using dynamic placeholders. It also difficulted clearing dynamic placeholders from the export path, as it is not shown in the window.

### Solution
To address this issue, the following changes were implemented:

- Exposed `path_formats` defined in `filename_formatter`, modifying its type from `vector` to `array` for improved performance.
- During the assignment of `m_outputPath` and `m_outputFilename`, dynamic placeholders such as {tag} are now considered part of `m_outputFilename` and excluded from `m_outputPath`.

#### Example
With the new behavior, let's consider the export path: `/home/user/{tag}/test/{frame}/file.png`.

- `m_outputPath` will be `/home/user/`
- `m_outputFilename` will be `{tag}/test/{frame}/file.png`

Now, the displayed path will include the entire dynamic placeholder structure, providing users with clear visibility of the file's destination and enabling the editing of these parameters.

### Future Considerations
Maintainers should be aware of potential implications when modifying path-related functionalities in the future. Additionally, it's essential to maintain consistency in handling dynamic placeholders across the application to avoid similar issues.

Resolves #4059

I acknowledge that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA"), as stated in [CLA.md](https://github.com/igarastudio/cla/blob/main/cla.md).

I have signed the CLA following the steps provided [here](https://github.com/igarastudio/cla#signing).