### PR TITLE
Don't clone strings repository by default (fix #4489)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ option(ENABLE_DRM          "Compile the DRM-enabled version (e.g. for automatic 
 option(ENABLE_STEAM        "Compile with Steam library" off)
 option(ENABLE_DEVMODE      "Compile vesion for developers" off)
 option(ENABLE_UI           "Compile UI (turn off to compile CLI-only version)" on)
+option(ENABLE_I18N_STRINGS "Clone i18n strings repo (https://github.com/aseprite/strings) to bin/data/strings.git" off)
 option(FULLSCREEN_PLATFORM "Enable fullscreen by default" off)
 option(ENABLE_CLANG_TIDY   "Enable static analysis" off)
 option(ENABLE_CCACHE       "Use CCache to improve recompilation speed (optional)" on)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -102,21 +102,24 @@ set(DATA_OUTPUT_DIR ${CMAKE_BINARY_DIR}/bin/data)
 ######################################################################
 # Clone "strings" repo with translations into bin/data/strings.git
 
-include(FetchContent)
-
-find_package(Git)
-if(GIT_FOUND)
-  FetchContent_Declare(
-    clone_strings
-    GIT_REPOSITORY    https://github.com/aseprite/strings.git
-    GIT_TAG           origin/main
-    SOURCE_DIR        ${DATA_OUTPUT_DIR}/strings.git
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND     ""
-    INSTALL_COMMAND   ""
-    TEST_COMMAND      "")
-  FetchContent_MakeAvailable(clone_strings)
-  add_custom_target(clone_strings DEPENDS clone_strings)
+if(ENABLE_I18N_STRINGS_REPO)
+  include(FetchContent)
+  find_package(Git)
+  if(GIT_FOUND)
+    FetchContent_Declare(
+      clone_strings
+      GIT_REPOSITORY    https://github.com/aseprite/strings.git
+      GIT_TAG           origin/main
+      SOURCE_DIR        ${DATA_OUTPUT_DIR}/strings.git
+      CONFIGURE_COMMAND ""
+      BUILD_COMMAND     ""
+      INSTALL_COMMAND   ""
+      TEST_COMMAND      "")
+    FetchContent_MakeAvailable(clone_strings)
+    add_custom_target(clone_strings DEPENDS clone_strings)
+  else()
+    add_custom_target(clone_strings)
+  endif()
 else()
   add_custom_target(clone_strings)
 endif()
@@ -134,7 +137,7 @@ foreach(fn ${src_data_files})
   list(APPEND out_data_files ${DATA_OUTPUT_DIR}/${fn})
 endforeach()
 
-if(GIT_FOUND)
+if(ENABLE_I18N_STRINGS_REPO AND GIT_FOUND)
   # Copy original en.ini to strings.git/en.ini to keep it updated. We
   # have to manually sync the "en.ini" file in the "strings" repo from
   # the "aseprite" repo.


### PR DESCRIPTION
Fix #4489

New ENABLE_I18N_STRINGS option (off by default) to avoid compilation errors cloning the strings repo (no connection, no git, etc.).
