### PR TITLE
Emit sprite UserData into data file

### DIFF
--- a/src/app/commands/cmd_export_sprite_sheet.cpp
+++ b/src/app/commands/cmd_export_sprite_sheet.cpp
@@ -267,6 +267,7 @@ Doc* generate_sprite_sheet_from_params(
   exporter.setSplitTags(splitTags);
   exporter.setIgnoreEmptyCels(ignoreEmpty);
   exporter.setMergeDuplicates(mergeDuplicates);
+  exporter.setUserData(sprite->userData());
   if (listLayers) exporter.setListLayers(true);
   if (listTags) exporter.setListTags(true);
   if (listSlices) exporter.setListSlices(true);

--- a/src/app/doc_exporter.cpp
+++ b/src/app/doc_exporter.cpp
@@ -591,7 +591,8 @@ public:
 };
 
 DocExporter::DocExporter()
-  : m_docBuf(std::make_shared<doc::ImageBuffer>())
+  : WithUserData(ObjectType::Sprite)
+  , m_docBuf(std::make_shared<doc::ImageBuffer>())
   , m_sampleBuf(std::make_shared<doc::ImageBuffer>())
 {
   m_cache.spriteId = doc::NullId;
@@ -1256,6 +1257,8 @@ Doc* DocExporter::createEmptyTexture(const Samples& samples,
       maxColors,
       m_docBuf));
 
+  sprite->setUserData(userData());
+
   if (palette.size() > 0)
     sprite->setPalette(&palette, false);
 
@@ -1421,7 +1424,8 @@ void DocExporter::createDataFile(const Samples& samples,
   os << ",\n"
      << " \"meta\": {\n"
      << "  \"app\": \"" << get_app_url() << "\",\n"
-     << "  \"version\": \"" << get_app_version() << "\",\n";
+     << "  \"version\": \"" << get_app_version() << "\""
+     << texture->userData() << ",\n";
 
   if (!m_textureFilename.empty())
     os << "  \"image\": \""

--- a/src/app/doc_exporter.h
+++ b/src/app/doc_exporter.h
@@ -18,6 +18,7 @@
 #include "doc/image_buffer.h"
 #include "doc/object_id.h"
 #include "doc/object_version.h"
+#include "doc/with_user_data.h"
 #include "gfx/fwd.h"
 #include "gfx/rect.h"
 
@@ -40,7 +41,7 @@ namespace app {
   class Context;
   class Doc;
 
-  class DocExporter {
+  class DocExporter : public doc::WithUserData {
   public:
     DocExporter();
 


### PR DESCRIPTION
<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the Individual Contributor License Agreement V4.0. -->
<!-- If you're a first-time contributor, please sign the CLA
     as indicated in https://github.com/igarastudio/cla#signing
     and acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing

---

This change updates the JSON data file exports so it include the sprite level user data as part of the `meta` field. Without this change, the user data doesn't exist in the exported JSON file at all.
