### PR TITLE
[docs] Improve phrasing for Tileset image data length

### DIFF
--- a/docs/ase-file-specs.md
+++ b/docs/ase-file-specs.md
@@ -509,7 +509,7 @@ The data of this chunk is as follows:
                 of the the External Files Chunk.
       DWORD     Tileset ID in the external file
     + If flag 2 is set
-      DWORD     Compressed data length
+      DWORD     Data length of the compressed Tileset image
       PIXEL[]   Compressed Tileset image (see NOTE.3):
                   (Tile Width) x (Tile Height x Number of Tiles)
 


### PR DESCRIPTION
Clarified the description for the data length field of the compressed Tileset image when flag 2 is set. The way it is written written now is misleading and I originally thought that the length field is also compressed.
