### PR TITLE
fix #4217: Disable mouse stabilizer while previewing a straight line

### DIFF
--- a/src/app/tools/tool_loop_manager.cpp
+++ b/src/app/tools/tool_loop_manager.cpp
@@ -202,6 +202,12 @@ void ToolLoopManager::movement(Pointer pointer)
   doLoopStep(false);
 }
 
+void ToolLoopManager::disableMouseStabilizer() 
+{
+  // Disable mouse stabilizer for the current ToolLoopManager
+  m_dynamics.stabilizer = false;
+}
+
 void ToolLoopManager::doLoopStep(bool lastStep)
 {
   // Original set of points to interwine (original user stroke,

--- a/src/app/tools/tool_loop_manager.h
+++ b/src/app/tools/tool_loop_manager.h
@@ -78,6 +78,10 @@ public:
   // Should be called each time the user moves the mouse inside the editor.
   void movement(Pointer pointer);
 
+  // Should be called when Shift+brush tool is used to disable stabilizer
+  // on the line preview
+  void disableMouseStabilizer();
+
   const Pointer& lastPointer() const { return m_lastPointer; }
 
 private:

--- a/src/app/ui/editor/drawing_state.cpp
+++ b/src/app/ui/editor/drawing_state.cpp
@@ -129,6 +129,12 @@ void DrawingState::initToolLoop(Editor* editor,
   editor->captureMouse();
 }
 
+void DrawingState::disableMouseStabilizer() 
+{
+  ASSERT(m_toolLoopManager);
+  m_toolLoopManager->disableMouseStabilizer();
+}
+
 void DrawingState::sendMovementToToolLoop(const tools::Pointer& pointer)
 {
   ASSERT(m_toolLoopManager);

--- a/src/app/ui/editor/drawing_state.h
+++ b/src/app/ui/editor/drawing_state.h
@@ -60,6 +60,10 @@ namespace app {
                       const ui::MouseMessage* msg,
                       const tools::Pointer& pointer);
 
+    // Used to disable the current ToolLoopManager's stabilizer
+    // when Shift+brush tool is used to paint a line
+    void disableMouseStabilizer();
+
     // Used to send a movement() to the ToolLoopManager when
     // Shift+brush tool is used to paint a line.
     void sendMovementToToolLoop(const tools::Pointer& pointer);

--- a/src/app/ui/editor/standby_state.cpp
+++ b/src/app/ui/editor/standby_state.cpp
@@ -696,6 +696,9 @@ bool StandbyState::checkStartDrawingStraightLine(Editor* editor,
                           pointer ? pointer->type(): PointerType::Unknown,
                           pointer ? pointer->pressure(): 0.0f));
     if (drawingState) {
+      // Disable stabilizer so that it does not affect the line preview
+      drawingState->disableMouseStabilizer();
+      
       drawingState->sendMovementToToolLoop(
         tools::Pointer(
           pointer ? pointer->point(): editor->screenToEditor(editor->mousePosInDisplay()),


### PR DESCRIPTION
# Pull Request: Fixing Bug #4217 

## Description

This pull request addresses and fixes bug #4217 , where the stabilizer feature interferes with the creation of straight lines when the Shift key is pressed during freehand drawing.

## Changes Made

- Added a statement to deactivate the stabilizer when the Shift key is pressed during freehand drawing events.
- Integrated the modified stabilizer behavior into the drawing tool's event handling mechanism.

## Cause

The root cause of the issue was identified as a lack of logic within the StraightLine Tool to deactivate the stabilizer when the Shift key was pressed during freehand drawing.

## Fix

To address the issue, the code was modified to include a statement that deactivates the stabilizer when a new DrawingState is created when starting line preview with shift key .

---

Thank you for considering this pull request. I look forward to your review and feedback.

This commit addresses the issue where the Shift+brush tool was not disabling the mouse stabilizer, leading to unintended behavior when previewing a line. This commit adds the necessary implementation to properly disable the stabilizer when Shift+brush tool is used. Additionally, the function DrawingState::disableMouseStabilizer() now calls ToolLoopManager::disableMouseStabilizer() to ensure the stabilizer is disabled correctly.

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing
