### PR TITLE
Fix extensions wrongly being detected as "built-in"

### DIFF
--- a/src/app/app_menus.cpp
+++ b/src/app/app_menus.cpp
@@ -391,7 +391,7 @@ void AppMenus::reload()
 #ifdef ENABLE_SCRIPTING
     // Load scripts
     ResourceFinder rf;
-    rf.includeUserDir("scripts/.");
+    rf.includeUserDir("scripts");
     std::string scriptsDir = rf.getFirstOrCreateDefault();
     scriptsDir = base::get_file_path(scriptsDir);
     if (base::is_directory(scriptsDir)) {

--- a/src/app/app_menus.cpp
+++ b/src/app/app_menus.cpp
@@ -393,7 +393,6 @@ void AppMenus::reload()
     ResourceFinder rf;
     rf.includeUserDir("scripts");
     std::string scriptsDir = rf.getFirstOrCreateDefault();
-    scriptsDir = base::get_file_path(scriptsDir);
     if (base::is_directory(scriptsDir)) {
       loadScriptsSubmenu(scriptsMenu->getSubmenu(), scriptsDir, true);
     }

--- a/src/app/extensions.cpp
+++ b/src/app/extensions.cpp
@@ -827,7 +827,8 @@ Extensions::Extensions()
       if (!base::is_directory(dir))
         continue;
 
-      const bool isBuiltinExtension = m_userExtensionsPath != base::get_file_path(dir);
+      const bool isBuiltinExtension =
+        (m_userExtensionsPath != base::get_file_path(dir));
 
       auto fullFn = base::join_path(dir, kPackageJson);
       fullFn = base::normalize_path(fullFn);

--- a/src/app/extensions.cpp
+++ b/src/app/extensions.cpp
@@ -800,7 +800,7 @@ Extensions::Extensions()
   // Create and get the user extensions directory
   {
     ResourceFinder rf2;
-    rf2.includeUserDir("extensions/.");
+    rf2.includeUserDir("extensions");
     m_userExtensionsPath = rf2.getFirstOrCreateDefault();
     m_userExtensionsPath = base::normalize_path(m_userExtensionsPath);
     if (!m_userExtensionsPath.empty() &&
@@ -817,33 +817,33 @@ Extensions::Extensions()
   // Load extensions from data/ directory on all possible locations
   // (installed folder and user folder)
   while (rf.next()) {
-    auto extensionsDir = rf.filename();
+    const auto& extensionsDir = rf.filename();
 
-    if (base::is_directory(extensionsDir)) {
-      for (auto fn : base::list_files(extensionsDir)) {
-        const auto dir = base::join_path(extensionsDir, fn);
-        if (!base::is_directory(dir))
-          continue;
+    if (!base::is_directory(extensionsDir))
+      continue;
 
-        const bool isBuiltinExtension =
-          (m_userExtensionsPath != base::get_file_path(dir));
+    for (auto& fn : base::list_files(extensionsDir)) {
+      const auto dir = base::join_path(extensionsDir, fn);
+      if (!base::is_directory(dir))
+        continue;
 
-        auto fullFn = base::join_path(dir, kPackageJson);
-        fullFn = base::normalize_path(fullFn);
+      const bool isBuiltinExtension = m_userExtensionsPath != base::get_file_path(dir);
 
-        LOG("EXT: Loading extension '%s'...\n", fullFn.c_str());
-        if (!base::is_file(fullFn)) {
-          LOG("EXT: File '%s' not found\n", fullFn.c_str());
-          continue;
-        }
+      auto fullFn = base::join_path(dir, kPackageJson);
+      fullFn = base::normalize_path(fullFn);
 
-        try {
-          loadExtension(dir, fullFn, isBuiltinExtension);
-        }
-        catch (const std::exception& ex) {
-          LOG("EXT: Error loading JSON file: %s\n",
-              ex.what());
-        }
+      LOG("EXT: Loading extension '%s'...\n", fullFn.c_str());
+      if (!base::is_file(fullFn)) {
+        LOG("EXT: File '%s' not found\n", fullFn.c_str());
+        continue;
+      }
+
+      try {
+        loadExtension(dir, fullFn, isBuiltinExtension);
+      }
+      catch (const std::exception& ex) {
+        LOG("EXT: Error loading JSON file: %s\n",
+            ex.what());
       }
     }
   }


### PR DESCRIPTION
The extra trailing path slash was making the comparison fail, must've been one of the changes to the base functions. Fixed it by just normalizing and removing any trailing slashes. Fixes [#4622](https://github.com/aseprite/aseprite/issues/4622)