### PR TITLE
Fix crash when previewing a sprite sheet export when selecting an empty layer group located at the bottom of the layer stack in the "Layers" combo box.

### DIFF
--- a/src/doc/sprite.cpp
+++ b/src/doc/sprite.cpp
@@ -311,7 +311,7 @@ LayerImage* Sprite::backgroundLayer() const
 Layer* Sprite::firstLayer() const
 {
   Layer* layer = root()->firstLayer();
-  while (layer->isGroup())
+  while (layer && layer->isGroup())
     layer = static_cast<LayerGroup*>(layer)->firstLayer();
   return layer;
 }


### PR DESCRIPTION
This bug was found during the classification and resolution of [#4456](https://github.com/aseprite/aseprite/issues/4456)

I recommend merging directly.