### PR TITLE
Improve UX importing images and sprites 

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -105,6 +105,13 @@ else()
   target_sources(app-lib PRIVATE font_path_unix.cpp)
 endif()
 
+# This defines a specific webp decoding utility function for using
+# in Windows when dragging and dropping images that are stored as
+# webp files (like Chrome does).
+if(WIN32 AND ENABLE_WEBP)
+  target_sources(app-lib PRIVATE util/decode_webp.cpp)
+endif()
+
 # Trial-version vs Full version (enable save command)
 if(ENABLE_TRIAL_MODE)
   target_compile_definitions(app-lib PUBLIC -DENABLE_TRIAL_MODE)

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -282,6 +282,7 @@ target_sources(app-lib PRIVATE
   cmd/copy_region.cpp
   cmd/crop_cel.cpp
   cmd/deselect_mask.cpp
+  cmd/drop_on_timeline.cpp
   cmd/flatten_layers.cpp
   cmd/flip_image.cpp
   cmd/flip_mask.cpp

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -689,6 +689,7 @@ target_sources(app-lib PRIVATE
   util/cel_ops.cpp
   util/clipboard.cpp
   util/clipboard_native.cpp
+  util/conversion_to_image.cpp
   util/conversion_to_surface.cpp
   util/expand_cel_canvas.cpp
   util/filetoks.cpp

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -78,6 +78,10 @@
   #include "os/x11/system.h"
 #endif
 
+#if ENABLE_WEBP && LAF_WINDOWS
+  #include "app/util/decode_webp.h"
+#endif
+
 #include <iostream>
 #include <memory>
 
@@ -482,6 +486,10 @@ void App::run()
     manager->display()->nativeWindow()
       ->setInterpretOneFingerGestureAsMouseMovement(
         preferences().experimental.oneFingerAsMouseMovement());
+  #if ENABLE_WEBP
+    // In Windows we use a custom webp decoder for drag & drop operations.
+    os::set_decode_webp(util::decode_webp);
+  #endif
 #endif
 
 #if LAF_LINUX

--- a/src/app/cmd/drop_on_timeline.cpp
+++ b/src/app/cmd/drop_on_timeline.cpp
@@ -1,0 +1,231 @@
+// Aseprite
+// Copyright (C) 2024  Igara Studio S.A.
+//
+// This program is distributed under the terms of
+// the End-User License Agreement for Aseprite.
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "app/cmd/drop_on_timeline.h"
+
+#include "app/cmd/add_layer.h"
+#include "app/cmd/set_pixel_format.h"
+#include "app/context_flags.h"
+#include "app/console.h"
+#include "app/doc.h"
+#include "app/doc_event.h"
+#include "app/file/file.h"
+#include "app/ui_context.h"
+#include "app/util/open_file_job.h"
+#include "app/tx.h"
+#include "base/fs.h"
+#include "doc/layer_list.h"
+#include "render/dithering.h"
+
+namespace app {
+namespace cmd {
+
+DropOnTimeline::DropOnTimeline(app::Doc* doc,
+                               doc::frame_t frame,
+                               doc::layer_t layerIndex,
+                               LayerInsertion insert,
+                               const base::paths& paths) : WithDocument(doc)
+                                                         , m_size(0)
+                                                         , m_paths(paths)
+                                                         , m_frame(frame)
+                                                         , m_layerIndex(layerIndex)
+                                                         , m_insert(insert)
+{
+  ASSERT(m_layerIndex >= 0);
+  for(const auto& path : m_paths)
+    m_size += path.size();
+}
+
+void DropOnTimeline::setupInsertionLayers(Layer** before, Layer** after, LayerGroup** group)
+{
+  const LayerList& allLayers = document()->sprite()->allLayers();
+  *after  = (m_insert == LayerInsertion::After  ? allLayers[m_layerIndex] : nullptr);
+  *before = (m_insert == LayerInsertion::Before ? allLayers[m_layerIndex] : nullptr);
+  if (*before && (*before)->isGroup()) {
+    *group = static_cast<LayerGroup*>(*before);
+    // The user is trying to drop layers into an empty group, so there is no after
+    // nor before layer...
+    if ((*group)->layersCount() == 0) {
+      *after = nullptr;
+      *before = nullptr;
+      return;
+    }
+    *after = static_cast<LayerGroup*>(*before)->lastLayer();
+    *before = nullptr;
+  }
+
+  *group  = (*after ? (*after)->parent() : (*before)->parent());
+}
+
+void DropOnTimeline::onExecute()
+{
+  Doc* destDoc = document();
+  Console console;
+  Context* context = document()->context();
+
+  m_previousTotalFrames = destDoc->sprite()->totalFrames();
+  // Layers after/before which the dropped layers will be inserted
+  Layer* afterThis = nullptr;
+  Layer* beforeThis = nullptr;
+  // Parent group of the after/before layers.
+  LayerGroup* group = nullptr;
+
+  int flags =
+    FILE_LOAD_DATA_FILE |
+    FILE_LOAD_CREATE_PALETTE;
+
+  for(const auto& path : m_paths) {
+    std::unique_ptr<FileOp> fop(
+      FileOp::createLoadDocumentOperation(context, path, flags));
+
+    // Do nothing (the user cancelled or something like that)
+    if (!fop)
+      return;
+
+    if (fop->hasError()) {
+      console.printf(fop->error().c_str());
+    }
+    else {
+      OpenFileJob task(fop.get(), true);
+      task.showProgressWindow();
+
+      // Post-load processing, it is called from the GUI because may require user intervention.
+      fop->postLoad();
+
+      // Show any error
+      if (fop->hasError() && !fop->isStop())
+        console.printf(fop->error().c_str());
+
+      Doc* srcDoc = fop->document();
+      if (srcDoc) {
+        // If source document doesn't match the destination document's color
+        // mode, change it.
+        if (srcDoc->colorMode() != destDoc->colorMode()) {
+          Tx tx(srcDoc);
+          tx(new cmd::SetPixelFormat(
+            srcDoc->sprite(), destDoc->sprite()->pixelFormat(),
+            render::Dithering(),
+            Preferences::instance().quantization.rgbmapAlgorithm(),
+            nullptr,
+            nullptr,
+            FitCriteria::DEFAULT));
+          tx.commit();
+        }
+
+        // If there is no room for the source frames, add frames to the
+        // destination sprite.
+        if (m_frame+srcDoc->sprite()->totalFrames() > destDoc->sprite()->totalFrames()) {
+          destDoc->sprite()->setTotalFrames(m_frame+srcDoc->sprite()->totalFrames());
+        }
+
+        setupInsertionLayers(&beforeThis, &afterThis, &group);
+
+        // Insert layers from the source document.
+        auto allLayers = srcDoc->sprite()->allLayers();
+        for (auto it = allLayers.cbegin(); it != allLayers.cend(); ++it) {
+          auto* layer = *it;
+          // TODO: If we could "relocate" a layer from the source document to the
+          // destination document we could avoid making a copy here.
+          auto* layerCopy = Layer::MakeCopyWithSprite(layer, destDoc->sprite());
+          destDoc->copyLayerContent(layer, destDoc, layerCopy);
+          layerCopy->displaceFrames(0, m_frame);
+
+          if (afterThis) {
+            group->insertLayer(layerCopy, afterThis);
+            afterThis = layerCopy;
+          }
+          else if (beforeThis) {
+            group->insertLayerBefore(layerCopy, beforeThis);
+            beforeThis = nullptr;
+            afterThis = layerCopy;
+          }
+          else {
+            group->addLayer(layerCopy);
+            afterThis = layerCopy;
+          }
+          m_droppedLayers.push_back(layerCopy);
+          m_size += layerCopy->getMemSize();
+        }
+        group->incrementVersion();
+      }
+    }
+  }
+  destDoc->sprite()->incrementVersion();
+  destDoc->incrementVersion();
+
+  notifyDocObservers(afterThis ? afterThis : beforeThis);
+}
+
+void DropOnTimeline::onUndo()
+{
+  Doc* doc = document();
+  frame_t currentTotalFrames = doc->sprite()->totalFrames();
+  Layer* layerBefore = nullptr;
+  for (auto* layer : m_droppedLayers) {
+    layerBefore = layer->getPrevious();
+    layer->parent()->removeLayer(layer);
+  }
+  doc->sprite()->setTotalFrames(m_previousTotalFrames);
+  m_previousTotalFrames = currentTotalFrames;
+
+  if (!layerBefore)
+    layerBefore = doc->sprite()->firstLayer();
+
+  notifyDocObservers(layerBefore);
+}
+
+void DropOnTimeline::onRedo()
+{
+  Doc* doc = document();
+  frame_t currentTotalFrames = doc->sprite()->totalFrames();
+  doc->sprite()->setTotalFrames(m_previousTotalFrames);
+  m_previousTotalFrames = currentTotalFrames;
+
+  Layer* afterThis = nullptr;
+  Layer* beforeThis = nullptr;
+  LayerGroup* group = nullptr;
+  setupInsertionLayers(&beforeThis, &afterThis, &group);
+
+  for (auto it = m_droppedLayers.cbegin(); it != m_droppedLayers.cend(); ++it) {
+    auto* layer = *it;
+
+    if (afterThis) {
+      group->insertLayer(layer, afterThis);
+      afterThis = layer;
+    }
+    else if (beforeThis) {
+      group->insertLayerBefore(layer, beforeThis);
+      beforeThis = nullptr;
+      afterThis = layer;
+    }
+    else {
+      group->addLayer(layer);
+      afterThis = layer;
+    }
+  }
+  notifyDocObservers(afterThis ? afterThis : beforeThis);
+}
+
+void DropOnTimeline::notifyDocObservers(Layer* layer)
+{
+  Doc* doc = document();
+  if (doc && layer) {
+    DocEvent ev(doc);
+    ev.sprite(doc->sprite());
+    ev.layer(layer);
+    // TODO: This is a hack, we send this notification because the timeline
+    // has the code we need to execute after this command. We tried using
+    // DocObserver::onAddLayer but it makes the redo crash.
+    doc->notify_observers<DocEvent&>(&DocObserver::onAfterRemoveLayer, ev);
+  }
+}
+
+} // namespace cmd
+} // namespace app

--- a/src/app/cmd/drop_on_timeline.cpp
+++ b/src/app/cmd/drop_on_timeline.cpp
@@ -24,6 +24,8 @@
 #include "doc/layer_list.h"
 #include "render/dithering.h"
 
+#include <algorithm>
+
 namespace app {
 namespace cmd {
 
@@ -79,11 +81,15 @@ void DropOnTimeline::onExecute()
 
   int flags =
     FILE_LOAD_DATA_FILE |
-    FILE_LOAD_CREATE_PALETTE;
+    FILE_LOAD_CREATE_PALETTE | FILE_LOAD_SEQUENCE_YES;
 
-  for(const auto& path : m_paths) {
+  while(!m_paths.empty()) {
     std::unique_ptr<FileOp> fop(
-      FileOp::createLoadDocumentOperation(context, path, flags));
+      FileOp::createLoadDocumentOperation(context, m_paths.front(), flags));
+
+    // Remove paths that will be loaded by the current file operation.
+    for (const auto& filename : fop->filenames())
+      m_paths.erase(std::find(m_paths.begin(), m_paths.end(), filename));
 
     // Do nothing (the user cancelled or something like that)
     if (!fop)

--- a/src/app/cmd/drop_on_timeline.cpp
+++ b/src/app/cmd/drop_on_timeline.cpp
@@ -23,6 +23,10 @@
 #include "doc/layer_list.h"
 #include "render/dithering.h"
 
+#if ENABLE_WEBP && LAF_WINDOWS
+#include "app/util/decode_webp.h"
+#endif
+
 #include <algorithm>
 
 namespace app {

--- a/src/app/cmd/drop_on_timeline.cpp
+++ b/src/app/cmd/drop_on_timeline.cpp
@@ -18,6 +18,7 @@
 #include "app/doc.h"
 #include "app/doc_event.h"
 #include "app/file/file.h"
+#include "app/util/layer_utils.h"
 #include "app/util/open_file_job.h"
 #include "app/tx.h"
 #include "doc/layer_list.h"
@@ -160,8 +161,7 @@ void DropOnTimeline::onExecute()
           auto* layer = *it;
           // TODO: If we could "relocate" a layer from the source document to the
           // destination document we could avoid making a copy here.
-          auto* layerCopy = Layer::MakeCopyWithSprite(layer, destDoc->sprite());
-          destDoc->copyLayerContent(layer, destDoc, layerCopy);
+          auto* layerCopy = copy_layer_with_sprite(layer, destDoc->sprite());
           layerCopy->displaceFrames(0, m_frame);
 
           if (afterThis) {

--- a/src/app/cmd/drop_on_timeline.cpp
+++ b/src/app/cmd/drop_on_timeline.cpp
@@ -81,13 +81,18 @@ void DropOnTimeline::onExecute()
   LayerGroup* group = nullptr;
 
   int flags =
-    FILE_LOAD_DATA_FILE |
+    FILE_LOAD_DATA_FILE | FILE_LOAD_AVOID_BACKGROUND_LAYER |
     FILE_LOAD_CREATE_PALETTE | FILE_LOAD_SEQUENCE_YES;
 
   int fopCount = 0;
   while(!m_paths.empty()) {
     std::unique_ptr<FileOp> fop(
       FileOp::createLoadDocumentOperation(context, m_paths.front(), flags));
+
+    // Do nothing (the user cancelled or something like that)
+    if (!fop)
+      return;
+
     fopCount++;
 
     base::paths fopFilenames;
@@ -98,10 +103,6 @@ void DropOnTimeline::onExecute()
       if (it != m_paths.end())
         m_paths.erase(it);
     }
-
-    // Do nothing (the user cancelled or something like that)
-    if (!fop)
-      return;
 
     if (fop->hasError()) {
       console.printf(fop->error().c_str());

--- a/src/app/cmd/drop_on_timeline.cpp
+++ b/src/app/cmd/drop_on_timeline.cpp
@@ -23,10 +23,6 @@
 #include "doc/layer_list.h"
 #include "render/dithering.h"
 
-#if ENABLE_WEBP && LAF_WINDOWS
-#include "app/util/decode_webp.h"
-#endif
-
 #include <algorithm>
 
 namespace app {

--- a/src/app/cmd/drop_on_timeline.h
+++ b/src/app/cmd/drop_on_timeline.h
@@ -1,0 +1,62 @@
+// Aseprite
+// Copyright (C) 2024 Igara Studio S.A.
+//
+// This program is distributed under the terms of
+// the End-User License Agreement for Aseprite.
+
+#ifndef APP_CMD_drop_on_timeline_H_INCLUDED
+#define APP_CMD_drop_on_timeline_H_INCLUDED
+#pragma once
+
+#include "app/cmd.h"
+#include "app/cmd/with_document.h"
+#include "app/doc_observer.h"
+#include "base/paths.h"
+#include "doc/frame.h"
+#include "doc/layer.h"
+#include "doc/layer_list.h"
+
+#include <vector>
+
+namespace app {
+namespace cmd {
+
+  class DropOnTimeline : public Cmd
+                       , public WithDocument {
+  public:
+    enum class LayerInsertion {
+      Before,
+      After,
+    };
+    // Inserts the layers and frames of the documents pointed by the specified
+    // paths, at the specified frame and before or after the specified layer index.
+    DropOnTimeline(app::Doc* doc, doc::frame_t frame, doc::layer_t layerIndex,
+                   LayerInsertion insert, const base::paths& paths);
+  protected:
+    void onExecute() override;
+    void onUndo() override;
+    void onRedo() override;
+    size_t onMemSize() const override {
+      return sizeof(*this) + m_size;
+    }
+
+  private:
+    void setupInsertionLayers(doc::Layer** before, doc::Layer** after, doc::LayerGroup** group);
+    void notifyAddLayer(doc::Layer* layer);
+    void notifyDocObservers(doc::Layer* layer);
+
+    size_t m_size;
+    base::paths m_paths;
+    doc::frame_t m_frame;
+    doc::layer_t m_layerIndex;
+    LayerInsertion m_insert;
+    // Holds the list of layers dropped into the document.
+    doc::LayerList m_droppedLayers;
+    // Number of frames the doc had before dropping.
+    doc::frame_t m_previousTotalFrames;
+  };
+
+} // namespace cmd
+} // namespace app
+
+#endif

--- a/src/app/cmd/drop_on_timeline.h
+++ b/src/app/cmd/drop_on_timeline.h
@@ -54,7 +54,8 @@ namespace cmd {
     }
 
   private:
-    void setupInsertionLayers(doc::Layer** before, doc::Layer** after, doc::LayerGroup** group);
+    void setupInsertionLayer(doc::Layer** layer, doc::LayerGroup** group);
+    void insertDroppedLayers(bool incGroupVersion);
     bool canMoveCelFrom(app::Doc* srcDoc);
     void notifyAddLayer(doc::Layer* layer);
     void notifyDocObservers(doc::Layer* layer);

--- a/src/app/cmd/drop_on_timeline.h
+++ b/src/app/cmd/drop_on_timeline.h
@@ -13,6 +13,7 @@
 #include "app/doc_observer.h"
 #include "base/paths.h"
 #include "doc/frame.h"
+#include "doc/image_ref.h"
 #include "doc/layer.h"
 #include "doc/layer_list.h"
 
@@ -38,6 +39,12 @@ namespace cmd {
     // paths, at the specified frame and before or after the specified layer index.
     DropOnTimeline(app::Doc* doc, doc::frame_t frame, doc::layer_t layerIndex,
                    InsertionPoint insert, DroppedOn droppedOn, const base::paths& paths);
+
+    // Inserts the image as if it were a document with just one layer and one
+    // frame, at the specified frame and before or after the specified layer index.
+    DropOnTimeline(app::Doc* doc, doc::frame_t frame, doc::layer_t layerIndex,
+                   InsertionPoint insert, DroppedOn droppedOn, const doc::ImageRef& image);
+
   protected:
     void onExecute() override;
     void onUndo() override;
@@ -51,9 +58,17 @@ namespace cmd {
     bool canMoveCelFrom(app::Doc* srcDoc);
     void notifyAddLayer(doc::Layer* layer);
     void notifyDocObservers(doc::Layer* layer);
+    bool hasPendingWork();
+    // Sets srcDoc's Doc* pointer to the next document to be processed.
+    // Returns false when the user cancelled the process, or true when the
+    // process must go on.
+    bool getNextDoc(Doc** srcDoc);
+    bool getNextDocFromImage(Doc** srcDoc);
+    bool getNextDocFromPaths(Doc** srcDoc);
 
     size_t m_size;
     base::paths m_paths;
+    doc::ImageRef m_image = nullptr;
     doc::frame_t m_frame;
     doc::layer_t m_layerIndex;
     InsertionPoint m_insert;

--- a/src/app/cmd_transaction.cpp
+++ b/src/app/cmd_transaction.cpp
@@ -14,6 +14,7 @@
 #include "app/app.h"
 #include "app/context.h"
 #include "app/site.h"
+#include "app/sprite_position.h"
 #include "app/ui/timeline/timeline.h"
 
 namespace app {
@@ -118,6 +119,12 @@ size_t CmdTransaction::onMemSize() const
 
 SpritePosition CmdTransaction::calcSpritePosition() const
 {
+  // This check was added to allow executing transactions on documents that are
+  // not part of any context. For instance, when dragging and dropping a
+  // document on the timeline, the dragged document doesn't have any context (
+  // it is not associated with any editor).
+  if (!context())
+    return SpritePosition();
   Site site = context()->activeSite();
   return SpritePosition(site.layer(), site.frame());
 }

--- a/src/app/commands/cmd_new_file.cpp
+++ b/src/app/commands/cmd_new_file.cpp
@@ -46,6 +46,7 @@ struct NewFileParams : public NewParams {
   Param<int> height { this, 0, "height" };
   Param<ColorMode> colorMode { this, ColorMode::RGB, "colorMode" };
   Param<bool> fromClipboard { this, false, "fromClipboard" };
+  Param<bool> fromDraggedData { this, false, "fromDraggedData" };
 };
 
 class NewFileCommand : public CommandWithNewParams<NewFileParams> {
@@ -86,8 +87,9 @@ void NewFileCommand::onExecute(Context* ctx)
   doc::Palette clipboardPalette(0, 256);
   const int ncolors = get_default_palette()->size();
 
-  if (params().fromClipboard()) {
-    clipboardImage = ctx->clipboard()->getImage(&clipboardPalette);
+  if (params().fromClipboard() || params().fromDraggedData()) {
+    clipboardImage = (params().fromClipboard() ? ctx->clipboard()->getImage(&clipboardPalette)
+                                               : ctx->draggedData()->getImage());
     if (!clipboardImage)
       return;
 

--- a/src/app/context.h
+++ b/src/app/context.h
@@ -96,7 +96,8 @@ namespace app {
       m_image = image;
     }
     DraggedData(const os::SurfaceRef& surface) {
-      convert_surface_to_image(surface.get(), 0, 0, surface->width(), surface->height(), m_image);
+      if (surface)
+        convert_surface_to_image(surface.get(), 0, 0, surface->width(), surface->height(), m_image);
     }
 
     const doc::ImageRef& getImage() const { return m_image; }

--- a/src/app/doc_api.cpp
+++ b/src/app/doc_api.cpp
@@ -48,6 +48,7 @@
 #include "app/snap_to_grid.h"
 #include "app/transaction.h"
 #include "app/util/autocrop.h"
+#include "app/util/layer_utils.h"
 #include "doc/algorithm/flip_image.h"
 #include "doc/algorithm/shrink_bounds.h"
 #include "doc/cel.h"
@@ -697,9 +698,7 @@ void DocApi::restackLayerBefore(Layer* layer, LayerGroup* parent, Layer* beforeT
 Layer* DocApi::duplicateLayerAfter(Layer* sourceLayer, LayerGroup* parent, Layer* afterLayer)
 {
   ASSERT(parent);
-  Layer* newLayerPtr = Layer::MakeCopy(sourceLayer);
-
-  m_document->copyLayerContent(sourceLayer, m_document, newLayerPtr);
+  Layer* newLayerPtr = copy_layer(sourceLayer);
 
   newLayerPtr->setName(newLayerPtr->name() + " Copy");
 

--- a/src/app/doc_api.cpp
+++ b/src/app/doc_api.cpp
@@ -697,27 +697,15 @@ void DocApi::restackLayerBefore(Layer* layer, LayerGroup* parent, Layer* beforeT
 Layer* DocApi::duplicateLayerAfter(Layer* sourceLayer, LayerGroup* parent, Layer* afterLayer)
 {
   ASSERT(parent);
-  std::unique_ptr<Layer> newLayerPtr;
+  Layer* newLayerPtr = Layer::MakeCopy(sourceLayer);
 
-  if (sourceLayer->isTilemap()) {
-    newLayerPtr.reset(new LayerTilemap(sourceLayer->sprite(),
-                                       static_cast<LayerTilemap*>(sourceLayer)->tilesetIndex()));
-  }
-  else if (sourceLayer->isImage())
-    newLayerPtr.reset(new LayerImage(sourceLayer->sprite()));
-  else if (sourceLayer->isGroup())
-    newLayerPtr.reset(new LayerGroup(sourceLayer->sprite()));
-  else
-    throw std::runtime_error("Invalid layer type");
-
-  m_document->copyLayerContent(sourceLayer, m_document, newLayerPtr.get());
+  m_document->copyLayerContent(sourceLayer, m_document, newLayerPtr);
 
   newLayerPtr->setName(newLayerPtr->name() + " Copy");
 
-  addLayer(parent, newLayerPtr.get(), afterLayer);
+  addLayer(parent, newLayerPtr, afterLayer);
 
-  // Release the pointer as it is owned by the sprite now.
-  return newLayerPtr.release();
+  return newLayerPtr;
 }
 
 Layer* DocApi::duplicateLayerBefore(Layer* sourceLayer, LayerGroup* parent, Layer* beforeLayer)

--- a/src/app/file/file.cpp
+++ b/src/app/file/file.cpp
@@ -533,6 +533,11 @@ FileOp* FileOp::createLoadDocumentOperation(Context* context,
       fop->m_dataFilename = dataFilename;
   }
 
+  // Avoid creating a background layer?
+  if (flags & FILE_LOAD_AVOID_BACKGROUND_LAYER) {
+    fop->m_avoidBackgroundLayer = true;
+  }
+
 done:;
   return fop.release();
 }
@@ -939,8 +944,9 @@ void FileOp::operate(IFileOpProgress* progress)
 
       // Final setup
       if (m_document) {
-        // Configure the layer as the 'Background'
-        if (!m_seq.has_alpha)
+        // Configure the layer as the 'Background'. Only if background layers
+        // are welcome.
+        if (!m_seq.has_alpha && !m_avoidBackgroundLayer)
           m_seq.layer->configureAsBackground();
 
         // Set the final canvas size (as the bigger loaded
@@ -1522,6 +1528,7 @@ FileOp::FileOp(FileOpType type,
   , m_oneframe(false)
   , m_createPaletteFromRgba(false)
   , m_ignoreEmpty(false)
+  , m_avoidBackgroundLayer(false)
   , m_embeddedColorProfile(false)
   , m_embeddedGridBounds(false)
 {

--- a/src/app/file/file.h
+++ b/src/app/file/file.h
@@ -27,13 +27,14 @@
 #include <string>
 
 // Flags for FileOp::createLoadDocumentOperation()
-#define FILE_LOAD_SEQUENCE_NONE         0x00000001
-#define FILE_LOAD_SEQUENCE_ASK          0x00000002
-#define FILE_LOAD_SEQUENCE_ASK_CHECKBOX 0x00000004
-#define FILE_LOAD_SEQUENCE_YES          0x00000008
-#define FILE_LOAD_ONE_FRAME             0x00000010
-#define FILE_LOAD_DATA_FILE             0x00000020
-#define FILE_LOAD_CREATE_PALETTE        0x00000040
+#define FILE_LOAD_SEQUENCE_NONE          0x00000001
+#define FILE_LOAD_SEQUENCE_ASK           0x00000002
+#define FILE_LOAD_SEQUENCE_ASK_CHECKBOX  0x00000004
+#define FILE_LOAD_SEQUENCE_YES           0x00000008
+#define FILE_LOAD_ONE_FRAME              0x00000010
+#define FILE_LOAD_DATA_FILE              0x00000020
+#define FILE_LOAD_CREATE_PALETTE         0x00000040
+#define FILE_LOAD_AVOID_BACKGROUND_LAYER 0x00000080
 
 namespace doc {
   class Tag;
@@ -285,6 +286,8 @@ namespace app {
     bool newBlend() const { return m_config.newBlend; }
     const FileOpConfig& config() const { return m_config; }
 
+    bool avoidBackgroundLayer() const { return m_avoidBackgroundLayer; }
+
   private:
     FileOp();                   // Undefined
     FileOp(FileOpType type,
@@ -314,6 +317,7 @@ namespace app {
                                 // GIF/FLI/ASE).
     bool m_createPaletteFromRgba;
     bool m_ignoreEmpty;
+    bool m_avoidBackgroundLayer;
 
     // True if the file contained a color profile when it was loaded.
     bool m_embeddedColorProfile;

--- a/src/app/file/fli_format.cpp
+++ b/src/app/file/fli_format.cpp
@@ -95,7 +95,8 @@ bool FliFormat::onLoad(FileOp* fop)
   Sprite* sprite = new Sprite(ImageSpec(ColorMode::INDEXED, w, h), 256);
   LayerImage* layer = new LayerImage(sprite);
   sprite->root()->addLayer(layer);
-  layer->configureAsBackground();
+  if (!fop->avoidBackgroundLayer())
+    layer->configureAsBackground();
 
   // Set frames and speed
   sprite->setTotalFrames(frame_t(header.frames));

--- a/src/app/file/gif_format.cpp
+++ b/src/app/file/gif_format.cpp
@@ -288,7 +288,7 @@ public:
           break;
       }
 
-      if (m_layer && m_opaque)
+      if (m_layer && m_opaque && !m_fop->avoidBackgroundLayer())
         m_layer->configureAsBackground();
 
       // sRGB is the default color space for GIF files

--- a/src/app/file/webp_format.cpp
+++ b/src/app/file/webp_format.cpp
@@ -211,7 +211,7 @@ bool WebPFormat::onLoad(FileOp* fop)
   }
   WebPAnimDecoderReset(dec);
 
-  if (!has_alpha)
+  if (!has_alpha && !fop->avoidBackgroundLayer())
     layer->configureAsBackground();
 
   WebPAnimDecoderDelete(dec);

--- a/src/app/modules/gui.cpp
+++ b/src/app/modules/gui.cpp
@@ -28,7 +28,6 @@
 #include "app/ui/editor/editor.h"
 #include "app/ui/keyboard_shortcuts.h"
 #include "app/ui/main_menu_bar.h"
-#include "app/ui/main_menu_bar.h"
 #include "app/ui/main_window.h"
 #include "app/ui/skin/skin_property.h"
 #include "app/ui/skin/skin_theme.h"

--- a/src/app/transaction.cpp
+++ b/src/app/transaction.cpp
@@ -117,7 +117,7 @@ void Transaction::commit()
     else
       set_current_palette(nullptr, false);
 
-    if (m_ctx->isUIAvailable())
+    if (m_ctx && m_ctx->isUIAvailable())
       ui::Manager::getDefault()->invalidate();
   }
 }

--- a/src/app/ui/main_window.cpp
+++ b/src/app/ui/main_window.cpp
@@ -440,7 +440,7 @@ void MainWindow::onActiveViewChange()
 
 void MainWindow::onDrop(ui::DragEvent& e)
 {
-  if (e.hasImage()) {
+  if (e.hasImage() && !e.hasPaths()) {
     auto* cmd = Commands::instance()->byId(CommandId::NewFile());
     Params params;
     params.set("fromDraggedData", "true");

--- a/src/app/ui/main_window.h
+++ b/src/app/ui/main_window.h
@@ -119,6 +119,8 @@ namespace app {
     void onActiveViewChange();
     void onLanguageChange();
 
+    void onDrop(ui::DragEvent& e) override;
+
   private:
     DocView* getDocView();
     HomeView* getHomeView();

--- a/src/app/ui/timeline/timeline.cpp
+++ b/src/app/ui/timeline/timeline.cpp
@@ -4487,7 +4487,7 @@ void Timeline::onDrag(ui::DragEvent& e)
   Widget::onDrag(e);
 
   // Dropping images into the timeline is not supported yet, so do nothing.
-  if (e.hasImage()) {
+  if (e.hasImage() && !e.hasPaths()) {
     return;
   }
 

--- a/src/app/ui/timeline/timeline.cpp
+++ b/src/app/ui/timeline/timeline.cpp
@@ -4182,8 +4182,11 @@ void Timeline::updateDropRange(const gfx::Point& pt)
     case Range::kLayers:
       m_dropRange.clearRange();
       if (!m_rows.empty()) {
-        m_dropRange.startRange(m_rows[m_hot.layer].layer(), m_hot.frame, m_range.type());
-        m_dropRange.endRange(m_rows[m_hot.layer].layer(), m_hot.frame);
+        auto* layer = (m_hot.layer >= 0 && m_hot.layer < m_rows.size()
+                       ? m_rows[m_hot.layer].layer()
+                       : nullptr);
+        m_dropRange.startRange(layer, m_hot.frame, m_range.type());
+        m_dropRange.endRange(layer, m_hot.frame);
       }
       break;
   }

--- a/src/app/ui/timeline/timeline.cpp
+++ b/src/app/ui/timeline/timeline.cpp
@@ -4485,6 +4485,12 @@ void Timeline::onDragLeave(ui::DragEvent& e)
 void Timeline::onDrag(ui::DragEvent& e)
 {
   Widget::onDrag(e);
+
+  // Dropping images into the timeline is not supported yet, so do nothing.
+  if (e.hasImage()) {
+    return;
+  }
+
   m_range.clearRange();
   setHot(hitTest(nullptr, e.position()));
   switch (m_hot.part) {
@@ -4561,9 +4567,9 @@ void Timeline::onDrop(ui::DragEvent& e)
       tx.commit();
       m_document->notifyGeneralUpdate();
     });
+    e.handled(true);
   }
 
-  e.handled(true);
   m_state = STATE_STANDBY;
   m_range.clearRange();
   m_dropRange.clearRange();

--- a/src/app/ui/timeline/timeline.h
+++ b/src/app/ui/timeline/timeline.h
@@ -46,6 +46,7 @@ namespace doc {
 namespace ui {
   class Graphics;
   class TooltipManager;
+  class DragEvent;
 }
 
 namespace app {
@@ -194,6 +195,11 @@ namespace app {
                  const gfx::Point* position) override;
     bool onClear(Context* ctx) override;
     void onCancel(Context* ctx) override;
+
+    void onDragEnter(ui::DragEvent& e) override;
+    void onDragLeave(ui::DragEvent& e) override;
+    void onDrag(ui::DragEvent& e) override;
+    void onDrop(ui::DragEvent& e) override;
 
   private:
     struct DrawCelData;

--- a/src/app/util/conversion_to_image.cpp
+++ b/src/app/util/conversion_to_image.cpp
@@ -1,0 +1,53 @@
+// Aseprite
+// Copyright (c) 2024  Igara Studio S.A.
+//
+// This program is distributed under the terms of
+// the End-User License Agreement for Aseprite.
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "app/util/conversion_to_image.h"
+
+#include "doc/image_traits.h"
+#include "doc/pixel_format.h"
+#include "os/surface.h"
+
+#include <memory>
+
+namespace app {
+
+using namespace doc;
+
+// TODO: This implementation has a lot of room for improvement, I made the bare
+// minimum to make it work. Right now it only supports converting RGBA surfaces,
+// other kind of surfaces won't be converted to an image as expected.
+void convert_surface_to_image(
+  const os::Surface* surface,
+  int src_x, int src_y,
+  int w, int h,
+  ImageRef& image)
+{
+  gfx::Rect srcBounds(src_x, src_y, w, h);
+  srcBounds = srcBounds.createIntersection(surface->getClipBounds());
+  if (srcBounds.isEmpty())
+    return;
+
+  src_x = srcBounds.x;
+  src_y = srcBounds.y;
+  w = srcBounds.w;
+  h = srcBounds.h;
+
+  image.reset(Image::create(PixelFormat::IMAGE_RGB, w, h));
+
+  for (int v=0; v<h; ++v, ++src_y) {
+    uint8_t* src_address = surface->getData(0, v);
+    uint8_t* dst_address = image->getPixelAddress(src_x, src_y);
+    std::copy(src_address,
+              src_address + RgbTraits::bytes_per_pixel * w,
+              dst_address);
+  }
+}
+
+} // namespace app

--- a/src/app/util/conversion_to_image.cpp
+++ b/src/app/util/conversion_to_image.cpp
@@ -20,6 +20,24 @@ namespace app {
 
 using namespace doc;
 
+uint32_t convert_color_to_image(
+  gfx::Color c,
+  const os::SurfaceFormatData* fd)
+{
+  uint8_t r = ((c & fd->redMask) >> fd->redShift);
+  uint8_t g = ((c & fd->greenMask) >> fd->greenShift);
+  uint8_t b = ((c & fd->blueMask) >> fd->blueShift);
+  uint8_t a = ((c & fd->alphaMask) >> fd->alphaShift);
+
+  if (fd->pixelAlpha == os::PixelAlpha::kPremultiplied) {
+    r = r * 255 / a;
+    g = g * 255 / a;
+    b = b * 255 / a;
+  }
+
+  return rgba(r, g, b, a);
+}
+
 // TODO: This implementation has a lot of room for improvement, I made the bare
 // minimum to make it work. Right now it only supports converting RGBA surfaces,
 // other kind of surfaces won't be converted to an image as expected.
@@ -41,12 +59,15 @@ void convert_surface_to_image(
 
   image.reset(Image::create(PixelFormat::IMAGE_RGB, w, h));
 
-  for (int v=0; v<h; ++v, ++src_y) {
-    uint8_t* src_address = surface->getData(0, v);
-    uint8_t* dst_address = image->getPixelAddress(src_x, src_y);
-    std::copy(src_address,
-              src_address + RgbTraits::bytes_per_pixel * w,
-              dst_address);
+  os::SurfaceFormatData fd;
+  surface->getFormat(&fd);
+
+  for (int v=0; v<h; ++v) {
+    for (int u=0; u<w; ++u) {
+      uint32_t* c = (uint32_t*)(surface->getData(u, v));
+      image->putPixel(src_x + u,
+                      src_y + v, convert_color_to_image(*c, &fd));
+    }
   }
 }
 

--- a/src/app/util/conversion_to_image.h
+++ b/src/app/util/conversion_to_image.h
@@ -1,0 +1,31 @@
+// Aseprite
+// Copyright (c) 2024  Igara Studio S.A.
+//
+// This program is distributed under the terms of
+// the End-User License Agreement for Aseprite.
+
+#ifndef APP_UTIL_CONVERSION_TO_IMAGE_H_INCLUDED
+#define APP_UTIL_CONVERSION_TO_IMAGE_H_INCLUDED
+#pragma once
+
+#include "doc/image_ref.h"
+
+namespace os {
+  class Surface;
+}
+
+namespace doc {
+  class Palette;
+}
+
+namespace app {
+
+void convert_surface_to_image(
+  const os::Surface* surface,
+  int src_x, int src_y,
+  int w, int h,
+  doc::ImageRef& image);
+
+} // namespace app
+
+#endif

--- a/src/app/util/decode_webp.cpp
+++ b/src/app/util/decode_webp.cpp
@@ -42,11 +42,10 @@ os::SurfaceRef decode_webp(const uint8_t* buf, uint32_t len)
 
   WebPDecoderConfig config;
   WebPInitDecoderConfig(&config);
-  if (WebPGetFeatures(webp_data.bytes, webp_data.size, &config.input)) {
-
-  }
-  else {
-    config.input.has_alpha = false;
+  auto status = WebPGetFeatures(webp_data.bytes, webp_data.size, &config.input);
+  if (status != VP8_STATUS_OK) {
+    // Error getting WebP features.
+    return nullptr;
   }
 
   const int w = anim_info.canvas_width;

--- a/src/app/util/decode_webp.cpp
+++ b/src/app/util/decode_webp.cpp
@@ -1,0 +1,81 @@
+// Aseprite
+// Copyright (C) 2024  Igara Studio S.A.
+//
+// This program is distributed under the terms of
+// the End-User License Agreement for Aseprite.
+
+#include "app/util/decode_webp.h"
+
+#include <webp/demux.h>
+#include <webp/mux.h>
+
+namespace app {
+namespace util {
+
+os::SurfaceRef decode_webp(const uint8_t* buf, uint32_t len)
+{
+  // I've considered using the FileFormatsManager here but we don't have a file
+  // in this case just the bytes. At some point maye we should refactor this or
+  // the WepFormat class to avoid duplicated logic.
+  WebPData webp_data;
+  WebPDataInit(&webp_data);
+  webp_data.bytes = &buf[0];
+  webp_data.size = len;
+
+  WebPAnimDecoderOptions dec_options;
+  WebPAnimDecoderOptionsInit(&dec_options);
+  dec_options.color_mode = MODE_RGBA;
+
+  WebPAnimDecoder* dec = WebPAnimDecoderNew(&webp_data, &dec_options);
+  if (dec == nullptr) {
+    // Error parsing WebP image
+    return nullptr;
+  }
+
+  WebPAnimInfo anim_info;
+  if (!WebPAnimDecoderGetInfo(dec, &anim_info)) {
+    // Error getting global info about the WebP animation
+    return nullptr;
+  }
+
+  WebPDecoderConfig config;
+  WebPInitDecoderConfig(&config);
+  if (WebPGetFeatures(webp_data.bytes, webp_data.size, &config.input)) {
+
+  }
+  else {
+    config.input.has_alpha = false;
+  }
+
+  const int w = anim_info.canvas_width;
+  const int h = anim_info.canvas_height;
+
+  if (anim_info.frame_count <= 0)
+    return nullptr;
+
+  auto surface = os::instance()->makeSurface(w, h);
+
+  // We just want the first frame, so we don't iterate.
+  WebPAnimDecoderHasMoreFrames(dec);
+
+  uint8_t* frame_rgba;
+  int frame_timestamp = 0;
+  if (!WebPAnimDecoderGetNext(dec, &frame_rgba, &frame_timestamp)) {
+    // Error loading WebP frame
+    return nullptr;
+  }
+
+  const uint32_t* src = (const uint32_t*)frame_rgba;
+  for (int y = 0; y < h; ++y, src += w) {
+    memcpy(surface->getData(0, y), src, w * sizeof(uint32_t));
+  }
+
+  WebPAnimDecoderReset(dec);
+
+  WebPAnimDecoderDelete(dec);
+
+  return surface;
+}
+
+}  // namespace util
+}  // namespace app

--- a/src/app/util/decode_webp.cpp
+++ b/src/app/util/decode_webp.cpp
@@ -6,6 +6,8 @@
 
 #include "app/util/decode_webp.h"
 
+#include "os/system.h"
+
 #include <webp/demux.h>
 #include <webp/mux.h>
 

--- a/src/app/util/decode_webp.cpp
+++ b/src/app/util/decode_webp.cpp
@@ -14,6 +14,14 @@
 namespace app {
 namespace util {
 
+static WEBP_CSP_MODE colorMode()
+{
+  auto surface = os::instance()->makeSurface(1, 1);
+  os::SurfaceFormatData fd;
+  surface->getFormat(&fd);
+  return (fd.redShift == 0 ? MODE_RGBA : MODE_BGRA);
+}
+
 os::SurfaceRef decode_webp(const uint8_t* buf, uint32_t len)
 {
   // I've considered using the FileFormatsManager here but we don't have a file
@@ -26,7 +34,7 @@ os::SurfaceRef decode_webp(const uint8_t* buf, uint32_t len)
 
   WebPAnimDecoderOptions dec_options;
   WebPAnimDecoderOptionsInit(&dec_options);
-  dec_options.color_mode = MODE_RGBA;
+  dec_options.color_mode = colorMode();
 
   WebPAnimDecoder* dec = WebPAnimDecoderNew(&webp_data, &dec_options);
   if (dec == nullptr) {

--- a/src/app/util/decode_webp.h
+++ b/src/app/util/decode_webp.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "os/surface.h"
-#include "os/system.h"
 
 namespace app {
 
@@ -18,11 +17,6 @@ namespace util {
 // Decodes webp content passed in buf and returns a surface with just the first
 // frame.
 os::SurfaceRef decode_webp(const uint8_t* buf, uint32_t len);
-
-static void* once = []() {
-  os::set_decode_webp(decode_webp);
-  return nullptr;
-}();
 
 }
 

--- a/src/app/util/decode_webp.h
+++ b/src/app/util/decode_webp.h
@@ -1,0 +1,31 @@
+// Aseprite
+// Copyright (C) 2024  Igara Studio S.A.
+//
+// This program is distributed under the terms of
+// the End-User License Agreement for Aseprite.
+
+#ifndef APP_UTIL_DECODE_WEBP_H_INCLUDED
+#define APP_UTIL_DECODE_WEBP_H_INCLUDED
+#pragma once
+
+#include "os/surface.h"
+#include "os/system.h"
+
+namespace app {
+
+namespace util {
+
+// Decodes webp content passed in buf and returns a surface with just the first
+// frame.
+os::SurfaceRef decode_webp(const uint8_t* buf, uint32_t len);
+
+static void* once = []() {
+  os::set_decode_webp(decode_webp);
+  return nullptr;
+}();
+
+}
+
+}
+
+#endif

--- a/src/app/util/layer_utils.cpp
+++ b/src/app/util/layer_utils.cpp
@@ -6,11 +6,14 @@
 
 #include "app/util/layer_utils.h"
 
+#include "app/doc.h"
 #include "app/i18n/strings.h"
 #include "app/ui/editor/editor.h"
 #include "app/ui/status_bar.h"
 #include "doc/layer.h"
+#include "doc/layer_tilemap.h"
 #include "doc/sprite.h"
+#include "doc/tilesets.h"
 #include "fmt/format.h"
 
 namespace app {
@@ -78,6 +81,41 @@ std::string get_layer_path(const Layer* layer)
     path.insert(0, layer->name());
   }
   return path;
+}
+
+Layer* copy_layer(doc::Layer* layer)
+{
+  return copy_layer_with_sprite(layer, layer->sprite());
+}
+
+Layer* copy_layer_with_sprite(doc::Layer* layer, doc::Sprite* sprite)
+{
+  std::unique_ptr<doc::Layer> clone;
+  if (layer->isTilemap()) {
+    auto* srcTilemap = static_cast<LayerTilemap*>(layer);
+    tileset_index tilesetIndex = srcTilemap->tilesetIndex();
+    // If the caller is trying to make a copy of a tilemap layer specifying a
+    // different sprite as its owner, then we must copy the tilesets of the
+    // given tilemap layer into the new owner.
+    if (sprite != srcTilemap->sprite()) {
+      auto* srcTilesetCopy = Tileset::MakeCopyCopyingImages(srcTilemap->tileset());
+      tilesetIndex = sprite->tilesets()->add(srcTilesetCopy);
+    }
+
+    clone.reset(new LayerTilemap(sprite, tilesetIndex));
+  }
+  else if (layer->isImage())
+    clone.reset(new LayerImage(sprite));
+  else if (layer->isGroup())
+    clone.reset(new LayerGroup(sprite));
+  else
+    throw std::runtime_error("Invalid layer type");
+
+  if (auto* doc = dynamic_cast<app::Doc*>(sprite->document())) {
+    doc->copyLayerContent(layer, doc, clone.get());
+  }
+
+  return clone.release();
 }
 
 } // namespace app

--- a/src/app/util/layer_utils.h
+++ b/src/app/util/layer_utils.h
@@ -12,6 +12,7 @@
 
 namespace doc {
   class Layer;
+  class Sprite;
 }
 
 namespace app {
@@ -30,6 +31,9 @@ namespace app {
   bool layer_is_locked(Editor* editor);
 
   std::string get_layer_path(const doc::Layer* layer);
+
+  doc::Layer* copy_layer(doc::Layer* layer);
+  doc::Layer* copy_layer_with_sprite(doc::Layer* layer, doc::Sprite* sprite);
 
 } // namespace app
 

--- a/src/app/util/open_file_job.h
+++ b/src/app/util/open_file_job.h
@@ -1,0 +1,59 @@
+// Aseprite
+// Copyright (C) 2024  Igara Studio S.A.
+//
+// This program is distributed under the terms of
+// the End-User License Agreement for Aseprite.
+
+#ifndef APP_OPEN_FILE_JOB_H_INCLUDED
+#define APP_OPEN_FILE_JOB_H_INCLUDED
+#pragma once
+
+#include "app/file/file.h"
+#include "app/i18n/strings.h"
+#include "app/job.h"
+
+namespace app {
+
+class OpenFileJob : public Job, public IFileOpProgress {
+public:
+  OpenFileJob(FileOp* fop, const bool showProgress)
+    : Job(Strings::open_file_loading(), showProgress)
+    , m_fop(fop)
+  {
+  }
+
+  void showProgressWindow() {
+    startJob();
+
+    if (isCanceled())
+      m_fop->stop();
+
+    waitJob();
+  }
+
+private:
+  // Thread to do the hard work: load the file from the disk.
+  virtual void onJob() override {
+    try {
+      m_fop->operate(this);
+    }
+    catch (const std::exception& e) {
+      m_fop->setError("Error loading file:\n%s", e.what());
+    }
+
+    if (m_fop->isStop() && m_fop->document())
+      delete m_fop->releaseDocument();
+
+    m_fop->done();
+  }
+
+  virtual void ackFileOpProgress(double progress) override {
+    jobProgress(progress);
+  }
+
+  FileOp* m_fop;
+};
+
+} // namespace app
+
+#endif

--- a/src/doc/layer.cpp
+++ b/src/doc/layer.cpp
@@ -45,39 +45,6 @@ Layer::~Layer()
 {
 }
 
-// static
-Layer* Layer::MakeCopy(doc::Layer* layer)
-{
-  return MakeCopyWithSprite(layer, layer->sprite());
-}
-
-// static
-Layer* Layer::MakeCopyWithSprite(doc::Layer* layer, doc::Sprite* sprite)
-{
-  std::unique_ptr<doc::Layer> clone;
-  if (layer->isTilemap()) {
-    auto* srcTilemap = static_cast<LayerTilemap*>(layer);
-    tileset_index tilesetIndex = srcTilemap->tilesetIndex();
-    // If the caller is trying to make a copy of a tilemap layer specifying a
-    // different sprite as its owner, then we must copy the tilesets of the
-    // given tilemap layer into the new owner.
-    if (sprite != srcTilemap->sprite()) {
-      auto* srcTilesetCopy = Tileset::MakeCopyCopyingImages(srcTilemap->tileset());
-      tilesetIndex = sprite->tilesets()->add(srcTilesetCopy);
-    }
-
-    clone.reset(new LayerTilemap(sprite, tilesetIndex));
-  }
-  else if (layer->isImage())
-    clone.reset(new LayerImage(sprite));
-  else if (layer->isGroup())
-    clone.reset(new LayerGroup(sprite));
-  else
-    throw std::runtime_error("Invalid layer type");
-
-  return clone.release();
-}
-
 int Layer::getMemSize() const
 {
   return sizeof(Layer);

--- a/src/doc/layer.cpp
+++ b/src/doc/layer.cpp
@@ -14,8 +14,10 @@
 #include "doc/cel.h"
 #include "doc/grid.h"
 #include "doc/image.h"
+#include "doc/layer_tilemap.h"
 #include "doc/primitives.h"
 #include "doc/sprite.h"
+#include "doc/tilesets.h"
 
 #include <algorithm>
 #include <cstring>
@@ -41,6 +43,39 @@ Layer::Layer(ObjectType type, Sprite* sprite)
 
 Layer::~Layer()
 {
+}
+
+// static
+Layer* Layer::MakeCopy(doc::Layer* layer)
+{
+  return MakeCopyWithSprite(layer, layer->sprite());
+}
+
+// static
+Layer* Layer::MakeCopyWithSprite(doc::Layer* layer, doc::Sprite* sprite)
+{
+  std::unique_ptr<doc::Layer> clone;
+  if (layer->isTilemap()) {
+    auto* srcTilemap = static_cast<LayerTilemap*>(layer);
+    tileset_index tilesetIndex = srcTilemap->tilesetIndex();
+    // If the caller is trying to make a copy of a tilemap layer specifying a
+    // different sprite as its owner, then we must copy the tilesets of the
+    // given tilemap layer into the new owner.
+    if (sprite != srcTilemap->sprite()) {
+      auto* srcTilesetCopy = Tileset::MakeCopyCopyingImages(srcTilemap->tileset());
+      tilesetIndex = sprite->tilesets()->add(srcTilesetCopy);
+    }
+
+    clone.reset(new LayerTilemap(sprite, tilesetIndex));
+  }
+  else if (layer->isImage())
+    clone.reset(new LayerImage(sprite));
+  else if (layer->isGroup())
+    clone.reset(new LayerGroup(sprite));
+  else
+    throw std::runtime_error("Invalid layer type");
+
+  return clone.release();
 }
 
 int Layer::getMemSize() const

--- a/src/doc/layer.cpp
+++ b/src/doc/layer.cpp
@@ -253,10 +253,11 @@ int LayerImage::getMemSize() const
 
   for (; it != end; ++it) {
     const Cel* cel = *it;
-    size += cel->getMemSize();
 
-    const Image* image = cel->image();
-    size += image->getMemSize();
+    if (cel->link())        // Skip link
+      continue;
+
+    size += cel->getMemSize();
   }
 
   return size;

--- a/src/doc/layer.cpp
+++ b/src/doc/layer.cpp
@@ -623,6 +623,17 @@ void LayerGroup::insertLayer(Layer* layer, Layer* after)
   layer->setParent(this);
 }
 
+void LayerGroup::insertLayerBefore(Layer* layer, Layer* before)
+{
+  auto before_it = m_layers.end();
+  if (before) {
+    before_it = std::find(m_layers.begin(), m_layers.end(), before);
+  }
+  m_layers.insert(before_it, layer);
+
+  layer->setParent(this);
+}
+
 void LayerGroup::stackLayer(Layer* layer, Layer* after)
 {
   ASSERT(layer != after);

--- a/src/doc/layer.h
+++ b/src/doc/layer.h
@@ -58,6 +58,9 @@ namespace doc {
   public:
     virtual ~Layer();
 
+    static Layer* MakeCopy(doc::Layer* layer);
+    static Layer* MakeCopyWithSprite(doc::Layer* layer, doc::Sprite* sprite);
+
     virtual int getMemSize() const override;
 
     const std::string& name() const { return m_name; }
@@ -144,7 +147,7 @@ namespace doc {
 
     BlendMode m_blendmode;
     int m_opacity;
-  
+
     // Disable assigment
     Layer& operator=(const Layer& other);
   };
@@ -183,7 +186,7 @@ namespace doc {
 
   private:
     void destroyAllCels();
-  
+
     CelList m_cels;   // List of all cels inside this layer used by frames.
   };
 

--- a/src/doc/layer.h
+++ b/src/doc/layer.h
@@ -58,9 +58,6 @@ namespace doc {
   public:
     virtual ~Layer();
 
-    static Layer* MakeCopy(doc::Layer* layer);
-    static Layer* MakeCopyWithSprite(doc::Layer* layer, doc::Sprite* sprite);
-
     virtual int getMemSize() const override;
 
     const std::string& name() const { return m_name; }

--- a/src/doc/layer.h
+++ b/src/doc/layer.h
@@ -206,6 +206,7 @@ namespace doc {
     void addLayer(Layer* layer);
     void removeLayer(Layer* layer);
     void insertLayer(Layer* layer, Layer* after);
+    void insertLayerBefore(Layer* layer, Layer* before);
     void stackLayer(Layer* layer, Layer* after);
 
     Layer* firstLayer() const { return (m_layers.empty() ? nullptr: m_layers.front()); }

--- a/src/ui/base.h
+++ b/src/ui/base.h
@@ -29,8 +29,9 @@ namespace ui {
     DOUBLE_BUFFERED  = 0x00002000, // The widget is painted in a back-buffer and then flipped to the main display
     TRANSPARENT      = 0x00004000, // The widget has transparent parts that needs the background painted before
     CTRL_RIGHT_CLICK = 0x00008000, // The widget should transform Ctrl+click to right-click on OS X.
+    ALLOW_DROP       = 0x40000000, // The widget can participate as a drop target in a drag & drop operation.
     IGNORE_MOUSE     = 0x80000000, // Don't process mouse messages for this widget (useful for labels, boxes, grids, etc.)
-    PROPERTIES_MASK  = 0x8000ffff,
+    PROPERTIES_MASK  = 0xC000ffff,
 
     HORIZONTAL       = 0x00010000,
     VERTICAL         = 0x00020000,
@@ -43,7 +44,7 @@ namespace ui {
     HOMOGENEOUS      = 0x01000000,
     WORDWRAP         = 0x02000000,
     CHARWRAP         = 0x04000000,
-    ALIGN_MASK       = 0x7fff0000,
+    ALIGN_MASK       = 0x3fff0000,
   };
 
 } // namespace ui

--- a/src/ui/drag_event.h
+++ b/src/ui/drag_event.h
@@ -8,7 +8,9 @@
 #define UI_DRAG_EVENT_H_INCLUDED
 #pragma once
 
+#include "base/paths.h"
 #include "os/dnd.h"
+#include "os/surface.h"
 #include "ui/event.h"
 #include "ui/widget.h"
 
@@ -36,6 +38,22 @@ namespace ui {
     void supportsOperation(os::DropOperation operation) { m_ev.dropResult(operation); }
 
     const gfx::Point& position() const { return m_position; }
+
+    bool hasPaths() const {
+      return m_ev.dataProvider()->contains(os::DragDataItemType::Paths);
+    }
+
+    bool hasImage() const {
+      return m_ev.dataProvider()->contains(os::DragDataItemType::Image);
+    }
+
+    base::paths getPaths() const {
+      return m_ev.dataProvider()->getPaths();
+    }
+
+    os::SurfaceRef getImage() const {
+      return m_ev.dataProvider()->getImage();
+    }
 
   private:
     bool m_handled = false;

--- a/src/ui/drag_event.h
+++ b/src/ui/drag_event.h
@@ -1,0 +1,48 @@
+// Aseprite UI Library
+// Copyright (C) 2024  Igara Studio S.A.
+//
+// This file is released under the terms of the MIT license.
+// Read LICENSE.txt for more information.
+
+#ifndef UI_DRAG_EVENT_H_INCLUDED
+#define UI_DRAG_EVENT_H_INCLUDED
+#pragma once
+
+#include "os/dnd.h"
+#include "ui/event.h"
+#include "ui/widget.h"
+
+namespace ui {
+
+  class DragEvent : public Event {
+  public:
+    DragEvent(Component* source, ui::Widget* target, os::DragEvent& ev)
+      : Event(source)
+      , m_position(ev.position() - target->bounds().origin())
+      , m_ev(ev) {}
+
+    bool handled() const { return m_handled; }
+    void handled(bool value) { m_handled = value; }
+
+    // Operations allowed by the source of the drag & drop operation. Can be a
+    // bitwise combination of values.
+    os::DropOperation allowedOperations() const { return m_ev.supportedOperations(); }
+
+    // Operation supported by the target of the drag & drop operation. Cannot
+    // be a bitwise combination of values.
+    os::DropOperation supportsOperation() const { return m_ev.dropResult(); }
+    // Set the operation supported by the target of the drag & drop operation.
+    // Cannot be a bitwise combination of values.
+    void supportsOperation(os::DropOperation operation) { m_ev.dropResult(operation); }
+
+    const gfx::Point& position() const { return m_position; }
+
+  private:
+    bool m_handled = false;
+    gfx::Point m_position;
+    os::DragEvent& m_ev;
+  };
+
+} // namespace ui
+
+#endif  // UI_DRAG_EVENT_H_INCLUDED

--- a/src/ui/manager.cpp
+++ b/src/ui/manager.cpp
@@ -2056,7 +2056,7 @@ void Manager::dragEnter(os::DragEvent& ev)
 {
   Widget* widget = pickForDragAndDrop(ev.position());
 
-  ASSERT(widget->hasFlags(ALLOW_DROP));
+  ASSERT(!widget || widget && widget->hasFlags(ALLOW_DROP));
 
   if (widget) {
     m_dragOverWidget = widget;
@@ -2080,7 +2080,7 @@ void Manager::drag(os::DragEvent& ev)
 {
   Widget* widget = pickForDragAndDrop(ev.position());
 
-  ASSERT(widget->hasFlags(ALLOW_DROP));
+  ASSERT(!widget || widget && widget->hasFlags(ALLOW_DROP));
 
   if (m_dragOverWidget && m_dragOverWidget != widget) {
     DragEvent uiev(this, m_dragOverWidget, ev);
@@ -2104,7 +2104,7 @@ void Manager::drop(os::DragEvent& ev)
   m_dragOverWidget = nullptr;
   Widget* widget = pickForDragAndDrop(ev.position());
 
-  ASSERT(widget->hasFlags(ALLOW_DROP));
+  ASSERT(!widget || widget && widget->hasFlags(ALLOW_DROP));
 
   if (widget) {
     DragEvent uiev(this, widget, ev);

--- a/src/ui/manager.h
+++ b/src/ui/manager.h
@@ -163,7 +163,7 @@ namespace ui {
     int pumpQueue();
     bool sendMessageToWidget(Message* msg, Widget* widget);
 
-    Widget* pickForDragAndDrop(const gfx::Point& pt);
+    Widget* findForDragAndDrop(Widget* widget);
     void dragEnter(os::DragEvent& ev) override;
     void dragLeave(os::DragEvent& ev) override;
     void drag(os::DragEvent& ev) override;

--- a/src/ui/manager.h
+++ b/src/ui/manager.h
@@ -163,6 +163,7 @@ namespace ui {
     int pumpQueue();
     bool sendMessageToWidget(Message* msg, Widget* widget);
 
+    Widget* pickForDragAndDrop(const gfx::Point& pt);
     void dragEnter(os::DragEvent& ev) override;
     void dragLeave(os::DragEvent& ev) override;
     void drag(os::DragEvent& ev) override;

--- a/src/ui/manager.h
+++ b/src/ui/manager.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "gfx/region.h"
+#include "os/dnd.h"
 #include "ui/display.h"
 #include "ui/keys.h"
 #include "ui/message_type.h"
@@ -28,7 +29,8 @@ namespace ui {
   class Timer;
   class Window;
 
-  class Manager : public Widget {
+  class Manager : public Widget
+                , public os::DragTarget {
   public:
     static Manager* getDefault() { return m_defaultManager; }
     static bool widgetAssociatedToManager(Widget* widget);
@@ -161,6 +163,11 @@ namespace ui {
     int pumpQueue();
     bool sendMessageToWidget(Message* msg, Widget* widget);
 
+    void dragEnter(os::DragEvent& ev) override;
+    void dragLeave(os::DragEvent& ev) override;
+    void drag(os::DragEvent& ev) override;
+    void drop(os::DragEvent& ev) override;
+
     static Widget* findLowestCommonAncestor(Widget* a, Widget* b);
     static bool someParentIsFocusStop(Widget* widget);
     static Widget* findMagneticWidget(Widget* widget);
@@ -189,6 +196,9 @@ namespace ui {
 
     // Last pressed mouse button.
     MouseButton m_mouseButton;
+
+    // Widget over which the drag is being hovered in a drag & drop operation.
+    Widget* m_dragOverWidget = nullptr;
   };
 
 } // namespace ui

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -21,6 +21,7 @@
 #include "ui/cursor.h"
 #include "ui/cursor_type.h"
 #include "ui/display.h"
+#include "ui/drag_event.h"
 #include "ui/entry.h"
 #include "ui/event.h"
 #include "ui/fit_bounds.h"

--- a/src/ui/widget.cpp
+++ b/src/ui/widget.cpp
@@ -22,6 +22,7 @@
 #include "text/font.h"
 #include "text/font_mgr.h"
 #include "ui/app_state.h"
+#include "ui/drag_event.h"
 #include "ui/init_theme_event.h"
 #include "ui/intern.h"
 #include "ui/layout_io.h"
@@ -1798,6 +1799,38 @@ text::TextBlobRef Widget::onMakeTextBlob() const
 text::ShaperFeatures Widget::onGetTextShaperFeatures() const
 {
   return text::ShaperFeatures();
+}
+
+void Widget::onDragEnter(DragEvent& e)
+{
+#ifdef _DEBUG
+  LOG(VERBOSE, "UI: [id=%s, type=%d]: onDragEnter(), position: (%d, %d)\n",
+      id().c_str(), type(), e.position().x, e.position().y);
+#endif
+}
+
+void Widget::onDragLeave(DragEvent& e)
+{
+#ifdef _DEBUG
+  LOG(VERBOSE, "UI: [id=%s, type=%d]: onDragLeave(), position: (%d, %d)\n",
+      id().c_str(), type(), e.position().x, e.position().y);
+#endif
+}
+
+void Widget::onDrag(DragEvent& e)
+{
+#ifdef _DEBUG
+  LOG(VERBOSE, "UI: [id=%s, type=%d]: onDrag(), position: (%d, %d)\n",
+      id().c_str(), type(), e.position().x, e.position().y);
+#endif
+}
+
+void Widget::onDrop(DragEvent& e)
+{
+#ifdef _DEBUG
+  LOG(VERBOSE, "UI: [id=%s, type=%d]: onDrop(), position: (%d, %d)\n",
+      id().c_str(), type(), e.position().x, e.position().y);
+#endif
 }
 
 void Widget::offsetWidgets(int dx, int dy)

--- a/src/ui/widget.h
+++ b/src/ui/widget.h
@@ -44,6 +44,7 @@ namespace ui {
   class Style;
   class Theme;
   class Window;
+  class DragEvent;
 
   class Widget : public Component {
   public:
@@ -445,6 +446,11 @@ namespace ui {
     virtual text::TextBlobRef onMakeTextBlob() const;
     virtual text::ShaperFeatures onGetTextShaperFeatures() const;
 
+    virtual void onDragEnter(DragEvent& e);
+    virtual void onDragLeave(DragEvent& e);
+    virtual void onDrag(DragEvent& e);
+    virtual void onDrop(DragEvent& e);
+
   private:
     void removeChild(const WidgetsList::iterator& it);
     void paint(Graphics* graphics,
@@ -483,6 +489,8 @@ namespace ui {
 
     gfx::Border m_border;       // Border separation with the parent
     int m_childSpacing;         // Separation between children
+
+    friend Manager;
   };
 
   WidgetType register_widget_type();


### PR DESCRIPTION
Introduce drag & drop operations to let the user drag images and files and drop them on the timeline to allow the user merge the content properly instead of always opening new files. 
Fix #131.

Supported features:
- Drag & drop files between layers, frames, or in a cel of the timeline:
  If the file is dropped on a cel and has only one image, then it will replace the existing cel's image. Otherwise it is appended as a new layer.
  If the file is dropped between layers, its cels/frames will be inserted after the currently selected frame.
  If the file is dropped between frames, the layer will be inserted after the currently selected layer. 
- Drag & drop images from other apps (i.e. from a browser) between layers, frames, or in a cel of the timeline:
  If the dropped element is an animation (like a gif or animated webp) only the first frame is imported.
  If the image is dropped on a cel, then it will replace the existing cel's image.
  If the image is dropped between layers, one cel/frame will be inserted after the currently selected frame.
  If the image is dropped between frames, the layer will be inserted after the currently selected layer. 
- Drag & drop images from other apps outside of the timeline: A new document with the image is created.
