### PR TITLE
 Snap cels to grid on moving cel action (fix aseprite#4027)

### DIFF
--- a/src/app/ui/editor/moving_cel_state.cpp
+++ b/src/app/ui/editor/moving_cel_state.cpp
@@ -417,20 +417,21 @@ gfx::RectF MovingCelState::calcFullBounds() const
 
 void MovingCelState::snapBoundsToGrid(gfx::RectF& celBounds) const
 {
+  const gfx::RectF& gridBounds = m_editor->getSite().gridBounds();
   if (m_scaled) {
     gfx::PointF gridOffset(
       snap_to_grid(
-        m_editor->getSite().gridBounds(),
+        gridBounds,
         gfx::Point(celBounds.w, celBounds.h),
         PreferSnapTo::ClosestGridVertex));
 
-    celBounds.w = gridOffset.x;
-    celBounds.h = gridOffset.y;
+    celBounds.w = std::max(gridBounds.w, gridOffset.x);
+    celBounds.h = std::max(gridBounds.h, gridOffset.y);
   }
   else if (m_moved) {
     gfx::PointF gridOffset(
       snap_to_grid(
-        m_editor->getSite().gridBounds(),
+        gridBounds,
         gfx::Point(celBounds.origin()),
         PreferSnapTo::ClosestGridVertex));
 

--- a/src/app/ui/editor/moving_cel_state.h
+++ b/src/app/ui/editor/moving_cel_state.h
@@ -59,6 +59,7 @@ namespace app {
     gfx::Point intCelOffset() const;
     gfx::RectF calcFullBounds() const;
     bool restoreCelStartPosition() const;
+    void snapBoundsToGrid(gfx::RectF& celBounds) const;
     // ContextObserver
     void onBeforeCommandExecution(CommandExecutionEvent& ev);
 
@@ -79,6 +80,7 @@ namespace app {
     bool m_hasReference = false;
     bool m_moved = false;
     bool m_scaled = false;
+    bool m_multiLayer = false;
     HandleType m_handle;
     Editor* m_editor;
 

--- a/src/app/ui/editor/moving_cel_state.h
+++ b/src/app/ui/editor/moving_cel_state.h
@@ -58,7 +58,9 @@ namespace app {
   private:
     gfx::Point intCelOffset() const;
     gfx::RectF calcFullBounds() const;
+    void calcPivot();
     bool restoreCelStartPosition() const;
+    void snapOffsetToGrid(gfx::Point& offset) const;
     void snapBoundsToGrid(gfx::RectF& celBounds) const;
     // ContextObserver
     void onBeforeCommandExecution(CommandExecutionEvent& ev);
@@ -72,7 +74,10 @@ namespace app {
     Cel* m_cel;
     CelList m_celList;
     std::vector<gfx::RectF> m_celStarts;
+    gfx::RectF m_fullBounds;
     gfx::PointF m_cursorStart;
+    gfx::PointF m_pivot;
+    gfx::PointF m_pivotOffset;
     gfx::PointF m_celOffset;
     gfx::SizeF m_celMainSize;
     gfx::SizeF m_celScale;
@@ -80,7 +85,6 @@ namespace app {
     bool m_hasReference = false;
     bool m_moved = false;
     bool m_scaled = false;
-    bool m_multiLayer = false;
     HandleType m_handle;
     Editor* m_editor;
 


### PR DESCRIPTION
Used the eponymous function from `app/snap_to_grid` to align the offsets and final position of cels to the grid during `MovingCelState`, when 'Snap To Grid' is enabled. Just for completeness, I've included scaling in this fix, though right now it should only affect reference layers far as I can tell.

A small detail: I've made it so the origins of cel bounds aren't individually snapped to the grid in cases where multiple layers are selected, simply because it felt weird when I tested it. In such situations, the cels will simply move together in grid-sized intervals. This can be easily reversed by changing the `snapToGrid && !m_multiLayer` conditionals to just `snapToGrid`.