### PR TITLE
Avoid drawing empty strings, other text fixes

### DIFF
--- a/src/app/ui/skin/skin_theme.cpp
+++ b/src/app/ui/skin/skin_theme.cpp
@@ -1288,7 +1288,8 @@ void SkinTheme::drawEntryText(ui::Graphics* g, ui::Entry* widget)
 
   // Draw suffix if there is enough space
   if (!widget->getSuffix().empty()) {
-    Rect sufBounds(bounds.x, bounds.y,
+    Rect sufBounds(bounds.x + widget->font()->textLength(" "),
+                   bounds.y,
                    bounds.x2()-widget->childSpacing()*guiscale()-bounds.x,
                    widget->textHeight());
     IntersectClip clip(g, sufBounds & widget->clientChildrenBounds());

--- a/src/app/ui/skin/skin_theme.cpp
+++ b/src/app/ui/skin/skin_theme.cpp
@@ -1264,6 +1264,9 @@ private:
 
 void SkinTheme::drawEntryText(ui::Graphics* g, ui::Entry* widget)
 {
+  if (widget->text().empty())
+    return;
+
   // Draw the text
   gfx::Rect bounds = widget->getEntryTextBounds();
 

--- a/src/ui/graphics.cpp
+++ b/src/ui/graphics.cpp
@@ -340,6 +340,8 @@ void Graphics::drawText(const std::string& str,
                         const gfx::Point& origPt,
                         text::DrawTextDelegate* delegate)
 {
+  ASSERT(!str.empty());
+
   gfx::Point pt(m_dx+origPt.x, m_dy+origPt.y);
 
   os::SurfaceLock lock(m_surface.get());
@@ -423,6 +425,8 @@ private:
 void Graphics::drawUIText(const std::string& str, gfx::Color fg, gfx::Color bg,
                           const gfx::Point& pt, const int mnemonic)
 {
+  ASSERT(!str.empty());
+
   os::SurfaceLock lock(m_surface.get());
   int x = m_dx+pt.x;
   int y = m_dy+pt.y;
@@ -451,12 +455,10 @@ gfx::Size Graphics::measureUIText(const std::string& str)
 int Graphics::measureUITextLength(const std::string& str,
                                   text::Font* font)
 {
-  DrawUITextDelegate delegate(nullptr, font, 0);
-  text::draw_text(nullptr, get_theme()->fontMgr(),
-                  base::AddRef(font), str,
-                  gfx::ColorNone, gfx::ColorNone,
-                  0, 0, &delegate);
-  return delegate.bounds().w;
+  if (str.empty())
+    return 0;
+
+  return font->textLength(str);
 }
 
 gfx::Size Graphics::fitString(const std::string& str, int maxWidth, int align)
@@ -561,7 +563,8 @@ gfx::Size Graphics::doUIStringAlgorithm(const std::string& str, gfx::Color fg, g
       else
         xout = pt.x;
 
-      drawText(line, fg, bg, gfx::Point(xout, pt.y));
+      if (line.size() > 0)
+        drawText(line, fg, bg, gfx::Point(xout, pt.y));
 
       if (!gfx::is_transparent(bg))
         fillAreaBetweenRects(bg,

--- a/src/ui/graphics.cpp
+++ b/src/ui/graphics.cpp
@@ -403,19 +403,27 @@ public:
         thickness = 1.0;
       }
 
-      auto typeface = m_font->typeface();
-      if (typeface.get()) {
-        // Give the underline some extra thickness based the font weight, if it's above Normal.
-        const int weight_value = (int) typeface.get()->fontStyle().weight() / 100;
-        const int weight_normal = (int) text::FontStyle::Weight::Normal / 100;
-        if (weight_value > weight_normal) {
-          thickness *= weight_value - weight_normal;
+      float underscoreY;
+      if (m_font->type() == text::FontType::Native) {
+        auto typeface = m_font->typeface();
+        if (typeface.get()) {
+          // Give the underline some extra thickness based the font weight, if it's above Normal.
+          const int weight_value =
+            (int)typeface.get()->fontStyle().weight() / 100;
+          const int weight_normal = (int)text::FontStyle::Weight::Normal / 100;
+          if (weight_value > weight_normal) {
+            thickness *= weight_value - weight_normal;
+          }
         }
+        underscoreY = charBounds.y + charBounds.h + metrics.underlinePosition;
+      }
+      else {
+        underscoreY = charBounds.y + (-metrics.ascent + metrics.underlinePosition - metrics.underlineThickness / 2.0f);
       }
 
       gfx::RectF underscoreBounds(
         charBounds.x,
-        charBounds.y + charBounds.h + metrics.underlinePosition,
+        underscoreY,
         charBounds.w,
         thickness);
 

--- a/src/ui/graphics.cpp
+++ b/src/ui/graphics.cpp
@@ -563,7 +563,7 @@ gfx::Size Graphics::doUIStringAlgorithm(const std::string& str, gfx::Color fg, g
       else
         xout = pt.x;
 
-      if (line.size() > 0)
+      if (!line.empty())
         drawText(line, fg, bg, gfx::Point(xout, pt.y));
 
       if (!gfx::is_transparent(bg))

--- a/src/ui/theme.cpp
+++ b/src/ui/theme.cpp
@@ -186,7 +186,6 @@ void Theme::setDecorativeWidgetBounds(Widget* widget)
       widget->setBounds(buttonBounds);
       break;
     }
-
   }
 }
 
@@ -336,16 +335,17 @@ void Theme::paintLayer(Graphics* g,
     return;
 
   switch (layer.type()) {
-
     case Style::Layer::Type::kBackground:
     case Style::Layer::Type::kBackgroundBorder:
-      if (layer.spriteSheet() &&
-          !layer.spriteBounds().isEmpty()) {
+      if (layer.spriteSheet() && !layer.spriteBounds().isEmpty()) {
         if (!layer.slicesBounds().isEmpty()) {
-          Theme::drawSlices(g, layer.spriteSheet(), rc,
+          Theme::drawSlices(g,
+                            layer.spriteSheet(),
+                            rc,
                             layer.spriteBounds(),
                             layer.slicesBounds(),
-                            layer.color(), true);
+                            layer.color(),
+                            true);
 
           if (layer.type() == Style::Layer::Type::kBackgroundBorder) {
             rc.x += layer.slicesBounds().x;
@@ -358,17 +358,17 @@ void Theme::paintLayer(Graphics* g,
         else {
           IntersectClip clip(g, rc);
           if (clip) {
-            auto draw = getDrawSurfaceFunction(
-              g, layer.spriteSheet(), layer.color());
+            auto draw =
+              getDrawSurfaceFunction(g, layer.spriteSheet(), layer.color());
 
             switch (layer.align()) {
-
               // Horizontal line
               case MIDDLE:
-                for (int x=rc.x; x<rc.x2(); x+=layer.spriteBounds().w) {
+                for (int x = rc.x; x < rc.x2(); x += layer.spriteBounds().w) {
                   draw(layer.spriteBounds().x,
                        layer.spriteBounds().y,
-                       x, rc.y+rc.h/2-layer.spriteBounds().h/2,
+                       x,
+                       rc.y + rc.h / 2 - layer.spriteBounds().h / 2,
                        layer.spriteBounds().w,
                        layer.spriteBounds().h);
                 }
@@ -376,10 +376,11 @@ void Theme::paintLayer(Graphics* g,
 
               // Vertical line
               case CENTER:
-                for (int y=rc.y; y<rc.y2(); y+=layer.spriteBounds().h) {
+                for (int y = rc.y; y < rc.y2(); y += layer.spriteBounds().h) {
                   draw(layer.spriteBounds().x,
                        layer.spriteBounds().y,
-                       rc.x+rc.w/2-layer.spriteBounds().w/2, y,
+                       rc.x + rc.w / 2 - layer.spriteBounds().w / 2,
+                       y,
                        layer.spriteBounds().w,
                        layer.spriteBounds().h);
                 }
@@ -389,19 +390,20 @@ void Theme::paintLayer(Graphics* g,
               case CENTER | MIDDLE:
                 draw(layer.spriteBounds().x,
                      layer.spriteBounds().y,
-                     rc.x+rc.w/2-layer.spriteBounds().w/2,
-                     rc.y+rc.h/2-layer.spriteBounds().h/2,
+                     rc.x + rc.w / 2 - layer.spriteBounds().w / 2,
+                     rc.y + rc.h / 2 - layer.spriteBounds().h / 2,
                      layer.spriteBounds().w,
                      layer.spriteBounds().h);
                 break;
 
               // Pattern
               case 0:
-                for (int y=rc.y; y<rc.y2(); y+=layer.spriteBounds().h) {
-                  for (int x=rc.x; x<rc.x2(); x+=layer.spriteBounds().w)
+                for (int y = rc.y; y < rc.y2(); y += layer.spriteBounds().h) {
+                  for (int x = rc.x; x < rc.x2(); x += layer.spriteBounds().w)
                     draw(layer.spriteBounds().x,
                          layer.spriteBounds().y,
-                         x, y,
+                         x,
+                         y,
                          layer.spriteBounds().w,
                          layer.spriteBounds().h);
                 }
@@ -417,13 +419,15 @@ void Theme::paintLayer(Graphics* g,
       break;
 
     case Style::Layer::Type::kBorder:
-      if (layer.spriteSheet() &&
-          !layer.spriteBounds().isEmpty() &&
+      if (layer.spriteSheet() && !layer.spriteBounds().isEmpty() &&
           !layer.slicesBounds().isEmpty()) {
-        Theme::drawSlices(g, layer.spriteSheet(), rc,
+        Theme::drawSlices(g,
+                          layer.spriteSheet(),
+                          rc,
                           layer.spriteBounds(),
                           layer.slicesBounds(),
-                          layer.color(), false);
+                          layer.color(),
+                          false);
 
         rc.x += layer.slicesBounds().x;
         rc.y += layer.slicesBounds().y;
@@ -435,60 +439,59 @@ void Theme::paintLayer(Graphics* g,
       }
       break;
 
-    case Style::Layer::Type::kText:
-      if (layer.color() != gfx::ColorNone) {
-        text::FontRef oldFont = base::AddRef(g->font());
-        if (style->font())
-          g->setFont(AddRef(style->font()));
+    case Style::Layer::Type::kText: {
+      if (text.empty())
+        break;
 
+      if (layer.color() != gfx::ColorNone) {
         if (layer.align() & WORDWRAP) {
           gfx::Rect textBounds = rc;
           textBounds.offset(layer.offset());
 
-          g->drawAlignedUIText(text,
-                               layer.color(),
-                               bgColor,
-                               textBounds, layer.align());
+          g->drawAlignedUIText(
+            text, layer.color(), bgColor, textBounds, layer.align());
         }
         else {
           gfx::Size textSize = g->measureUIText(text);
           gfx::Point pt;
           gfx::Border undef = Style::UndefinedBorder();
           gfx::Border padding = style->padding();
-          if (padding.left() == undef.left()) padding.left(0);
-          if (padding.right() == undef.right()) padding.right(0);
-          if (padding.top() == undef.top()) padding.top(0);
-          if (padding.bottom() == undef.bottom()) padding.bottom(0);
+          if (padding.left() == undef.left())
+            padding.left(0);
+          if (padding.right() == undef.right())
+            padding.right(0);
+          if (padding.top() == undef.top())
+            padding.top(0);
+          if (padding.bottom() == undef.bottom())
+            padding.bottom(0);
 
           if (layer.align() & LEFT)
-            pt.x = rc.x+padding.left();
+            pt.x = rc.x + padding.left();
           else if (layer.align() & RIGHT)
-            pt.x = rc.x+rc.w-textSize.w-padding.right();
+            pt.x = rc.x + rc.w - textSize.w - padding.right();
           else {
-            pt.x = CALC_FOR_CENTER(rc.x+padding.left(), rc.w-padding.width(), textSize.w);
+            pt.x = CALC_FOR_CENTER(rc.x + padding.left(), rc.w - padding.width(), textSize.w);
           }
 
           if (layer.align() & TOP)
-            pt.y = rc.y+padding.top();
+            pt.y = rc.y + padding.top();
           else if (layer.align() & BOTTOM)
-            pt.y = rc.y+rc.h-textSize.h-padding.bottom();
+            pt.y = rc.y + rc.h - textSize.h - padding.bottom();
           else {
-            pt.y = CALC_FOR_CENTER(rc.y+padding.top(), rc.h-padding.height(), textSize.h);
+            pt.y = CALC_FOR_CENTER(rc.y + padding.top(), rc.h - padding.height(), textSize.h);
           }
 
           pt += layer.offset();
 
-          if (!text.empty())
-            g->drawUIText(text,
-                          layer.color(),
-                          bgColor,
-                          pt, style->mnemonics() ? mnemonic : 0);
+          g->drawUIText(text,
+                        layer.color(),
+                        bgColor,
+                        pt,
+                        style->mnemonics() ? mnemonic : 0);
         }
-
-        if (style->font())
-          g->setFont(oldFont);
       }
       break;
+    }
 
     case Style::Layer::Type::kIcon: {
       os::Surface* icon = providedIcon ? providedIcon : layer.icon();

--- a/src/ui/theme.cpp
+++ b/src/ui/theme.cpp
@@ -478,10 +478,11 @@ void Theme::paintLayer(Graphics* g,
 
           pt += layer.offset();
 
-          g->drawUIText(text,
-                        layer.color(),
-                        bgColor,
-                        pt, style->mnemonics() ? mnemonic : 0);
+          if (!text.empty())
+            g->drawUIText(text,
+                          layer.color(),
+                          bgColor,
+                          pt, style->mnemonics() ? mnemonic : 0);
         }
 
         if (style->font())
@@ -592,16 +593,18 @@ void Theme::measureLayer(const Widget* widget,
     case Style::Layer::Type::kText:
       if (layer.color() != gfx::ColorNone) {
         gfx::Size textSize;
-        if (style->font() &&
-            style->font() != widget->font()) {
-          text::Font* font = style->font();
-          textSize = gfx::Size(Graphics::measureUITextLength(widget->text(), font),
-                               font->height());
-        }
-        else {
-          // We can use Widget::textSize() because we're going to use
-          // the widget font and, probably, the cached TextBlob.
-          textSize = widget->textSize();
+        if (widget->text().size() > 0) {
+          if (style->font() && style->font() != widget->font()) {
+            text::Font* font = style->font();
+            textSize =
+              gfx::Size(Graphics::measureUITextLength(widget->text(), font),
+                        font->height());
+          }
+          else {
+            // We can use Widget::textSize() because we're going to use
+            // the widget font and, probably, the cached TextBlob.
+            textSize = widget->textSize();
+          }
         }
 
         textHint.offset(layer.offset());
@@ -949,7 +952,7 @@ void Theme::drawTextBox(Graphics* g, const Widget* widget,
     len = font->textLength(beg);
 
     // Render the text
-    if (g) {
+    if (g && len > 0) {
       int xout;
 
       if (widget->align() & CENTER)

--- a/src/ui/theme.cpp
+++ b/src/ui/theme.cpp
@@ -593,7 +593,7 @@ void Theme::measureLayer(const Widget* widget,
     case Style::Layer::Type::kText:
       if (layer.color() != gfx::ColorNone) {
         gfx::Size textSize;
-        if (widget->text().size() > 0) {
+        if (!widget->text().empty()) {
           if (style->font() && style->font() != widget->font()) {
             text::Font* font = style->font();
             textSize =

--- a/src/ui/widget.cpp
+++ b/src/ui/widget.cpp
@@ -920,7 +920,7 @@ void Widget::getDrawableRegion(gfx::Region& region, DrawableRegionFlags flags)
 
 text::TextBlobRef Widget::textBlob() const
 {
-  if (!m_blob) {
+  if (!m_blob && !m_text.empty()) {
     m_blob = text::TextBlob::MakeWithShaper(
       theme()->fontMgr(),
       AddRef(font()),


### PR DESCRIPTION
Avoids sending empty strings to the graphics API, adds some asserts to prevent it from happening in future.

Uses measureText() from the font to measure text length instead of drawing.

Improves underline bounds calculations
