### PR TITLE
Fix indentation in MacOS (Apple Silicon) install instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -208,7 +208,7 @@ steps as above but when we call `cmake`, we have some differences:
       -DPNG_ARM_NEON:STRING=on \
       -G Ninja \
       ..
-      ninja aseprite
+    ninja aseprite
 
 ### Issues with Retina displays
 


### PR DESCRIPTION
In the MacOS (Apple Silicon) install commands, "ninja aseprite" was incorrectly indented.
It is supposed to be a separate command (as shown in other platforms) but is indented as part of the cmake.

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing
