### PR TITLE
Fix crashes with ill-formed fmt format strings (fix #2274)

### DIFF
--- a/src/app/commands/cmd_add_color.cpp
+++ b/src/app/commands/cmd_add_color.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2020  Igara Studio S.A.
+// Copyright (C) 2019-2024  Igara Studio S.A.
 // Copyright (C) 2016-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -20,7 +20,6 @@
 #include "app/pref/preferences.h"
 #include "app/tx.h"
 #include "doc/palette.h"
-#include "fmt/format.h"
 
 #ifdef ENABLE_SCRIPTING
 #include "app/script/luacpp.h"
@@ -148,7 +147,7 @@ std::string AddColorCommand::onGetFriendlyName() const
     case AddColorSource::Bg: source = Strings::commands_AddColor_Background(); break;
     case AddColorSource::Color: source = Strings::commands_AddColor_Specific(); break;
   }
-  return fmt::format(getBaseFriendlyName(), source);
+  return Strings::commands_AddColor(source);
 }
 
 Command* CommandFactory::createAddColorCommand()

--- a/src/app/commands/cmd_cel_opacity.cpp
+++ b/src/app/commands/cmd_cel_opacity.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2020-2022  Igara Studio S.A.
+// Copyright (C) 2020-2024  Igara Studio S.A.
 // Copyright (C) 2018  David Capello
 //
 // This program is distributed under the terms of
@@ -22,7 +22,6 @@
 #include "doc/cel.h"
 #include "doc/cels_range.h"
 #include "doc/sprite.h"
-#include "fmt/format.h"
 
 #include <string>
 
@@ -109,9 +108,8 @@ void CelOpacityCommand::onExecute(Context* context)
 
 std::string CelOpacityCommand::onGetFriendlyName() const
 {
-  return fmt::format(getBaseFriendlyName(),
-                     m_opacity,
-                     int(100.0 * m_opacity / 255.0));
+  return Strings::commands_CelOpacity(m_opacity,
+                                      int(100.0 * m_opacity / 255.0));
 }
 
 Command* CommandFactory::createCelOpacityCommand()

--- a/src/app/commands/cmd_change_brush.cpp
+++ b/src/app/commands/cmd_change_brush.cpp
@@ -27,7 +27,6 @@
 #include "doc/image_ref.h"
 #include "doc/primitives.h"
 #include "doc/tile.h"
-#include "fmt/format.h"
 
 #include <algorithm>
 #include <string>
@@ -328,10 +327,10 @@ std::string ChangeBrushCommand::onGetFriendlyName() const
     case FlipD: change = Strings::commands_ChangeBrush_FlipD(); break;
     case Rotate90CW: change = Strings::commands_ChangeBrush_Rotate90CW(); break;
     case CustomBrush:
-      change = fmt::format(Strings::commands_ChangeBrush_CustomBrush(), m_slot);
+      change = Strings::commands_ChangeBrush_CustomBrush(m_slot);
       break;
   }
-  return fmt::format(getBaseFriendlyName(), change);
+  return Strings::commands_ChangeBrush(change);
 }
 
 Command* CommandFactory::createChangeBrushCommand()

--- a/src/app/commands/cmd_change_color.cpp
+++ b/src/app/commands/cmd_change_color.cpp
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2024  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This program is distributed under the terms of
@@ -17,7 +18,6 @@
 #include "app/modules/palettes.h"
 #include "app/ui/color_bar.h"
 #include "doc/palette.h"
-#include "fmt/format.h"
 
 namespace app {
 
@@ -120,7 +120,7 @@ std::string ChangeColorCommand::onGetFriendlyName() const
       break;
   }
 
-  return fmt::format(getBaseFriendlyName(), action);
+  return Strings::commands_ChangeColor(action);
 }
 
 Command* CommandFactory::createChangeColorCommand()

--- a/src/app/commands/cmd_change_pixel_format.cpp
+++ b/src/app/commands/cmd_change_pixel_format.cpp
@@ -727,7 +727,7 @@ std::string ChangePixelFormatCommand::onGetFriendlyName() const
   else
     conversion = Strings::commands_ChangePixelFormat_MoreOptions();
 
-  return fmt::format(getBaseFriendlyName(), conversion);
+  return Strings::commands_ChangePixelFormat(conversion);
 }
 
 Command* CommandFactory::createChangePixelFormatCommand()

--- a/src/app/commands/cmd_export_sprite_sheet.cpp
+++ b/src/app/commands/cmd_export_sprite_sheet.cpp
@@ -48,7 +48,7 @@
 #include "export_sprite_sheet.xml.h"
 
 #include <limits>
-#include <sstream>
+#include <string>
 
 namespace app {
 
@@ -93,20 +93,19 @@ bool ask_overwrite(const bool askFilename, const std::string& filename,
       (askDataname &&
        !dataname.empty() &&
        base::is_file(dataname))) {
-    std::stringstream text;
+    std::string text;
 
     if (base::is_file(filename))
-      text << "<<" << base::get_file_name(filename).c_str();
+      text += "<<" + base::get_file_name(filename);
 
     if (base::is_file(dataname))
-      text << "<<" << base::get_file_name(dataname).c_str();
+      text += "<<" + base::get_file_name(dataname);
 
     const int ret =
       OptionalAlert::show(
         Preferences::instance().spriteSheet.showOverwriteFilesAlert,
         1, // Yes is the default option when the alert dialog is disabled
-        fmt::format(Strings::alerts_overwrite_files_on_export_sprite_sheet(),
-                    text.str()));
+        Strings::alerts_overwrite_files_on_export_sprite_sheet(text));
     if (ret != 1)
       return false;
   }

--- a/src/app/commands/cmd_flip.cpp
+++ b/src/app/commands/cmd_flip.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2022  Igara Studio S.A.
+// Copyright (C) 2019-2024  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -39,7 +39,6 @@
 #include "doc/layer.h"
 #include "doc/mask.h"
 #include "doc/sprite.h"
-#include "fmt/format.h"
 #include "gfx/size.h"
 
 
@@ -256,7 +255,7 @@ std::string FlipCommand::onGetFriendlyName() const
   else
     orientation = Strings::commands_Flip_Vertically();
 
-  return fmt::format(getBaseFriendlyName(), content, orientation);
+  return Strings::commands_Flip(content, orientation);
 }
 
 Command* CommandFactory::createFlipCommand()

--- a/src/app/commands/cmd_keyboard_shortcuts.cpp
+++ b/src/app/commands/cmd_keyboard_shortcuts.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2022  Igara Studio S.A.
+// Copyright (C) 2018-2024  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -31,7 +31,6 @@
 #include "base/scoped_value.h"
 #include "base/split_string.h"
 #include "base/string.h"
-#include "fmt/format.h"
 #include "ui/alert.h"
 #include "ui/fit_bounds.h"
 #include "ui/graphics.h"
@@ -239,9 +238,7 @@ private:
     ui::Accelerator accel = m_key->accels()[index];
 
     if (ui::Alert::show(
-          fmt::format(
-            Strings::alerts_delete_shortcut(),
-            accel.toString())) != 1)
+          Strings::alerts_delete_shortcut(accel.toString())) != 1)
       return;
 
     m_key->disableAccel(accel, KeySource::UserDefined);

--- a/src/app/commands/cmd_layer_opacity.cpp
+++ b/src/app/commands/cmd_layer_opacity.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2020-2022  Igara Studio S.A.
+// Copyright (C) 2020-2024  Igara Studio S.A.
 // Copyright (C) 2016-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -20,7 +20,6 @@
 #include "app/tx.h"
 #include "app/ui/timeline/timeline.h"
 #include "doc/layer.h"
-#include "fmt/format.h"
 
 #include <string>
 
@@ -94,9 +93,8 @@ void LayerOpacityCommand::onExecute(Context* context)
 
 std::string LayerOpacityCommand::onGetFriendlyName() const
 {
-  return fmt::format(getBaseFriendlyName(),
-                     m_opacity,
-                     int(100.0 * m_opacity / 255.0));
+  return Strings::commands_LayerOpacity(m_opacity,
+                                        int(100.0 * m_opacity / 255.0));
 }
 
 Command* CommandFactory::createLayerOpacityCommand()

--- a/src/app/commands/cmd_load_mask.cpp
+++ b/src/app/commands/cmd_load_mask.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019  Igara Studio S.A.
+// Copyright (C) 2019-2024  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -20,7 +20,6 @@
 #include "app/util/msk_file.h"
 #include "doc/mask.h"
 #include "doc/sprite.h"
-#include "fmt/format.h"
 #include "ui/alert.h"
 
 namespace app {
@@ -70,7 +69,7 @@ void LoadMaskCommand::onExecute(Context* context)
 
   std::unique_ptr<Mask> mask(load_msk_file(m_filename.c_str()));
   if (!mask) {
-    ui::Alert::show(fmt::format(Strings::alerts_error_loading_file(), m_filename));
+    ui::Alert::show(Strings::alerts_error_loading_file(m_filename));
     return;
   }
 

--- a/src/app/commands/cmd_load_palette.cpp
+++ b/src/app/commands/cmd_load_palette.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2023  Igara Studio S.A.
+// Copyright (C) 2023-2024  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -19,7 +19,6 @@
 #include "app/modules/palettes.h"
 #include "base/fs.h"
 #include "doc/palette.h"
-#include "fmt/format.h"
 #include "ui/alert.h"
 
 namespace app {
@@ -81,7 +80,7 @@ void LoadPaletteCommand::onExecute(Context* context)
   std::unique_ptr<doc::Palette> palette(load_palette(filename.c_str()));
   if (!palette) {
     if (context->isUIAvailable())
-      ui::Alert::show(fmt::format(Strings::alerts_error_loading_file(), filename));
+      ui::Alert::show(Strings::alerts_error_loading_file(filename));
     return;
   }
 

--- a/src/app/commands/cmd_modify_selection.cpp
+++ b/src/app/commands/cmd_modify_selection.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2022  Igara Studio S.A.
+// Copyright (C) 2019-2024  Igara Studio S.A.
 // Copyright (C) 2015-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -23,7 +23,6 @@
 #include "doc/brush_type.h"
 #include "doc/mask.h"
 #include "filters/neighboring_pixels.h"
-#include "fmt/format.h"
 
 #include "modify_selection.xml.h"
 
@@ -151,11 +150,9 @@ std::string ModifySelectionCommand::onGetFriendlyName() const
 {
   std::string quantity;
   if (m_quantity > 0)
-    quantity = fmt::format(Strings::commands_ModifySelection_Quantity(), m_quantity);
+    quantity = Strings::commands_ModifySelection_Quantity(m_quantity);
 
-  return fmt::format(getBaseFriendlyName(),
-                     getActionName(),
-                     quantity);
+  return Strings::commands_ModifySelection(getActionName(), quantity);
 }
 
 std::string ModifySelectionCommand::getActionName() const

--- a/src/app/commands/cmd_move_mask.cpp
+++ b/src/app/commands/cmd_move_mask.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2022  Igara Studio S.A.
+// Copyright (C) 2019-2024  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -26,7 +26,6 @@
 #include "base/convert_to.h"
 #include "doc/mask.h"
 #include "doc/sprite.h"
-#include "fmt/format.h"
 #include "ui/view.h"
 
 namespace app {
@@ -124,8 +123,8 @@ std::string MoveMaskCommand::onGetFriendlyName() const
     case Boundaries: content = Strings::commands_MoveMask_Boundaries(); break;
     case Content: content = Strings::commands_MoveMask_Content(); break;
   }
-  return fmt::format(getBaseFriendlyName(),
-                     content, m_moveThing.getFriendlyString());
+  return Strings::commands_MoveMask(content,
+                                    m_moveThing.getFriendlyString());
 }
 
 Command* CommandFactory::createMoveMaskCommand()

--- a/src/app/commands/cmd_new_file.cpp
+++ b/src/app/commands/cmd_new_file.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2022  Igara Studio S.A.
+// Copyright (C) 2018-2024  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -285,9 +285,9 @@ void NewFileCommand::onExecute(Context* ctx)
 std::string NewFileCommand::onGetFriendlyName() const
 {
   if (params().fromClipboard())
-    return fmt::format(Strings::commands_NewFile_FromClipboard());
+    return Strings::commands_NewFile_FromClipboard();
   else
-    return fmt::format(Strings::commands_NewFile());
+    return Strings::commands_NewFile();
 }
 
 Command* CommandFactory::createNewFileCommand()

--- a/src/app/commands/cmd_new_frame.cpp
+++ b/src/app/commands/cmd_new_frame.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2023  Igara Studio S.A.
+// Copyright (C) 2018-2024  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -29,7 +29,6 @@
 #include "doc/image.h"
 #include "doc/layer.h"
 #include "doc/sprite.h"
-#include "fmt/format.h"
 #include "ui/ui.h"
 
 #include <stdexcept>
@@ -181,8 +180,7 @@ void NewFrameCommand::onExecute(Context* context)
     update_screen_for_document(document);
 
     StatusBar::instance()->showTip(
-      1000, fmt::format(
-        Strings::commands_NewFrame_tooltip(),
+      1000, Strings::commands_NewFrame_tooltip(
         (int)context->activeSite().frame()+1,
         (int)sprite->totalFrames()));
 

--- a/src/app/commands/cmd_new_layer.cpp
+++ b/src/app/commands/cmd_new_layer.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2023  Igara Studio S.A.
+// Copyright (C) 2019-2024  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -274,8 +274,7 @@ void NewLayerCommand::onExecute(Context* context)
   Layer* layer = nullptr;
   {
     ContextWriter writer(reader);
-    Tx tx(writer,
-          fmt::format(Strings::commands_NewLayer(), layerPrefix()));
+    Tx tx(writer, Strings::commands_NewLayer(layerPrefix()));
     DocApi api = document->getApi(tx);
     bool afterBackground = false;
 
@@ -513,17 +512,17 @@ std::string NewLayerCommand::onGetFriendlyName() const
 {
   std::string text;
   if (m_place == Place::BeforeActiveLayer)
-    text = fmt::format(Strings::commands_NewLayer_BeforeActiveLayer(), layerPrefix());
+    text = Strings::commands_NewLayer_BeforeActiveLayer(layerPrefix());
   else
-    text = fmt::format(Strings::commands_NewLayer(), layerPrefix());
+    text = Strings::commands_NewLayer(layerPrefix());
   if (params().fromClipboard())
-    text = fmt::format(Strings::commands_NewLayer_FromClipboard(), text);
+    text = Strings::commands_NewLayer_FromClipboard(text);
   if (params().viaCopy())
-    text = fmt::format(Strings::commands_NewLayer_ViaCopy(), text);
+    text = Strings::commands_NewLayer_ViaCopy(text);
   if (params().viaCut())
-    text = fmt::format(Strings::commands_NewLayer_ViaCut(), text);
+    text = Strings::commands_NewLayer_ViaCut(text);
   if (params().ask())
-    text = fmt::format(Strings::commands_NewLayer_WithDialog(), text);
+    text = Strings::commands_NewLayer_WithDialog(text);
   return text;
 }
 

--- a/src/app/commands/cmd_options.cpp
+++ b/src/app/commands/cmd_options.cpp
@@ -888,9 +888,7 @@ public:
     m_pref.save();
 
     if (!warnings.empty()) {
-      ui::Alert::show(
-        fmt::format(Strings::alerts_restart_by_preferences(),
-                    warnings));
+      ui::Alert::show(Strings::alerts_restart_by_preferences(warnings));
     }
 
     // Probably it's safe to switch this flag in runtime
@@ -929,8 +927,7 @@ public:
     }
 
     // Install?
-    if (ui::Alert::show(
-          fmt::format(Strings::alerts_install_extension(), filename)) != 1)
+    if (ui::Alert::show(Strings::alerts_install_extension(filename)) != 1)
       return false;
 
     installExtension(filename);
@@ -1495,8 +1492,7 @@ private:
           // Ask if the user want to adjust the Screen/UI Scaling
           const int result =
             ui::Alert::show(
-              fmt::format(
-                Strings::alerts_update_screen_ui_scaling_with_theme_values(),
+              Strings::alerts_update_screen_ui_scaling_with_theme_values(
                 themeName,
                 100 * m_pref.general.screenScale(),
                 100 * (newScreenScale > 0 ? newScreenScale: m_pref.general.screenScale()),
@@ -1587,8 +1583,7 @@ private:
 
         // Uninstall?
         if (ui::Alert::show(
-              fmt::format(
-                Strings::alerts_update_extension(),
+              Strings::alerts_update_extension(
                 ext->name(),
                 (isDowngrade ? Strings::alerts_update_extension_downgrade():
                                Strings::alerts_update_extension_upgrade()),
@@ -1664,8 +1659,7 @@ private:
       return;
 
     if (ui::Alert::show(
-          fmt::format(
-            Strings::alerts_uninstall_extension_warning(),
+          Strings::alerts_uninstall_extension_warning(
             item->text())) != 1)
       return;
 

--- a/src/app/commands/cmd_palette_editor.cpp
+++ b/src/app/commands/cmd_palette_editor.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2023  Igara Studio S.A.
+// Copyright (C) 2023-2024  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This program is distributed under the terms of
@@ -15,7 +15,6 @@
 #include "app/ui/color_bar.h"
 #include "base/replace_string.h"
 #include "base/trim_string.h"
-#include "fmt/format.h"
 
 namespace app {
 
@@ -107,7 +106,7 @@ std::string PaletteEditorCommand::onGetFriendlyName() const
       popup = Strings::commands_PaletteEditor_FgPopup();
   }
 
-  std::string result = fmt::format(getBaseFriendlyName(), edit, plus, popup);
+  std::string result = Strings::commands_PaletteEditor(edit, plus, popup);
   // TODO create a new function to remove duplicate whitespaces
   base::replace_string(result, "  ", " ");
   base::replace_string(result, "  ", " ");

--- a/src/app/commands/cmd_remove_layer.cpp
+++ b/src/app/commands/cmd_remove_layer.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2020-2021  Igara Studio S.A.
+// Copyright (C) 2020-2024  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -24,7 +24,6 @@
 #include "doc/layer_tilemap.h"
 #include "doc/sprite.h"
 #include "doc/tilesets.h"
-#include "fmt/format.h"
 #include "ui/alert.h"
 #include "ui/widget.h"
 
@@ -90,7 +89,7 @@ static bool continue_deleting_unused_tilesets(
 
   std::string message;
   if (tsiToDelete.size() >= 1)
-    message = fmt::format(Strings::alerts_deleting_tilemaps_will_delete_tilesets(), layerNames);
+    message = Strings::alerts_deleting_tilemaps_will_delete_tilesets(layerNames);
 
   return tsiToDelete.empty() ||
          app::OptionalAlert::show(
@@ -205,12 +204,14 @@ void RemoveLayerCommand::onExecute(Context* context)
     update_screen_for_document(document);
 
     StatusBar::instance()->invalidate();
-    if (!layerName.empty())
+    if (!layerName.empty()) {
       StatusBar::instance()->showTip(
-        1000, fmt::format(Strings::remove_layer_x_removed(), layerName));
-    else
-      StatusBar::instance()->showTip(1000,
-                                     Strings::remove_layer_layers_removed());
+        1000, Strings::remove_layer_x_removed(layerName));
+    }
+    else {
+      StatusBar::instance()->showTip(
+        1000, Strings::remove_layer_layers_removed());
+    }
   }
 #endif
 }

--- a/src/app/commands/cmd_remove_slice.cpp
+++ b/src/app/commands/cmd_remove_slice.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2020  Igara Studio S.A.
+// Copyright (C) 2019-2024  Igara Studio S.A.
 // Copyright (C) 2017-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -22,7 +22,6 @@
 #include "doc/selected_objects.h"
 #include "doc/slice.h"
 #include "doc/sprite.h"
-#include "fmt/format.h"
 #include "ui/alert.h"
 #include "ui/widget.h"
 
@@ -121,14 +120,14 @@ void RemoveSliceCommand::onExecute(Context* context)
   }
 
   StatusBar::instance()->invalidate();
-  if (!sliceName.empty())
+  if (!sliceName.empty()) {
     StatusBar::instance()->showTip(
-      1000, fmt::format(Strings::remove_slice_x_removed(), sliceName));
-  else
+      1000, Strings::remove_slice_x_removed(sliceName));
+  }
+  else {
     StatusBar::instance()->showTip(
-      1000,
-      fmt::format(Strings::remove_slice_n_slices_removed(),
-                  slicesToDelete.size()));
+      1000, Strings::remove_slice_n_slices_removed(slicesToDelete.size()));
+  }
 }
 
 Command* CommandFactory::createRemoveSliceCommand()

--- a/src/app/commands/cmd_rotate.cpp
+++ b/src/app/commands/cmd_rotate.cpp
@@ -32,7 +32,6 @@
 #include "doc/image.h"
 #include "doc/mask.h"
 #include "doc/sprite.h"
-#include "fmt/format.h"
 #include "ui/ui.h"
 
 namespace app {
@@ -261,8 +260,8 @@ std::string RotateCommand::onGetFriendlyName() const
     content = Strings::commands_Rotate_Selection();
   else
     content = Strings::commands_Rotate_Sprite();
-  return fmt::format(getBaseFriendlyName(),
-                     content, base::convert_to<std::string>(m_angle));
+  return Strings::commands_Rotate(content,
+                                  base::convert_to<std::string>(m_angle));
 }
 
 Command* CommandFactory::createRotateCommand()

--- a/src/app/commands/cmd_run_script.cpp
+++ b/src/app/commands/cmd_run_script.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2023  Igara Studio S.A.
+// Copyright (C) 2018-2024  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -70,7 +70,7 @@ void RunScriptCommand::onExecute(Context* context)
     int ret = OptionalAlert::show(
       Preferences::instance().scripts.showRunScriptAlert,
       1, // Yes is the default option when the alert dialog is disabled
-      fmt::format(Strings::alerts_run_script(), m_filename));
+      Strings::alerts_run_script(m_filename));
     if (ret != 1)
       return;
   }
@@ -89,11 +89,11 @@ void RunScriptCommand::onExecute(Context* context)
 std::string RunScriptCommand::onGetFriendlyName() const
 {
   if (m_filename.empty())
-    return getBaseFriendlyName();
-  else
-    return fmt::format("{0}: {1}",
-                       getBaseFriendlyName(),
-                       base::get_file_name(m_filename));
+    return Strings::commands_RunScript();
+
+  return fmt::format("{0}: {1}",
+                     Strings::commands_RunScript(),
+                     base::get_file_name(m_filename));
 }
 
 Command* CommandFactory::createRunScriptCommand()

--- a/src/app/commands/cmd_save_file.cpp
+++ b/src/app/commands/cmd_save_file.cpp
@@ -41,7 +41,6 @@
 #include "doc/mask.h"
 #include "doc/sprite.h"
 #include "doc/tag.h"
-#include "fmt/format.h"
 #include "ui/ui.h"
 #include "undo/undo_state.h"
 
@@ -269,8 +268,7 @@ void SaveFileBaseCommand::saveDocumentInBackground(
 #ifdef ENABLE_UI
     if (context->isUIAvailable() && params().ui()) {
       StatusBar::instance()->setStatusText(
-        2000, fmt::format(Strings::save_file_saved(),
-                          base::get_file_name(filename)));
+        2000, Strings::save_file_saved(base::get_file_name(filename)));
     }
 #endif
   }
@@ -428,8 +426,7 @@ void SaveFileCopyAsCommand::onExecute(Context* context)
       int ret = OptionalAlert::show(
         Preferences::instance().exportFile.showOverwriteFilesAlert,
         1, // Yes is the default option when the alert dialog is disabled
-        fmt::format(Strings::alerts_overwrite_files_on_export(),
-                    outputFilename));
+        Strings::alerts_overwrite_files_on_export(outputFilename));
       if (ret != 1)
         goto again;
     }

--- a/src/app/commands/cmd_save_mask.cpp
+++ b/src/app/commands/cmd_save_mask.cpp
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2024  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -16,7 +17,6 @@
 #include "base/fs.h"
 #include "doc/mask.h"
 #include "doc/sprite.h"
-#include "fmt/format.h"
 #include "ui/alert.h"
 
 namespace app {
@@ -55,7 +55,7 @@ void SaveMaskCommand::onExecute(Context* context)
   std::string filename = selFilename.front();
 
   if (save_msk_file(document->mask(), filename.c_str()) != 0)
-    ui::Alert::show(fmt::format(Strings::alerts_error_saving_file(), filename));
+    ui::Alert::show(Strings::alerts_error_saving_file(filename));
 }
 
 Command* CommandFactory::createSaveMaskCommand()

--- a/src/app/commands/cmd_save_palette.cpp
+++ b/src/app/commands/cmd_save_palette.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2021  Igara Studio S.A.
+// Copyright (C) 2021-2024  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -21,7 +21,6 @@
 #include "app/modules/palettes.h"
 #include "base/fs.h"
 #include "doc/palette.h"
-#include "fmt/format.h"
 #include "ui/alert.h"
 
 namespace app {
@@ -78,8 +77,8 @@ void SavePaletteCommand::onExecute(Context* ctx)
     if (!base::has_file_extension(filename, exts)) {
       if (ctx->isUIAvailable()) {
         ui::Alert::show(
-          fmt::format(Strings::alerts_file_format_doesnt_support_palette(),
-                      base::get_file_extension(filename)));
+          Strings::alerts_file_format_doesnt_support_palette(
+            base::get_file_extension(filename)));
       }
       return;
     }
@@ -90,7 +89,7 @@ void SavePaletteCommand::onExecute(Context* ctx)
     colorSpace = activeDoc->sprite()->colorSpace();
 
   if (!save_palette(filename.c_str(), palette, 16, colorSpace)) // TODO 16 should be configurable
-    ui::Alert::show(fmt::format(Strings::alerts_error_saving_file(), filename));
+    ui::Alert::show(Strings::alerts_error_saving_file(filename));
 
   if (m_preset == get_default_palette_preset_name()) {
     set_default_palette(palette);

--- a/src/app/commands/cmd_scroll.cpp
+++ b/src/app/commands/cmd_scroll.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2020-2022  Igara Studio S.A.
+// Copyright (C) 2020-2024  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This program is distributed under the terms of
@@ -17,7 +17,6 @@
 #include "app/i18n/strings.h"
 #include "app/ui/editor/editor.h"
 #include "base/convert_to.h"
-#include "fmt/format.h"
 #include "ui/view.h"
 
 namespace app {
@@ -64,8 +63,7 @@ void ScrollCommand::onExecute(Context* context)
 
 std::string ScrollCommand::onGetFriendlyName() const
 {
-  return fmt::format(getBaseFriendlyName(),
-                     m_moveThing.getFriendlyString());
+  return Strings::commands_Scroll(m_moveThing.getFriendlyString());
 }
 
 Command* CommandFactory::createScrollCommand()

--- a/src/app/commands/cmd_select_palette.cpp
+++ b/src/app/commands/cmd_select_palette.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2021  Igara Studio SA
+// Copyright (C) 2021-2024  Igara Studio SA
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -229,7 +229,7 @@ std::string SelectPaletteColorsCommand::onGetFriendlyName() const
     case UsedTiles:    return Strings::commands_SelectPaletteColors_UsedTiles();
     case UnusedTiles:  return Strings::commands_SelectPaletteColors_UnusedTiles();
   }
-  return getBaseFriendlyName();
+  return Strings::commands_SelectPaletteColors();
 }
 
 Command* CommandFactory::createSelectPaletteColorsCommand()

--- a/src/app/commands/cmd_select_tile.cpp
+++ b/src/app/commands/cmd_select_tile.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2022  Igara Studio S.A.
+// Copyright (C) 2018-2024  Igara Studio S.A.
 // Copyright (C) 2015-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -19,7 +19,6 @@
 #include "app/tx.h"
 #include "app/ui/editor/editor.h"
 #include "doc/mask.h"
-#include "fmt/format.h"
 #include "ui/system.h"
 
 namespace app {
@@ -124,7 +123,7 @@ std::string SelectTileCommand::onGetFriendlyName() const
       text = Strings::commands_SelectTile_Intersect();
       break;
     default:
-      text = getBaseFriendlyName();
+      text = Strings::commands_SelectTile();
       break;
   }
   return text;

--- a/src/app/commands/cmd_set_color_selector.cpp
+++ b/src/app/commands/cmd_set_color_selector.cpp
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2024  Igara Studio S.A.
 // Copyright (C) 2016-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -13,7 +14,6 @@
 #include "app/commands/params.h"
 #include "app/i18n/strings.h"
 #include "app/ui/color_bar.h"
-#include "fmt/format.h"
 
 namespace app {
 
@@ -90,7 +90,7 @@ std::string SetColorSelectorCommand::onGetFriendlyName() const
       type = Strings::commands_SetColorSelector_NormalMapWheel();
       break;
   }
-  return fmt::format(getBaseFriendlyName() + ": {0}", type);
+  return fmt::format("{0}: {1}", Command::onGetFriendlyName(), type);
 }
 
 Command* CommandFactory::createSetColorSelectorCommand()

--- a/src/app/commands/cmd_set_ink_type.cpp
+++ b/src/app/commands/cmd_set_ink_type.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2020  Igara Studio S.A.
+// Copyright (C) 2020-2024  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This program is distributed under the terms of
@@ -16,7 +16,6 @@
 #include "app/i18n/strings.h"
 #include "app/tools/ink_type.h"
 #include "app/ui/context_bar.h"
-#include "fmt/format.h"
 
 namespace app {
 
@@ -72,7 +71,7 @@ std::string SetInkTypeCommand::onGetFriendlyName() const
       ink = Strings::inks_shading();
       break;
   }
-  return fmt::format(getBaseFriendlyName(), ink);
+  return Strings::commands_SetInkType(ink);
 }
 
 Command* CommandFactory::createSetInkTypeCommand()

--- a/src/app/commands/cmd_sprite_properties.cpp
+++ b/src/app/commands/cmd_sprite_properties.cpp
@@ -35,7 +35,6 @@
 #include "doc/sprite.h"
 #include "doc/tilesets.h"
 #include "doc/user_data.h"
-#include "fmt/format.h"
 #include "os/color_space.h"
 #include "os/system.h"
 #include "ui/ui.h"
@@ -100,7 +99,7 @@ private:
      auto sprite = tileset->sprite();
      auto tilesetClone = Tileset::MakeCopyCopyingImages(tileset);
 
-     Tx tx(sprite, fmt::format(Strings::commands_TilesetDuplicate()));
+     Tx tx(sprite, Strings::commands_TilesetDuplicate());
      tx(new cmd::AddTileset(sprite, tilesetClone));
      tx.commit();
 
@@ -119,12 +118,12 @@ private:
     }
     if (!tilemapsNames.empty()) {
       tilemapsNames = tilemapsNames.substr(0, tilemapsNames.size()-2);
-      ui::Alert::show(fmt::format(Strings::alerts_cannot_delete_used_tileset(), tilemapsNames));
+      ui::Alert::show(Strings::alerts_cannot_delete_used_tileset(tilemapsNames));
       return;
     }
 
     auto sprite = tileset->sprite();
-    Tx tx(sprite, fmt::format(Strings::commands_TilesetDelete()));
+    Tx tx(sprite, Strings::commands_TilesetDelete());
     tx(new cmd::RemoveTileset(sprite, tsi));
     tx.commit();
 
@@ -276,8 +275,8 @@ void SpritePropertiesCommand::onExecute(Context* context)
         imgtype_text = Strings::sprite_properties_grayscale();
         break;
       case IMAGE_INDEXED:
-        imgtype_text = fmt::format(Strings::sprite_properties_indexed_color(),
-                                   sprite->palette(0)->size());
+        imgtype_text = Strings::sprite_properties_indexed_color(
+          sprite->palette(0)->size());
         break;
       default:
         ASSERT(false);

--- a/src/app/commands/cmd_zoom.cpp
+++ b/src/app/commands/cmd_zoom.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2021-2022  Igara Studio S.A.
+// Copyright (C) 2021-2024  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This program is distributed under the terms of
@@ -16,7 +16,6 @@
 #include "app/pref/preferences.h"
 #include "app/ui/editor/editor.h"
 #include "base/convert_to.h"
-#include "fmt/format.h"
 #include "render/zoom.h"
 #include "ui/manager.h"
 #include "ui/system.h"
@@ -130,8 +129,7 @@ std::string ZoomCommand::onGetFriendlyName() const
       text = Strings::commands_Zoom_Out();
       break;
     case Action::Set:
-      text = fmt::format(Strings::commands_Zoom_Set(),
-                         int(100.0*m_zoom.scale()));
+      text = Strings::commands_Zoom_Set(int(100.0*m_zoom.scale()));
       break;
   }
 

--- a/src/app/commands/command.cpp
+++ b/src/app/commands/command.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2020  Igara Studio S.A.
+// Copyright (C) 2020-2024  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This program is distributed under the terms of
@@ -20,16 +20,10 @@ Command::Command(const char* id, CommandFlags flags)
   : m_id(id)
   , m_flags(flags)
 {
-  generateFriendlyName();
 }
 
 Command::~Command()
 {
-}
-
-std::string Command::friendlyName() const
-{
-  return onGetFriendlyName();
 }
 
 bool Command::needsParams() const
@@ -62,15 +56,6 @@ bool Command::isChecked(Context* context)
     // TODO add a status-bar item...
     return false;
   }
-}
-
-void Command::generateFriendlyName()
-{
-  std::string strId = "commands." + this->id();
-  if (auto s = Strings::instance())
-    m_friendlyName = s->translate(strId.c_str());
-  else
-    m_friendlyName = strId;
 }
 
 void Command::execute(Context* context)
@@ -110,7 +95,9 @@ void Command::onExecute(Context* context)
 
 std::string Command::onGetFriendlyName() const
 {
-  return m_friendlyName;
+  if (auto* strings = Strings::instance())
+    return strings->translate(("commands." + id()).c_str());
+  return id();
 }
 
 } // namespace app

--- a/src/app/commands/command.h
+++ b/src/app/commands/command.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2024  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -29,13 +30,12 @@ namespace app {
     virtual ~Command();
 
     const std::string& id() const { return m_id; }
-    std::string friendlyName() const;
+    std::string friendlyName() const { return onGetFriendlyName(); }
 
     bool needsParams() const;
     void loadParams(const Params& params);
     bool isEnabled(Context* context);
     bool isChecked(Context* context);
-    void generateFriendlyName();
 
   protected:
     virtual bool onNeedsParams() const;
@@ -45,16 +45,11 @@ namespace app {
     virtual void onExecute(Context* context);
     virtual std::string onGetFriendlyName() const;
 
-    const std::string& getBaseFriendlyName() const {
-      return m_friendlyName;
-    }
-
   private:
     friend class Context;
     void execute(Context* context);
 
     std::string m_id;
-    std::string m_friendlyName;
     CommandFlags m_flags;
   };
 

--- a/src/app/commands/convert_layer.cpp
+++ b/src/app/commands/convert_layer.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2021-2023  Igara Studio S.A.
+// Copyright (C) 2021-2024  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -303,7 +303,7 @@ std::string ConvertLayerCommand::onGetFriendlyName() const
     case ConvertLayerParam::Background: return Strings::commands_ConvertLayer_Background(); break;
     case ConvertLayerParam::Layer:      return Strings::commands_ConvertLayer_Layer(); break;
     case ConvertLayerParam::Tilemap:    return Strings::commands_ConvertLayer_Tilemap(); break;
-    default: return getBaseFriendlyName();
+    default: return Strings::commands_ConvertLayer();
   }
 }
 

--- a/src/app/commands/move_thing.cpp
+++ b/src/app/commands/move_thing.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019  Igara Studio S.A.
+// Copyright (C) 2019-2024  Igara Studio S.A.
 // Copyright (C) 2017  David Capello
 //
 // This program is distributed under the terms of
@@ -16,7 +16,6 @@
 #include "app/ui/doc_view.h"
 #include "app/ui/editor/editor.h"
 #include "app/ui_context.h"
-#include "fmt/format.h"
 
 #include <algorithm>
 
@@ -66,8 +65,7 @@ std::string MoveThing::getFriendlyString() const
     case Down:  dir = Strings::commands_Move_Down(); break;
   }
 
-  return fmt::format(Strings::commands_Move_Thing(),
-                     quantity, dim, dir);
+  return Strings::commands_Move_Thing(quantity, dim, dir);
 }
 
 gfx::Point MoveThing::getDelta(Context* context) const

--- a/src/app/commands/set_playback_speed.cpp
+++ b/src/app/commands/set_playback_speed.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (c) 2023  Igara Studio S.A.
+// Copyright (c) 2023-2024  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -9,9 +9,9 @@
 #endif
 
 #include "app/commands/new_params.h"
-#include "app/ui_context.h"
+#include "app/i18n/strings.h"
 #include "app/ui/editor/editor.h"
-#include "fmt/format.h"
+#include "app/ui_context.h"
 
 namespace app {
 
@@ -55,7 +55,7 @@ void SetPlaybackSpeedCommand::onExecute(Context* ctx)
 
 std::string SetPlaybackSpeedCommand::onGetFriendlyName() const
 {
-  return fmt::format(getBaseFriendlyName(), params().multiplier());
+  return Strings::commands_SetPlaybackSpeed(params().multiplier());
 }
 
 Command* CommandFactory::createSetPlaybackSpeedCommand()

--- a/src/app/commands/show_menu.cpp
+++ b/src/app/commands/show_menu.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2022  Igara Studio S.A.
+// Copyright (C) 2022-2024  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -13,7 +13,6 @@
 #include "app/commands/new_params.h"
 #include "app/context.h"
 #include "app/i18n/strings.h"
-#include "fmt/format.h"
 
 namespace app {
 
@@ -55,7 +54,7 @@ std::string ShowMenuCommand::onGetFriendlyName() const
     name = menuitem->text();
   else
     name = params().menu();
-  return fmt::format(Strings::commands_ShowMenu(), name);
+  return Strings::commands_ShowMenu(name);
 }
 
 MenuItem* ShowMenuCommand::findMenuItem() const

--- a/src/app/commands/tileset_mode.cpp
+++ b/src/app/commands/tileset_mode.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2020  Igara Studio S.A.
+// Copyright (C) 2020-2024  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -13,7 +13,6 @@
 #include "app/commands/params.h"
 #include "app/i18n/strings.h"
 #include "app/ui/color_bar.h"
-#include "fmt/format.h"
 
 namespace app {
 
@@ -52,7 +51,7 @@ protected:
       case TilesetMode::Auto:   mode = Strings::commands_TilesetMode_Auto();   break;
       case TilesetMode::Stack:  mode = Strings::commands_TilesetMode_Stack();  break;
     }
-    return fmt::format(getBaseFriendlyName(), mode);
+    return Strings::commands_TilesetMode(mode);
   }
 
 private:

--- a/src/app/file/file.cpp
+++ b/src/app/file/file.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2023  Igara Studio S.A.
+// Copyright (C) 2018-2024  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -704,8 +704,7 @@ FileOp* FileOp::createSaveDocumentOperation(const Context* context,
       // show the alert dialog.
       if (fatal) {
         ui::Alert::show(
-          fmt::format(
-            Strings::alerts_file_format_doesnt_support_error(),
+          Strings::alerts_file_format_doesnt_support_error(
             format->name(),
             warnings));
         ret = 1;
@@ -714,8 +713,7 @@ FileOp* FileOp::createSaveDocumentOperation(const Context* context,
         ret = OptionalAlert::show(
           Preferences::instance().saveFile.showFileFormatDoesntSupportAlert,
           1, // Yes is the default option when the alert dialog is disabled
-          fmt::format(
-            Strings::alerts_file_format_doesnt_support_warning(),
+          Strings::alerts_file_format_doesnt_support_warning(
             format->name(),
             warnings));
       }
@@ -785,8 +783,7 @@ FileOp* FileOp::createSaveDocumentOperation(const Context* context,
         OptionalAlert::show(
           Preferences::instance().saveFile.showExportAnimationInSequenceAlert,
           1,
-          fmt::format(
-            Strings::alerts_export_animation_in_sequence(),
+          Strings::alerts_export_animation_in_sequence(
             int(fop->m_seq.filename_list.size()),
             base::get_file_name(fop->m_seq.filename_list[0]),
             base::get_file_name(fop->m_seq.filename_list[1]))) != 1) {

--- a/src/app/i18n/strings.h
+++ b/src/app/i18n/strings.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "app/i18n/lang_info.h"
+#include "fmt/core.h"
 #include "obs/signal.h"
 #include "strings.ini.h"
 
@@ -32,10 +33,29 @@ namespace app {
     static Strings* instance();
 
     const std::string& translate(const char* id) const;
+    const std::string& defaultString(const char* id) const;
 
     std::set<LangInfo> availableLanguages() const;
     std::string currentLanguage() const;
     void setCurrentLanguage(const std::string& langId);
+
+    void logError(const char* id, const char* error) const;
+
+    static const std::string& Translate(const char* id) {
+      Strings* s = Strings::instance();
+      return s->translate(id);
+    }
+
+    // Formats a string with the given arguments, if it fails
+    // (e.g. because the translation contains an invalid formatted
+    // string) it tries to return the original string from the default
+    // en.ini file.
+    template<typename...Args>
+    static std::string Format(const char* id, Args&&...args) {
+      return VFormat(id, fmt::make_format_args(args...));
+    }
+
+    static std::string VFormat(const char* id, const fmt::format_args& vargs);
 
     obs::signal<void()> LanguageChange;
 
@@ -50,7 +70,8 @@ namespace app {
 
     Preferences& m_pref;
     Extensions& m_exts;
-    mutable std::unordered_map<std::string, std::string> m_strings;
+    mutable std::unordered_map<std::string, std::string> m_default; // Default strings from en.ini
+    mutable std::unordered_map<std::string, std::string> m_strings; // Strings from current language
   };
 
 } // namespace app

--- a/src/app/i18n/xml_translator.cpp
+++ b/src/app/i18n/xml_translator.cpp
@@ -26,9 +26,9 @@ std::string XmlTranslator::operator()(const XMLElement* elem,
     return std::string();
   else if (value[0] == '@') {   // Translate string
     if (value[1] == '.')
-      return Strings::instance()->translate((m_stringIdPrefix + (value+1)).c_str());
+      return Strings::Translate((m_stringIdPrefix + (value+1)).c_str());
     else
-      return Strings::instance()->translate(value+1);
+      return Strings::Translate(value+1);
   }
   else if (value[0] == '!')     // Raw string
     return std::string(value+1);

--- a/src/app/job.cpp
+++ b/src/app/job.cpp
@@ -15,7 +15,6 @@
 #include "app/console.h"
 #include "app/context.h"
 #include "app/i18n/strings.h"
-#include "fmt/format.h"
 #include "ui/alert.h"
 #include "ui/widget.h"
 #include "ui/window.h"
@@ -41,8 +40,7 @@ Job::Job(const std::string& jobName,
   m_canceled_flag = false;
 
   if (showProgress && App::instance()->isGui()) {
-    m_alert_window = ui::Alert::create(
-      fmt::format(Strings::alerts_job_working(), jobName));
+    m_alert_window = ui::Alert::create(Strings::alerts_job_working(jobName));
     m_alert_window->addProgress();
 
     m_timer = std::make_unique<ui::Timer>(kMonitoringPeriod, m_alert_window.get());

--- a/src/app/launcher.cpp
+++ b/src/app/launcher.cpp
@@ -1,5 +1,6 @@
 // Aseprite
-// Copyright (C) 2001-2015, 2017  David Capello
+// Copyright (C) 2024  Igara Studio S.A.
+// Copyright (C) 2001-2017  David Capello
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -13,7 +14,6 @@
 #include "app/i18n/strings.h"
 #include "base/exception.h"
 #include "base/launcher.h"
-#include "fmt/format.h"
 #include "ui/alert.h"
 
 namespace app {
@@ -27,13 +27,13 @@ void open_url(const std::string& url)
 void open_file(const std::string& file)
 {
   if (!base::launcher::open_file(file))
-    ui::Alert::show(fmt::format(Strings::alerts_cannot_open_file(), file));
+    ui::Alert::show(Strings::alerts_cannot_open_file(file));
 }
 
 void open_folder(const std::string& file)
 {
   if (!base::launcher::open_folder(file))
-    ui::Alert::show(fmt::format(Strings::alerts_cannot_open_folder(), file));
+    ui::Alert::show(Strings::alerts_cannot_open_folder(file));
 }
 
 } // namespace launcher

--- a/src/app/ui/button_set.cpp
+++ b/src/app/ui/button_set.cpp
@@ -13,7 +13,6 @@
 
 #include "app/modules/gui.h"
 #include "app/ui/skin/skin_theme.h"
-#include "fmt/format.h"
 #include "gfx/color.h"
 #include "os/surface.h"
 #include "ui/box.h"

--- a/src/app/ui/context_bar.cpp
+++ b/src/app/ui/context_bar.cpp
@@ -1436,30 +1436,24 @@ protected:
 class ContextBar::EyedropperField : public HBox {
 public:
   EyedropperField() {
-    const auto combined = Strings::context_bar_eyedropper_combined();
-    m_channel.addItem(fmt::format(
-                        combined,
+    m_channel.addItem(Strings::context_bar_eyedropper_combined(
                         Strings::context_bar_eyedropper_color(),
                         Strings::context_bar_eyedropper_alpha()));
     m_channel.addItem(Strings::context_bar_eyedropper_color());
     m_channel.addItem(Strings::context_bar_eyedropper_alpha());
-    m_channel.addItem(fmt::format(
-                        combined,
+    m_channel.addItem(Strings::context_bar_eyedropper_combined(
                         Strings::context_bar_eyedropper_rgb(),
                         Strings::context_bar_eyedropper_alpha()));
     m_channel.addItem(Strings::context_bar_eyedropper_rgb());
-    m_channel.addItem(fmt::format(
-                        combined,
+    m_channel.addItem(Strings::context_bar_eyedropper_combined(
                         Strings::context_bar_eyedropper_hsv(),
                         Strings::context_bar_eyedropper_alpha()));
     m_channel.addItem(Strings::context_bar_eyedropper_hsv());
-    m_channel.addItem(fmt::format(
-                        combined,
+    m_channel.addItem(Strings::context_bar_eyedropper_combined(
                         Strings::context_bar_eyedropper_hsl(),
                         Strings::context_bar_eyedropper_alpha()));
     m_channel.addItem(Strings::context_bar_eyedropper_hsl());
-    m_channel.addItem(fmt::format(
-                        combined,
+    m_channel.addItem(Strings::context_bar_eyedropper_combined(
                         Strings::context_bar_eyedropper_gray(),
                         Strings::context_bar_eyedropper_alpha()));
     m_channel.addItem(Strings::context_bar_eyedropper_gray());

--- a/src/app/ui/data_recovery_view.cpp
+++ b/src/app/ui/data_recovery_view.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2022  Igara Studio S.A.
+// Copyright (C) 2019-2024  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This program is distributed under the terms of
@@ -30,7 +30,6 @@
 #include "app/ui/workspace.h"
 #include "app/ui_context.h"
 #include "base/fs.h"
-#include "fmt/format.h"
 #include "ui/alert.h"
 #include "ui/button.h"
 #include "ui/entry.h"
@@ -346,9 +345,7 @@ void DataRecoveryView::fillListWith(const bool crashes)
 
     std::string title = session->name();
     if (session->version() != get_app_version())
-      title =
-        fmt::format(Strings::recover_files_incompatible(),
-                    title, session->version());
+      title = Strings::recover_files_incompatible(title, session->version());
 
     auto sep = new SeparatorInView(title, HORIZONTAL);
     sep->InitTheme.connect(
@@ -492,8 +489,7 @@ void DataRecoveryView::onDelete()
     return;
 
   // Delete one backup
-  if (Alert::show(
-        fmt::format(Strings::alerts_delete_selected_backups(),
+  if (Alert::show(Strings::alerts_delete_selected_backups(
                     int(items.size()))) != 1)
     return;                     // Cancel
 
@@ -531,11 +527,11 @@ void DataRecoveryView::onChangeSelection()
   m_openButton.setEnabled(count > 0);
   if (count < 2) {
     m_openButton.mainButton()->setText(
-      fmt::format(Strings::recover_files_recover_sprite(), count));
+      Strings::recover_files_recover_sprite());
   }
   else {
     m_openButton.mainButton()->setText(
-      fmt::format(Strings::recover_files_recover_n_sprites(), count));
+      Strings::recover_files_recover_n_sprites(count));
   }
 }
 

--- a/src/app/ui/doc_view.cpp
+++ b/src/app/ui/doc_view.cpp
@@ -317,8 +317,7 @@ bool DocView::onCloseView(Workspace* workspace, bool quitting)
     while (m_document->isModified()) {
       // ask what want to do the user with the changes in the sprite
       int ret = Alert::show(
-        fmt::format(
-          Strings::alerts_save_sprite_changes(),
+        Strings::alerts_save_sprite_changes(
           m_document->name(),
           (quitting ? Strings::alerts_save_sprite_changes_quitting():
                       Strings::alerts_save_sprite_changes_closing())));

--- a/src/app/ui/editor/standby_state.cpp
+++ b/src/app/ui/editor/standby_state.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2023  Igara Studio S.A.
+// Copyright (C) 2018-2024  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -187,13 +187,11 @@ bool StandbyState::onMouseDown(Editor* editor, MouseMessage* msg)
       }
       else if (!layer->isVisibleHierarchy()) {
         StatusBar::instance()->showTip(
-          1000,
-          fmt::format(Strings::statusbar_tips_layer_x_is_hidden(),
-                      layer->name()));
+          1000, Strings::statusbar_tips_layer_x_is_hidden(layer->name()));
       }
       else if (!layer->isMovable() || !layer->isEditableHierarchy()) {
         StatusBar::instance()->showTip(
-          1000, fmt::format(Strings::statusbar_tips_layer_locked(), layer->name()));
+          1000, Strings::statusbar_tips_layer_locked(layer->name()));
       }
       else {
         MovingCelCollect collect(editor, layer);
@@ -698,7 +696,7 @@ bool StandbyState::checkStartDrawingStraightLine(Editor* editor,
     if (drawingState) {
       // Disable stabilizer so that it does not affect the line preview
       drawingState->disableMouseStabilizer();
-      
+
       drawingState->sendMovementToToolLoop(
         tools::Pointer(
           pointer ? pointer->point(): editor->screenToEditor(editor->mousePosInDisplay()),
@@ -760,9 +758,7 @@ void StandbyState::transformSelection(Editor* editor, MouseMessage* msg, HandleT
   Layer* layer = editor->layer();
   if (layer && layer->isReference()) {
     StatusBar::instance()->showTip(
-      1000,
-      fmt::format(Strings::statusbar_tips_non_transformable_reference_layer(),
-                        layer->name()));
+      1000, Strings::statusbar_tips_non_transformable_reference_layer(layer->name()));
     return;
   }
 

--- a/src/app/ui/editor/tool_loop_impl.cpp
+++ b/src/app/ui/editor/tool_loop_impl.cpp
@@ -869,9 +869,7 @@ tools::ToolLoop* create_tool_loop(
       if (toolPref.floodfill.referTo() ==
           app::gen::FillReferTo::ACTIVE_LAYER) {
         StatusBar::instance()->showTip(
-          1000,
-          fmt::format(Strings::statusbar_tips_layer_x_is_hidden(),
-                      layer->name()));
+          1000, Strings::statusbar_tips_layer_x_is_hidden(layer->name()));
         return nullptr;
       }
     }
@@ -883,8 +881,7 @@ tools::ToolLoop* create_tool_loop(
     else if (layer->isReference()) {
       StatusBar::instance()->showTip(
         1000,
-        fmt::format(Strings::statusbar_tips_unmodifiable_reference_layer(),
-                    layer->name()));
+        Strings::statusbar_tips_unmodifiable_reference_layer(layer->name()));
       return nullptr;
     }
   }

--- a/src/app/ui/export_file_window.cpp
+++ b/src/app/ui/export_file_window.cpp
@@ -256,9 +256,10 @@ void ExportFileWindow::updateAdjustResizeButton()
 
   if (adjustResize()->isVisible() != newState) {
     adjustResize()->setVisible(newState);
-    if (newState)
-      adjustResize()->setText(fmt::format(Strings::export_file_adjust_resize(),
-                                          100 * m_preferredResize));
+    if (newState) {
+      adjustResize()->setText(
+        Strings::export_file_adjust_resize(100 * m_preferredResize));
+    }
     adjustResize()->parent()->layout();
   }
 }
@@ -286,7 +287,7 @@ void ExportFileWindow::onOK()
     }
     else {
       ui::Alert::show(
-        fmt::format(Strings::alerts_unknown_output_file_format_error(), ext));
+        Strings::alerts_unknown_output_file_format_error(ext));
       return;
     }
   }

--- a/src/app/ui/file_selector.cpp
+++ b/src/app/ui/file_selector.cpp
@@ -28,7 +28,6 @@
 #include "base/fs.h"
 #include "base/paths.h"
 #include "base/string.h"
-#include "fmt/format.h"
 #include "ui/ui.h"
 
 #include "new_folder_window.xml.h"
@@ -638,9 +637,8 @@ again:
         const char* invalid_chars = ": * ? \" < > |";
 
         ui::Alert::show(
-            fmt::format(
-                Strings::alerts_invalid_chars_in_filename(),
-                invalid_chars));
+          Strings::alerts_invalid_chars_in_filename(
+            invalid_chars));
 
         // show the window again
         setVisible(true);
@@ -659,9 +657,7 @@ again:
 
     if (m_type == FileSelectorType::Save && base::is_file(buf)) {
       int ret = Alert::show(
-        fmt::format(
-          Strings::alerts_overwrite_existent_file(),
-          base::get_file_name(buf)));
+        Strings::alerts_overwrite_existent_file(base::get_file_name(buf)));
       if (ret == 2) {
         setVisible(true);
         goto again;

--- a/src/app/ui/home_view.cpp
+++ b/src/app/ui/home_view.cpp
@@ -303,8 +303,7 @@ void HomeView::onUpToDate()
 void HomeView::onNewUpdate(const std::string& url, const std::string& version)
 {
   checkUpdate()->setText(
-    fmt::format(Strings::home_view_new_version_available(),
-                get_app_name(), version));
+    Strings::home_view_new_version_available(get_app_name(), version));
 #ifdef ENABLE_DRM
   DRM_INVALID {
     checkUpdate()->setUrl(url);

--- a/src/app/ui/main_window.cpp
+++ b/src/app/ui/main_window.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2023  Igara Studio S.A.
+// Copyright (C) 2018-2024  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -217,15 +217,6 @@ MainWindow::~MainWindow()
 
 void MainWindow::onLanguageChange()
 {
-  auto commands = Commands::instance();
-  std::vector<std::string> commandIDs;
-  commands->getAllIds(commandIDs);
-
-  for (const auto& commandID : commandIDs) {
-    Command* command = commands->byId(commandID.c_str());
-    command->generateFriendlyName();
-  }
-
   m_menuBar->reload();
   layout();
   invalidate();

--- a/src/app/ui/toolbar.cpp
+++ b/src/app/ui/toolbar.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2022  Igara Studio S.A.
+// Copyright (C) 2018-2024  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -518,8 +518,7 @@ void ToolBar::openTipWindow(int group_index, Tool* tool)
     KeyPtr key = KeyboardShortcuts::instance()->tool(tool);
     if (key && !key->accels().empty()) {
       tooltip += "\n\n";
-      tooltip += fmt::format(Strings::tools_shortcut(),
-                             key->accels().front().toString());
+      tooltip += Strings::tools_shortcut(key->accels().front().toString());
     }
   }
   else if (group_index == PreviewVisibilityIndex) {

--- a/src/app/util/layer_utils.cpp
+++ b/src/app/util/layer_utils.cpp
@@ -56,8 +56,7 @@ bool layer_is_locked(Editor* editor)
 #ifdef ENABLE_UI
     if (statusBar) {
       statusBar->showTip(
-        1000, fmt::format(Strings::statusbar_tips_layer_x_is_hidden(),
-                          layer->name()));
+        1000, Strings::statusbar_tips_layer_x_is_hidden(layer->name()));
     }
 #endif
     return true;
@@ -67,7 +66,7 @@ bool layer_is_locked(Editor* editor)
 #ifdef ENABLE_UI
     if (statusBar) {
       statusBar->showTip(
-        1000, fmt::format(Strings::statusbar_tips_layer_locked(), layer->name()));
+        1000, Strings::statusbar_tips_layer_locked(layer->name()));
     }
 #endif
     return true;

--- a/src/gen/strings_class.cpp
+++ b/src/gen/strings_class.cpp
@@ -1,4 +1,5 @@
 // Aseprite Code Generator
+// Copyright (c) 2024 Igara Studio S.A.
 // Copyright (c) 2016-2017 David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -11,12 +12,41 @@
 #include "base/string.h"
 #include "cfg/cfg.h"
 
+#include <algorithm>
+#include <cctype>
 #include <iostream>
 
 static std::string to_cpp(std::string stringId)
 {
   base::replace_string(stringId, ".", "_");
   return stringId;
+}
+
+static size_t count_fmt_args(const std::string& format)
+{
+  size_t n = 0;
+  for (size_t i=0; i<format.size(); ++i) {
+    if (format[i] == '{') {
+      if (format[i+1] == '}') {
+        ++n;
+      }
+      else if (std::isdigit(format[i+1]) &&
+               format[i+2] == '}') {
+        n = std::max<size_t>(n, (format[i+1]-'0')+1);
+      }
+    }
+  }
+  return n;
+}
+
+// Strings with raw "{something}" that are not a fmt format string.
+//
+// TODO This is a super hacky way to filter out these strings, find
+//      another way.
+static bool force_simple_string(const std::string& stringId)
+{
+  return (stringId == "data_filename_format_tooltip" ||
+          stringId == "data_tagname_format_tooltip");
 }
 
 void gen_strings_class(const std::string& inputFn)
@@ -38,7 +68,9 @@ void gen_strings_class(const std::string& inputFn)
     << "\n"
     << "  template<typename T>\n"
     << "  class Strings {\n"
-    << "  public:\n";
+    << "  public:\n"
+    << "    class ID {\n"
+    << "    public:\n";
 
   std::vector<std::string> sections;
   std::vector<std::string> keys;
@@ -49,10 +81,61 @@ void gen_strings_class(const std::string& inputFn)
 
     std::string textId = section;
     textId.push_back('.');
-    for (auto key : keys) {
+    for (const auto& key : keys) {
+      textId.append(key);
+      std::cout << "      static constexpr const char* " << to_cpp(textId) << " = \"" << textId << "\";\n";
+      textId.erase(section.size()+1);
+    }
+  }
+
+  std::cout
+    << "    };\n"
+    << "\n";
+
+  for (const auto& section : sections) {
+    keys.clear();
+    cfg.getAllKeys(section.c_str(), keys);
+
+    std::string textId = section;
+    textId.push_back('.');
+    for (const auto& key : keys) {
       textId.append(key);
 
-      std::cout << "    static const std::string& " << to_cpp(textId) << "() { return T::instance()->translate(\"" << textId << "\"); }\n";
+      std::string value = cfg.getValue(section.c_str(), key.c_str(), "");
+
+      std::string cppId = to_cpp(textId);
+      size_t nargs = count_fmt_args(value);
+
+      // Create just a function to get the translated string (it
+      // doesn't have arguments).
+      if (nargs == 0 || force_simple_string(cppId)) {
+        std::cout << "    static const std::string& " << cppId << "() { return T::Translate(ID::" << cppId << "); }\n";
+      }
+      // Create a function to format the translated string with a
+      // specific number of arguments (the good part is that we can
+      // check the number of required arguments at compile-time).
+      else {
+        std::cout << "    template<";
+        for (int i=1; i<=nargs; ++i) {
+          std::cout << "typename T" << i;
+          if (i < nargs)
+            std::cout << ", ";
+        }
+        std::cout << ">\n";
+        std::cout << "    static std::string " << cppId << "(";
+        for (int i=1; i<=nargs; ++i) {
+          std::cout << "T" << i << "&& arg" << i;
+          if (i < nargs)
+            std::cout << ", ";
+        }
+        std::cout << ") { return T::Format(ID::" << cppId << ", ";
+        for (int i=1; i<=nargs; ++i) {
+          std::cout << "arg" << i;
+          if (i < nargs)
+            std::cout << ", ";
+        }
+        std::cout << "); }\n";
+      }
 
       textId.erase(section.size()+1);
     }


### PR DESCRIPTION
Fix #2274

There is a third-party translation (and can happen with our own translations) that a fmt format string is ill-formed in the .ini file of the translation (this could happen even if the en.ini file was manually modified/broken by hand).

This patch includes a refactor of the Strings class so we can:

1. Static check at compile-time about the number of required arguments to format a string (no need to call fmt::format() directly with arbitrary number of args)
2. If a string is not valid for the fmt library, the runtime exception is caught and the default (English) string is returned.
