### PR TITLE
[lua] restore rollback of failed transactions

### DIFF
--- a/src/app/script/app_object.cpp
+++ b/src/app/script/app_object.cpp
@@ -168,7 +168,7 @@ int App_transaction(lua_State* L)
       if (lua_pcall(L, 0, LUA_MULTRET, 0) == LUA_OK)
         tx.commit();
       else
-        return lua_error(L); // pcall already put an error object on the stack
+        lua_error(L); // pcall already put an error object on the stack
       nresults = lua_gettop(L) - top;
     }
     catch (const LockedDocException& ex) {


### PR DESCRIPTION
Hello! This hopefully fixes a sneaky problem that, regretfully, was created by me a while ago when I needed to fix a different issue.

Currently, calling `error()` from inside `app.transaction` in lua script does not rollback changes. If that happens the transaction seems to "slurp" all following drawing and commands. On the surface undo/redo keeps working, except undo history window which gets stuck on the last item in the list before running the script. Sometimes, depending on script doings, it may also modify pixels that are not recorded by history states.

My understanding is that an early return (removed in te commit) prevented disposal of the Tx for some reason (?).

With this change, the transaction will roll back, which I have tested with some scripts that were failing for me, and also confirmed by logging TX_TRACE.

Regarding catching errors that happen inside transaction, cases where an actual error happens

```lua
local a, b = "foo", "bar"
app.transaction("Test1", function() 
    print(a + b)
end)

app.transaction("Test1", function() 
    error("it broke")
end)
```
will revert transaction correctly, and still print the error message, while 

```lua
app.transaction("Test1", function() 
    error()
end)
```
will revert it silently, so an option to cancel on purpose remains.

---------------------------------------

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing
