### PR TITLE
Compose groups separately from all other layers

### DIFF
--- a/data/pref.xml
+++ b/data/pref.xml
@@ -235,6 +235,7 @@
       <option id="multiple_windows" type="bool" default="false" />
       <option id="new_render_engine" type="bool" default="true" />
       <option id="new_blend" type="bool" default="true" />
+      <option id="compose_groups" type="bool" default="false" />
       <option id="use_native_clipboard" type="bool" default="true" />
       <option id="use_native_file_dialog" type="bool" default="true" />
       <option id="use_shaders_for_color_selectors" type="bool" default="true" />

--- a/data/strings/en.ini
+++ b/data/strings/en.ini
@@ -1498,6 +1498,7 @@ color_quantization = Color Quantization
 performance = Performance
 multiple_windows = UI with multiple windows
 new_blend = New layer blending method
+compose_groups = Compose groups separately
 new_render_engine = New render engine for sprite editor
 native_clipboard = Use native clipboard
 native_file_dialog = Use native file dialog

--- a/data/widgets/options.xml
+++ b/data/widgets/options.xml
@@ -568,6 +568,11 @@
                    pref="experimental.new_blend" />
             <link text="(#1096)" url="https://github.com/aseprite/aseprite/issues/1096" />
           </hbox>
+          <hbox>
+            <check text="@.compose_groups"
+                   pref="experimental.compose_groups" />
+            <link text="(#3225)" url="https://github.com/aseprite/aseprite/issues/3225" />
+          </hbox>
           <check id="native_clipboard" text="@.native_clipboard"
                  pref="experimental.use_native_clipboard" />
           <check id="native_file_dialog" text="@.native_file_dialog"

--- a/src/app/render/renderer.h
+++ b/src/app/render/renderer.h
@@ -42,6 +42,11 @@ namespace app {
       // True if renderSprite() composite an unpremultiplied RGBA
       // surface when we draw on a transparent background.
       bool outputsUnpremultiplied = false;
+
+      // True if the renderer can compose groups of layers in a
+      // layer image, in other case the renderer should render each
+      // layer separately merging one by one.
+      bool composeGroups = false;
     };
 
     virtual ~Renderer() { }
@@ -56,6 +61,7 @@ namespace app {
     virtual void setRefLayersVisiblity(const bool visible) = 0;
     virtual void setNonactiveLayersOpacity(const int opacity) = 0;
     virtual void setNewBlendMethod(const bool newBlend) = 0;
+    virtual void setComposeGroups(bool composeGroups) = 0;
     virtual void setBgOptions(const render::BgOptions& bg) = 0;
     virtual void setProjection(const render::Projection& projection) = 0;
 

--- a/src/app/render/shader_renderer.cpp
+++ b/src/app/render/shader_renderer.cpp
@@ -109,6 +109,11 @@ void ShaderRenderer::setNewBlendMethod(const bool newBlend)
   // TODO impl
 }
 
+void ShaderRenderer::setComposeGroups(const bool m_composeGroups)
+{
+  // TODO impl
+}
+
 void ShaderRenderer::setBgOptions(const render::BgOptions& bg)
 {
   m_bgOptions = bg;

--- a/src/app/render/shader_renderer.h
+++ b/src/app/render/shader_renderer.h
@@ -39,6 +39,7 @@ namespace app {
     void setRefLayersVisiblity(const bool visible) override;
     void setNonactiveLayersOpacity(const int opacity) override;
     void setNewBlendMethod(const bool newBlend) override;
+    void setComposeGroups(const bool composeGroups) override;
     void setBgOptions(const render::BgOptions& bg) override;
     void setProjection(const render::Projection& projection) override;
 

--- a/src/app/render/simple_renderer.cpp
+++ b/src/app/render/simple_renderer.cpp
@@ -37,6 +37,11 @@ void SimpleRenderer::setNewBlendMethod(const bool newBlend)
   m_render.setNewBlend(newBlend);
 }
 
+void SimpleRenderer::setComposeGroups(const bool composeGroups)
+{
+  m_render.setComposeGroups(composeGroups);
+}
+
 void SimpleRenderer::setBgOptions(const render::BgOptions& bg)
 {
   m_render.setBgOptions(bg);

--- a/src/app/render/simple_renderer.h
+++ b/src/app/render/simple_renderer.h
@@ -24,6 +24,7 @@ namespace app {
     void setRefLayersVisiblity(const bool visible) override;
     void setNonactiveLayersOpacity(const int opacity) override;
     void setNewBlendMethod(const bool newBlend) override;
+    void setComposeGroups(bool composeGroups) override;
     void setBgOptions(const render::BgOptions& bg) override;
     void setProjection(const render::Projection& projection) override;
 

--- a/src/app/script/image_class.cpp
+++ b/src/app/script/image_class.cpp
@@ -105,6 +105,7 @@ void render_sprite(Image* dst,
 {
   render::Render render;
   render.setNewBlend(true);
+  render.setComposeGroups(Preferences::instance().experimental.composeGroups());
   render.renderSprite(
     dst, sprite, frame,
     gfx::Clip(x, y,

--- a/src/app/script/layer_class.cpp
+++ b/src/app/script/layer_class.cpp
@@ -20,6 +20,7 @@
 #include "app/script/engine.h"
 #include "app/script/luacpp.h"
 #include "app/script/userdata.h"
+#include "app/pref/preferences.h"
 #include "app/tx.h"
 #include "doc/layer.h"
 #include "doc/layer_tilemap.h"
@@ -130,7 +131,7 @@ int Layer_get_name(lua_State* L)
 int Layer_get_opacity(lua_State* L)
 {
   auto layer = get_docobj<Layer>(L, 1);
-  if (layer->isImage()) {
+  if (layer->isImage() || (layer->isGroup() && app::Preferences::instance().experimental.composeGroups())) {
     lua_pushinteger(L, static_cast<LayerImage*>(layer)->opacity());
     return 1;
   }
@@ -141,7 +142,7 @@ int Layer_get_opacity(lua_State* L)
 int Layer_get_blendMode(lua_State* L)
 {
   auto layer = get_docobj<Layer>(L, 1);
-  if (layer->isImage()) {
+  if (layer->isImage() || (layer->isGroup() && app::Preferences::instance().experimental.composeGroups())) {
     lua_pushinteger(
       L, int(base::convert_to<app::script::BlendMode>(
                static_cast<LayerImage*>(layer)->blendMode())));
@@ -261,7 +262,7 @@ int Layer_set_opacity(lua_State* L)
 {
   auto layer = get_docobj<Layer>(L, 1);
   const int opacity = lua_tointeger(L, 2);
-  if (layer->isImage()) {
+  if (layer->isImage() || layer->isGroup()) {
     Tx tx(layer->sprite());
     tx(new cmd::SetLayerOpacity(static_cast<LayerImage*>(layer), opacity));
     tx.commit();
@@ -273,7 +274,7 @@ int Layer_set_blendMode(lua_State* L)
 {
   auto layer = get_docobj<Layer>(L, 1);
   auto blendMode = app::script::BlendMode(lua_tointeger(L, 2));
-  if (layer->isImage()) {
+  if (layer->isImage() || layer->isGroup()) {
     Tx tx(layer->sprite());
     tx(new cmd::SetLayerBlendMode(static_cast<LayerImage*>(layer),
                                   base::convert_to<doc::BlendMode>(blendMode)));

--- a/src/app/ui/editor/editor.cpp
+++ b/src/app/ui/editor/editor.cpp
@@ -670,6 +670,7 @@ void Editor::drawOneSpriteUnclippedRect(ui::Graphics* g, const gfx::Rect& sprite
     // the original cel) before it can be used by the RenderEngine.
     m_document->notifyExposeSpritePixels(m_sprite, gfx::Region(expose));
 
+    m_renderEngine->setComposeGroups(pref.experimental.composeGroups());
     m_renderEngine->setNewBlendMethod(pref.experimental.newBlend());
     m_renderEngine->setRefLayersVisiblity(true);
     m_renderEngine->setSelectedLayer(m_layer);

--- a/src/app/ui/editor/editor_render.cpp
+++ b/src/app/ui/editor/editor_render.cpp
@@ -26,6 +26,8 @@ EditorRender::EditorRender()
 {
   m_renderer->setNewBlendMethod(
     Preferences::instance().experimental.newBlend());
+  m_renderer->setComposeGroups(
+    Preferences::instance().experimental.composeGroups());
 }
 
 EditorRender::~EditorRender()
@@ -70,6 +72,11 @@ void EditorRender::setNonactiveLayersOpacity(const int opacity)
 void EditorRender::setNewBlendMethod(const bool newBlend)
 {
   m_renderer->setNewBlendMethod(newBlend);
+}
+
+void EditorRender::setComposeGroups(const bool composeGroups)
+{
+  m_renderer->setComposeGroups(composeGroups);
 }
 
 void EditorRender::setProjection(const render::Projection& projection)

--- a/src/app/ui/editor/editor_render.h
+++ b/src/app/ui/editor/editor_render.h
@@ -57,6 +57,7 @@ namespace app {
     void setRefLayersVisiblity(const bool visible);
     void setNonactiveLayersOpacity(const int opacity);
     void setNewBlendMethod(const bool newBlend);
+    void setComposeGroups(bool composeGroups);
 
     void setProjection(const render::Projection& projection);
 

--- a/src/doc/layer.cpp
+++ b/src/doc/layer.cpp
@@ -29,6 +29,8 @@ Layer::Layer(ObjectType type, Sprite* sprite)
   , m_flags(LayerFlags(
       int(LayerFlags::Visible) |
       int(LayerFlags::Editable)))
+  , m_blendmode(BlendMode::NORMAL)
+  , m_opacity(255)
 {
   ASSERT(type == ObjectType::LayerImage ||
          type == ObjectType::LayerGroup ||
@@ -228,8 +230,6 @@ Cel* Layer::cel(frame_t frame) const
 
 LayerImage::LayerImage(ObjectType type, Sprite* sprite)
   : Layer(type, sprite)
-  , m_blendmode(BlendMode::NORMAL)
-  , m_opacity(255)
 {
 }
 

--- a/src/doc/layer.h
+++ b/src/doc/layer.h
@@ -125,6 +125,12 @@ namespace doc {
         m_flags = LayerFlags(int(m_flags) & ~int(flags));
     }
 
+    BlendMode blendMode() const { return m_blendmode; }
+    void setBlendMode(BlendMode blendmode) { m_blendmode = blendmode; }
+
+    int opacity() const { return m_opacity; }
+    void setOpacity(int opacity) { m_opacity = opacity; }
+
     virtual Grid grid() const;
     virtual Cel* cel(frame_t frame) const;
     virtual void getCels(CelList& cels) const = 0;
@@ -136,6 +142,9 @@ namespace doc {
     LayerGroup* m_parent;        // parent layer
     LayerFlags m_flags;           // stack order cannot be changed
 
+    BlendMode m_blendmode;
+    int m_opacity;
+  
     // Disable assigment
     Layer& operator=(const Layer& other);
   };
@@ -150,12 +159,6 @@ namespace doc {
     virtual ~LayerImage();
 
     virtual int getMemSize() const override;
-
-    BlendMode blendMode() const { return m_blendmode; }
-    void setBlendMode(BlendMode blendmode) { m_blendmode = blendmode; }
-
-    int opacity() const { return m_opacity; }
-    void setOpacity(int opacity) { m_opacity = opacity; }
 
     void addCel(Cel *cel);
     void removeCel(Cel *cel);
@@ -180,9 +183,7 @@ namespace doc {
 
   private:
     void destroyAllCels();
-
-    BlendMode m_blendmode;
-    int m_opacity;
+  
     CelList m_cels;   // List of all cels inside this layer used by frames.
   };
 

--- a/src/doc/render_plan.cpp
+++ b/src/doc/render_plan.cpp
@@ -35,21 +35,12 @@ void RenderPlan::addLayer(const Layer* layer,
   if (!layer->isVisible())
     return;
 
-  switch (layer->type()) {
-
-    case ObjectType::LayerImage:
-    case ObjectType::LayerTilemap: {
-      m_items.emplace_back(m_order, layer, layer->cel(frame));
-      break;
+  if (layer->isGroup() && !m_composeGroups) {
+    for (auto *const child : static_cast<const LayerGroup*>(layer)->layers()) {
+      addLayer(child, frame);
     }
-
-    case ObjectType::LayerGroup: {
-      for (const auto child : static_cast<const LayerGroup*>(layer)->layers()) {
-        addLayer(child, frame);
-      }
-      break;
-    }
-
+  } else {
+    m_items.emplace_back(m_order, layer, layer->cel(frame));
   }
 }
 

--- a/src/doc/render_plan.h
+++ b/src/doc/render_plan.h
@@ -33,6 +33,8 @@ namespace doc {
     using Items = std::vector<Item>;
 
     RenderPlan();
+    RenderPlan(const bool composeGroups)
+      : m_composeGroups(composeGroups) { }
 
     const Items& items() const {
       if (m_processZIndex)
@@ -49,6 +51,7 @@ namespace doc {
     int m_order = 0;
     mutable Items m_items;
     mutable bool m_processZIndex = true;
+    bool m_composeGroups = false;
   };
 
 } // namespace doc

--- a/src/render/render.h
+++ b/src/render/render.h
@@ -60,6 +60,7 @@ namespace render {
     void setRefLayersVisiblity(const bool visible);
     void setNonactiveLayersOpacity(const int opacity);
     void setNewBlend(const bool newBlend);
+    void setComposeGroups(bool composeGroup);
     void setProjection(const Projection& projection);
     void setBgOptions(const BgOptions& bg);
     void setSelectedLayer(const Layer* layer);
@@ -224,6 +225,7 @@ namespace render {
     BlendMode m_previewBlendMode;
     OnionskinOptions m_onionskin;
     ImageBufferPtr m_tmpBuf;
+    bool m_composeGroups = false;
   };
 
   void composite_image(Image* dst,

--- a/tests/scripts/compose_groups.lua
+++ b/tests/scripts/compose_groups.lua
@@ -1,0 +1,186 @@
+-- Copyright (C) 2024  Igara Studio S.A.
+--
+-- This file is released under the terms of the MIT license.
+-- Read LICENSE.txt for more information.
+
+dofile('./test_utils.lua')
+
+-- Enable experimental compose groups feature
+app.preferences.experimental.compose_groups = true
+
+function create_group_layer()
+  local s = Sprite(2, 2)
+  assert(#s.layers == 1)
+
+  -- create two layers and a group layer
+  local a = s.layers[1]   a.name = "a"
+  assert(#s.layers == 1)
+  local b = s:newLayer()  b.name = "b"
+  assert(#s.layers == 2)
+  local g = s:newGroup()  g.name = "g"
+  assert(#s.layers == 3)
+
+  -- b is child of g
+  b.parent = g
+  assert(g.parent == s)
+  assert(b.parent == g)
+
+  assert(#s.layers == 2)
+  assert(s.layers[1] == a)
+  assert(s.layers[2] == g)
+
+  return s, a, b, g
+end
+
+-- Test groups opacity to impact on children layers
+do
+  assert(app.preferences.experimental.compose_groups == true)
+
+  local s, a, b, g = create_group_layer()
+
+	-- draw in b layer
+	local cel = s:newCel(b, 1, Image(2, 2, ColorMode.RGB))
+	local img = cel.image
+
+	img:drawPixel(0, 0, Color(255, 0, 0, 255))
+	img:drawPixel(1, 0, Color(0, 255, 0, 255))
+	img:drawPixel(0, 1, Color(0, 0, 255, 255))
+	img:drawPixel(1, 1, Color(255, 255, 0, 255))
+
+	local r = Image(s.spec) -- render
+	r:drawSprite(s, 1, 0, 0)
+
+	expect_clr(r:getPixel(0, 0), app.pixelColor.rgba(255, 0, 0, 255))
+	expect_clr(r:getPixel(1, 0), app.pixelColor.rgba(0, 255, 0, 255))
+	expect_clr(r:getPixel(0, 1), app.pixelColor.rgba(0, 0, 255, 255))
+	expect_clr(r:getPixel(1, 1), app.pixelColor.rgba(255, 255, 0, 255))
+
+	-- Set opacity to 50%
+	g.opacity = 128
+
+	r = Image(s.spec)
+	r:drawSprite(s, 1, 0, 0)
+
+	print(g.opacity)
+
+	print(r:getPixel(0, 0), app.pixelColor.rgba(255, 0, 0, 255))
+
+	-- Assert that the image is drawn with 50% opacity
+	expect_clr(r:getPixel(0, 0), app.pixelColor.rgba(255, 0, 0, 128))
+	expect_clr(r:getPixel(1, 0), app.pixelColor.rgba(0, 255, 0, 128))
+	expect_clr(r:getPixel(0, 1), app.pixelColor.rgba(0, 0, 255, 128))
+	expect_clr(r:getPixel(1, 1), app.pixelColor.rgba(255, 255, 0, 128))
+
+	-- Set opacity to 100%
+	g.opacity = 255
+
+	r = Image(s.spec)
+	r:drawSprite(s, 1, 0, 0)
+
+	expect_eq(g.opacity, 255)
+
+	-- Assert that the image is drawn with 100% opacity
+	expect_clr(r:getPixel(0, 0), app.pixelColor.rgba(255, 0, 0, 255))
+	expect_clr(r:getPixel(1, 0), app.pixelColor.rgba(0, 255, 0, 255))
+	expect_clr(r:getPixel(0, 1), app.pixelColor.rgba(0, 0, 255, 255))
+	expect_clr(r:getPixel(1, 1), app.pixelColor.rgba(255, 255, 0, 255))
+
+	-- Set group opacity to 50% and layer opacity to 50%
+	g.opacity = 128
+	b.opacity = 128
+
+	r = Image(s.spec)
+	r:drawSprite(s, 1, 0, 0)
+
+	assert(g.opacity == 128)
+	assert(b.opacity == 128)
+
+	-- Assert that the image is drawn with 25% opacity
+	expect_clr(r:getPixel(0, 0), app.pixelColor.rgba(255, 0, 0, 64))
+	expect_clr(r:getPixel(1, 0), app.pixelColor.rgba(0, 255, 0, 64))
+	expect_clr(r:getPixel(0, 1), app.pixelColor.rgba(0, 0, 255, 64))
+	expect_clr(r:getPixel(1, 1), app.pixelColor.rgba(255, 255, 0, 64))
+
+	-- Create a new layer in front of the group and check that it's not affected by the group opacity
+	local c = s:newLayer()
+	c.name = "c"
+
+	-- draw in c layer
+	local cel = s:newCel(c, 1, Image(1, 1, ColorMode.RGB))
+	local img = cel.image
+
+	img:drawPixel(0, 0, Color(255, 0, 255, 255))
+
+	r = Image(s.spec)
+	r:drawSprite(s, 1, 0, 0)
+
+	-- Assert that the first pixel is drawn with 100% opacity and the remaining ones with 25% opacity
+	expect_clr(r:getPixel(0, 0), app.pixelColor.rgba(255, 0, 255, 255))
+	expect_clr(r:getPixel(1, 0), app.pixelColor.rgba(0, 255, 0, 64))
+	expect_clr(r:getPixel(0, 1), app.pixelColor.rgba(0, 0, 255, 64))
+	expect_clr(r:getPixel(1, 1), app.pixelColor.rgba(255, 255, 0, 64))
+
+end
+
+do -- test group blend to impact children layers
+  assert(app.preferences.experimental.compose_groups == true)
+
+  local s, a, b, g = create_group_layer()
+
+  -- draw all black in layer a
+  local cel = s:newCel(a, 1, Image(2, 2, ColorMode.RGB))
+  local img = cel.image
+
+  img:drawPixel(0, 0, Color(0, 0, 0, 255))
+  img:drawPixel(1, 0, Color(0, 0, 0, 255))
+  img:drawPixel(0, 1, Color(0, 0, 0, 255))
+  img:drawPixel(1, 1, Color(0, 0, 0, 255))
+
+  -- draw in b layer
+  local cel = s:newCel(b, 1, Image(2, 2, ColorMode.RGB))
+  local img = cel.image
+
+  img:drawPixel(0, 0, Color(255, 0, 0, 255))
+  img:drawPixel(1, 0, Color(0, 255, 0, 255))
+  img:drawPixel(0, 1, Color(0, 0, 255, 255))
+  img:drawPixel(1, 1, Color(255, 255, 0, 255))
+
+  local r = Image(s.spec) -- render
+  r:drawSprite(s, 1, 0, 0)
+
+  expect_clr(r:getPixel(0, 0), app.pixelColor.rgba(255, 0, 0, 255))
+  expect_clr(r:getPixel(1, 0), app.pixelColor.rgba(0, 255, 0, 255))
+  expect_clr(r:getPixel(0, 1), app.pixelColor.rgba(0, 0, 255, 255))
+  expect_clr(r:getPixel(1, 1), app.pixelColor.rgba(255, 255, 0, 255))
+
+  -- Set blend to MULTIPLY
+  g.blendMode = BlendMode.MULTIPLY
+
+  r = Image(s.spec)
+  r:drawSprite(s, 1, 0, 0)
+
+  -- Assert that the image is drawn with MULTIPLY blend mode
+  expect_clr(r:getPixel(0, 0), app.pixelColor.rgba(0, 0, 0, 255))
+  expect_clr(r:getPixel(1, 0), app.pixelColor.rgba(0, 0, 0, 255))
+  expect_clr(r:getPixel(0, 1), app.pixelColor.rgba(0, 0, 0, 255))
+  expect_clr(r:getPixel(1, 1), app.pixelColor.rgba(0, 0, 0, 255))
+
+  -- Create a new layer in front of the group and check that it's not affected by the group blend mode
+  local c = s:newLayer()
+  c.name = "c"
+
+  -- draw in c layer
+  local cel = s:newCel(c, 1, Image(1, 1, ColorMode.RGB))
+  local img = cel.image
+
+  img:drawPixel(0, 0, Color(255, 0, 255, 255))
+
+  r = Image(s.spec)
+  r:drawSprite(s, 1, 0, 0)
+
+  -- Assert that the first pixel is drawn with Normal blend mode and the remaining ones with Multiply blend mode
+  expect_clr(r:getPixel(0, 0), app.pixelColor.rgba(255, 0, 255, 255))
+  expect_clr(r:getPixel(1, 0), app.pixelColor.rgba(0, 0, 0, 255))
+  expect_clr(r:getPixel(0, 1), app.pixelColor.rgba(0, 0, 0, 255))
+  expect_clr(r:getPixel(1, 1), app.pixelColor.rgba(0, 0, 0, 255))
+end

--- a/tests/scripts/test_utils.lua
+++ b/tests/scripts/test_utils.lua
@@ -27,6 +27,24 @@ local function dump_img(image)
   print('}')
 end
 
+function expect_clr(color, expectedColor)
+  if color ~= expectedColor then
+    print(debug.traceback())
+    print('Expected A == B but:')
+    print(string.format(' - Value A = rgba(%d,%d,%d,%d)',
+      app.pixelColor.rgbaR(color),
+      app.pixelColor.rgbaG(color),
+      app.pixelColor.rgbaB(color),
+      app.pixelColor.rgbaA(color)))
+    print(string.format(' - Value B = rgba(%d,%d,%d,%d)',
+      app.pixelColor.rgbaR(expectedColor),
+      app.pixelColor.rgbaG(expectedColor),
+      app.pixelColor.rgbaB(expectedColor),
+      app.pixelColor.rgbaA(expectedColor)))
+    assert(color == expectedColor)
+  end
+end
+
 function expect_img(image, expectedPixels)
   local w = image.width
   local h = image.height


### PR DESCRIPTION
Co-authored-by: @belchiorg 

## Description of the Feature
This feature introduces a new logic for rendering group layers in Aseprite, enabling the application of effects not only to individual layers but also to entire groups. This hierarchical rendering approach allows properties like opacity and blending modes to be adjusted at the group level, paving the way for future enhancements such as mask layers (#459) and other highly requested features.

## Implementation Details
Previously, the rendering logic flattened the layer tree structure, ignoring group hierarchies during the rendering process. This update removes the flattening step, adopting a hierarchical (tree-based) approach instead of a sequential (linear) one. Each group layer is treated as a node in the tree, and rendering now processes these nodes recursively.

![image](https://github.com/aseprite/aseprite/assets/62722700/9c45f6fb-bbcb-4285-a818-16d1d5ca4b34)

## 1. Features added
- Enables setting opacity to a group layer.
- Enables setting blend mode to a group layer. The blend mode is applied when all child layers are already composed, so you can apply multiple blend modes on top of each other using group layers.
- Adds one more step to the render plan process, that can be used to apply other effects in the entire group layer

![Screenshot from 2024-05-27 11-33-41](https://github.com/aseprite/aseprite/assets/62722700/40c333a3-d47f-4a0c-8346-2bf3b9871277)

## 2. Recursive Rendering
- When rendering a group of layers, a new auxiliary image (temporary surface) is created along with a new sub-rendering plan.
- This sub-rendering plan allows groups to be rendered independently into the temporary image.
- After rendering all child nodes, the temporary image is merged back into the parent image. This approach supports nested groups by ensuring each temporary image is correctly integrated with its parent.

## 3. Performance Considerations

- The current implementation requires rendering the complete image, which may impact performance during operations like the preview of drawing tools.
- While the previous logic allowed re-rendering of specific layers in a defined area, the new hierarchical approach necessitates rendering all parent levels, potentially affecting efficiency.
- Efforts to optimize this were considered but would require significant changes to the low-level rendering code, introducing undesirable complexity and potential bugs.

## 4. Breaking changes
Since group layers are now rendered in an auxiliary image, previously, a bottom layer within a group could apply its blend mode to the first layer below it outside the group. To achieve this same result now, you must set the blend mode for the entire group layer.

Resolves #3225 

---

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing