### PR TITLE
define WEBP_LIBRARIES path

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -205,6 +205,7 @@ steps as above but when we call `cmake`, we have some differences:
       -DSKIA_DIR=$HOME/deps/skia \
       -DSKIA_LIBRARY_DIR=$HOME/deps/skia/out/Release-arm64 \
       -DSKIA_LIBRARY=$HOME/deps/skia/out/Release-arm64/libskia.a \
+      -DWEBP_LIBRARIES=$HOME/deps/skia/out/Release-arm64/libwebp.a \
       -DPNG_ARM_NEON:STRING=on \
       -G Ninja \
       ..


### PR DESCRIPTION
This PR will update the `cmake` command in  documentation for Apple Silicon, as we also need to define the path for `WEBP_LIBRARIES` since by default it's enabled and without defining it, the build will fail. 