### PR TITLE
zlib: Update to 1.3.1

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -96,9 +96,7 @@ if(ENABLE_PSD)
 endif()
 
 # libarchive definitions
-add_definitions(-DLIBARCHIVE_STATIC)
-add_definitions(-DHAVE_WCSCPY)
-add_definitions(-DHAVE_WCSLEN)
+add_definitions(-DLIBARCHIVE_STATIC -DHAVE_WCSCPY=1 -DHAVE_WCSLEN=1)
 
 ######################################################################
 # app-lib target

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -97,6 +97,8 @@ endif()
 
 # libarchive definitions
 add_definitions(-DLIBARCHIVE_STATIC)
+add_definitions(-DHAVE_WCSCPY)
+add_definitions(-DHAVE_WCSLEN)
 
 ######################################################################
 # app-lib target

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -95,8 +95,11 @@ if(ENABLE_PSD)
   add_definitions(-DENABLE_PSD)
 endif()
 
-# libarchive definitions
-add_definitions(-DLIBARCHIVE_STATIC -DHAVE_WCSCPY=1 -DHAVE_WCSLEN=1)
+# libarchive definitions and variables
+add_definitions(-DLIBARCHIVE_STATIC)
+
+set(HAVE_WCSCPY 1)
+set(HAVE_WCSLEN 1)
 
 ######################################################################
 # app-lib target

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 if(NOT USE_SHARED_ZLIB)
   set(SKIP_INSTALL_ALL on)
   # Don't build zlib tests
-  set(ZLIB_TESTS OFF CACHE BOOL "Build zlib tests")
+  set(ZLIB_BUILD_EXAMPLES OFF CACHE BOOL "Build zlib tests")
   add_subdirectory(zlib)
 endif()
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 if(NOT USE_SHARED_ZLIB)
   set(SKIP_INSTALL_ALL on)
   # Don't build zlib tests
-  set(ZLIB_BUILD_EXAMPLES OFF CACHE BOOL "Build zlib tests")
+  set(ZLIB_BUILD_EXAMPLES OFF CACHE BOOL "Enable Zlib Examples")
   add_subdirectory(zlib)
 endif()
 


### PR DESCRIPTION
- This PR updates the third party library `zlib` to current stable upstream version: `1.3.1`.
- Since commit https://github.com/madler/zlib/commit/6201f893846bfd22faf060e84a3bb7bfc0e61761 no patches are needed downstream.
- Full changelog: https://github.com/madler/zlib/compare/v1.2.11...v1.3.1.

---

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing
