### PR TITLE
Add pre-commit configuration and documentation.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,38 @@
+exclude: 'third_party/.*|laf/.*'
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.5.5
+    hooks:
+      - id: remove-tabs
+        args: [--whitespaces-count, '8']
+
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v18.1.8
+    hooks:
+      - id: clang-format
+        files: \.(c|h|cpp|hpp|cc|hh|cxx|hxx)$
+        types_or: [text]
+
+  - repo: https://github.com/pocc/pre-commit-hooks
+    rev: v1.3.5
+    hooks:
+      - id: clang-tidy
+        files: \.(c|h|cpp|hpp|cc|hh|cxx|hxx)$
+        args: [--fix, --quiet, --use-color]
+        types_or: [text]
+        additional_dependencies: [clang-tidy==18.1.8]
+        require_serial: true
+        stages: [manual]
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.3.0
+    hooks:
+      - id: codespell
+        additional_dependencies: [tomli]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Before you submit an issue:
   click the `Subscribe` or `Watching` button to get notifications
   via email.
 
-# Compilation problem
+# Compilation problems
 
 Before you submit an issue or a post about a **compilation problem**,
 check the following items:
@@ -76,6 +76,20 @@ make comments, or create
 new [features](https://community.aseprite.org/c/features),
 [bug reports](https://community.aseprite.org/c/bugs), etc. You are
 encouraged to create mockups for any issue you see and attach them.
+
+## Pre-commit hooks
+
+We use [pre-commit](https://pre-commit.com/) as way to set up hooks, you can install it with:
+
+```
+pip install pre-commit
+pre-commit install
+```
+
+If you need to run it manually, use `pre-commit run`.
+
+To run `clang-tidy`, you can use `pre-commit run --hook-stage manual clang-tidy`.
+Make sure to check the suggestions and to not apply them arbitrarily, since some might not be 100% applicable to what you're doing.
 
 ## Code submission policy
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -59,7 +59,7 @@ To compile Aseprite you will need:
 
 ## Windows dependencies
 
-* Windows 10 (we don't support cross-compiling)
+* Windows 10/11 (we don't support cross-compiling)
 * [Visual Studio Community 2022](https://visualstudio.microsoft.com/downloads/) (we don't support [MinGW](#mingw))
 * The [Desktop development with C++ item + Windows 10.0.18362.0 SDK](https://imgur.com/a/7zs51IT)
   from the Visual Studio installer


### PR DESCRIPTION
Implements [#4642](https://github.com/aseprite/aseprite/issues/4642), which adds `clang-format`, `clang-tidy`, and `codespell` as pre-commit hooks.

`clang-tidy` is not run automatically, that one is manual but it's nice to have to make it easier to run with `pre-commit run --hook-stage manual clang-tidy`.