### PR TITLE
Release mouse before command execution on dragging value state

### DIFF
--- a/src/app/ui/editor/dragging_value_state.cpp
+++ b/src/app/ui/editor/dragging_value_state.cpp
@@ -162,6 +162,8 @@ bool DraggingValueState::onUpdateStatusBar(Editor* editor)
 
 void DraggingValueState::onBeforeCommandExecution(CommandExecutionEvent& ev)
 {
+  if (m_editor->hasCapture())
+    m_editor->releaseMouse();
   m_editor->backToPreviousState();
 }
 


### PR DESCRIPTION
Fix #4484

Same as the old commit, I merely rebased to drop unrelated changes.

I haven't been able to sign the document yet, due to what appears to be a browser error, so just in case: I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md