### PR TITLE
Fix a couple of bugs restoring backup sessions

### DIFF
--- a/src/app/crash/internals.h
+++ b/src/app/crash/internals.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2024  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -43,10 +44,10 @@ namespace crash {
 
     // Adds a version (we don't know if the version if the latest one)
     void add(doc::ObjectVersion ver) {
-      auto minver = std::min_element(m_vers, m_vers+2);
+      auto* minver = std::min_element(m_vers, m_vers+size());
       if (*minver < ver) {
         *minver = ver;
-        std::sort(m_vers, m_vers+2, std::greater<doc::ObjectVersion>());
+        std::sort(m_vers, m_vers+size(), std::greater<doc::ObjectVersion>());
       }
     }
 


### PR DESCRIPTION
With https://community.aseprite.org/t/layers-become-empty-when-autosaving/22141 we found a couple of bugs where only 2 backed up versions of stored objects were added in ObjVersions::add().

Also as ObjVersions has a limited space for 3 versions, it's a good idea to ignore invalid binary files (files without the magic number "FINE" as header). So now we only add valid versions to ObjVersions, previously we could lead to a situation where 3 invalid binary versions of the same object were added to the ObjVersions and a 4th valid version were ignored.

Related to: https://github.com/aseprite/aseprite/issues/4481
