### PR TITLE
zlib: Update to 1.3.1

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 if(NOT USE_SHARED_ZLIB)
   set(SKIP_INSTALL_ALL on)
   # Don't build zlib tests
-  set(ZLIB_TESTS OFF CACHE BOOL "Build zlib tests")
+  set(ZLIB_BUILD_EXAMPLES OFF CACHE BOOL "Enable Zlib Examples")
   add_subdirectory(zlib)
 endif()
 
@@ -126,6 +126,9 @@ endif()
 add_subdirectory(json11)
 
 # libarchive
+set(HAVE_WCSCPY 1)
+set(HAVE_WCSLEN 1)
+
 set(ENABLE_WERROR OFF CACHE BOOL "Treat warnings as errors - default is ON for Debug, OFF otherwise.")
 set(ENABLE_TEST OFF CACHE BOOL "Enable unit and regression tests")
 set(ENABLE_COVERAGE OFF CACHE BOOL "Enable code coverage (GCC only, automatically sets ENABLE_TEST to ON)")


### PR DESCRIPTION
- Redo of #4408.

---

- This PR updates the third party library `zlib` to current stable upstream version: `1.3.1`.
- Since commit https://github.com/madler/zlib/commit/6201f893846bfd22faf060e84a3bb7bfc0e61761 no patches are needed downstream.
- Full changelog: https://github.com/madler/zlib/compare/v1.2.11...v1.3.1.

---

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing
