### PR TITLE
Use new list_files, parse dates to check if sessions are old

### DIFF
--- a/src/app/crash/data_recovery.cpp
+++ b/src/app/crash/data_recovery.cpp
@@ -143,29 +143,27 @@ void DataRecovery::searchForSessions()
 
   // Existent sessions
   RECO_TRACE("RECO: Listing sessions from '%s'\n", m_sessionsDir.c_str());
-  for (auto& itemname : base::list_files(m_sessionsDir)) {
-    std::string itempath = base::join_path(m_sessionsDir, itemname);
-    if (base::is_directory(itempath)) {
-      RECO_TRACE("RECO: Session '%s'\n", itempath.c_str());
+  for (const auto& itemname : base::list_files(m_sessionsDir, base::ItemType::Directories)) {
+    const auto& itempath = base::join_path(m_sessionsDir, itemname);
+    RECO_TRACE("RECO: Session '%s' ", itempath.c_str());
 
-      SessionPtr session(new Session(&m_config, itempath));
-      if (!session->isRunning()) {
-        if ((session->isEmpty()) ||
-            (!session->isCrashedSession() && session->isOldSession())) {
-          RECO_TRACE("RECO: - to be deleted (%s)\n",
-                     session->isEmpty() ? "is empty":
-                     (session->isOldSession() ? "is old":
-                                                "unknown reason"));
-          session->removeFromDisk();
-        }
-        else {
-          RECO_TRACE("RECO:  - to be loaded\n");
-          sessions.push_back(session);
-        }
+    SessionPtr session(new Session(&m_config, itempath));
+    if (!session->isRunning()) {
+      if ((session->isEmpty()) ||
+          (!session->isCrashedSession() && session->isOldSession())) {
+        RECO_TRACE("to be deleted (%s)\n",
+                    session->isEmpty() ? "is empty":
+                    (session->isOldSession() ? "is old":
+                                              "unknown reason"));
+        session->removeFromDisk();
       }
-      else
-        RECO_TRACE("is running\n");
+      else {
+        RECO_TRACE("to be loaded\n");
+        sessions.push_back(session);
+      }
     }
+    else
+      RECO_TRACE("is running\n");
   }
 
   // Sort sessions from the most recent one to the oldest one

--- a/src/app/crash/log.h
+++ b/src/app/crash/log.h
@@ -10,7 +10,10 @@
 
 #include "base/debug.h"
 
-// TODO should we log some events in release?
-#define RECO_TRACE(...) // TRACE(__VA_ARGS__)
+#ifdef _DEBUG
+  #define RECO_TRACE(...) TRACE(__VA_ARGS__)
+#else
+  #define RECO_TRACE(...)
+#endif
 
 #endif

--- a/src/app/crash/log.h
+++ b/src/app/crash/log.h
@@ -10,10 +10,7 @@
 
 #include "base/debug.h"
 
-#ifdef _DEBUG
-  #define RECO_TRACE(...) TRACE(__VA_ARGS__)
-#else
-  #define RECO_TRACE(...)
-#endif
+// TODO should we log some events in release?
+#define RECO_TRACE(...) // TRACE(__VA_ARGS__)
 
 #endif

--- a/src/app/crash/read_document.cpp
+++ b/src/app/crash/read_document.cpp
@@ -77,7 +77,7 @@ public:
     , m_docVersions(nullptr)
     , m_loadInfo(nullptr)
     , m_taskToken(t) {
-    for (const auto& fn : base::list_files(dir)) {
+    for (const auto& fn : base::list_files(dir, base::ItemType::Files)) {
       auto i = fn.find('-');
       if (i == std::string::npos)
         continue;               // Has no ID

--- a/src/app/crash/session.cpp
+++ b/src/app/crash/session.cpp
@@ -30,6 +30,7 @@
 #include "base/thread.h"
 #include "base/time.h"
 #include "doc/cancel_io.h"
+#include "ui/app_state.h"
 #include "fmt/format.h"
 #include "ver/info.h"
 
@@ -114,11 +115,12 @@ std::string Session::version()
 const Session::Backups& Session::backups()
 {
   if (m_backups.empty()) {
-    for (auto& item : base::list_files(m_path)) {
+    for (const auto& item : base::list_files(m_path, base::ItemType::Directories)) {
+      if (ui::is_app_state_closing())
+        continue;
+
       std::string docDir = base::join_path(m_path, item);
-      if (base::is_directory(docDir)) {
-        m_backups.push_back(std::make_shared<Backup>(docDir));
-      }
+      m_backups.push_back(std::make_shared<Backup>(docDir));
     }
   }
   return m_backups;
@@ -147,18 +149,40 @@ bool Session::isOldSession()
     return true;
 
   int lifespanDays = m_config->keepEditedSpriteDataFor;
-  base::Time sessionTime = base::get_modification_time(verfile);
+  base::Time sessionTime;
+  
+  // Get the session time from the name if possible, to avoid re-scanning when transferring files
+  std::vector<std::string> parts;
+  base::split_string(base::get_file_title(m_path), parts, "-");
+
+  if (parts.size() == 3 && parts[0].size() == 8) {
+    try {
+      sessionTime = base::Time(filenamePartToInt(parts[0].substr(0, 4)),
+                               filenamePartToInt(parts[0].substr(4, 2)),
+                               filenamePartToInt(parts[0].substr(6, 2)),
+                               0,
+                               0,
+                               0);
+    }
+    catch (std::exception& ex) {
+      LOG(ERROR,
+          "Failed to parse a date from '%s', error: %s",
+          parts[0].c_str(),
+          ex.what());
+    }
+  }
+  
+  if (!sessionTime.valid()) {
+    // Get modification time as a fallback
+    sessionTime = base::get_modification_time(verfile);
+  }
 
   return (sessionTime.addDays(lifespanDays) < base::current_time());
 }
 
 bool Session::isEmpty()
 {
-  for (auto& item : base::list_files(m_path)) {
-    if (base::is_directory(base::join_path(m_path, item)))
-      return false;
-  }
-  return true;
+  return base::list_files(m_path, base::ItemType::Directories).empty();
 }
 
 void Session::create(base::pid pid)
@@ -385,12 +409,13 @@ void Session::deleteDirectory(const std::string& dir)
   if (dir.empty())
     return;
 
-  for (auto& item : base::list_files(dir)) {
+  for (const auto& item : base::list_files(dir, base::ItemType::Files)) {
+    if (ui::is_app_state_closing())
+      return;
+
     std::string objfn = base::join_path(dir, item);
-    if (base::is_file(objfn)) {
-      RECO_TRACE("RECO: Deleting file '%s'\n", objfn.c_str());
-      base::delete_file(objfn);
-    }
+    RECO_TRACE("RECO: Deleting file '%s'\n", objfn.c_str());
+    base::delete_file(objfn);
   }
   base::remove_directory(dir);
 }
@@ -409,6 +434,21 @@ void Session::fixFilename(Doc* doc)
     base::join_path(
       base::get_file_path(fn),
       base::get_file_title(fn) + "-Recovered" + ext));
+}
+
+int Session::filenamePartToInt(const std::string& part) const
+{
+  if (part.empty())
+    throw base::Exception("Invalid part");
+
+  int result = std::strtol(part.c_str(), NULL, 10);
+  if (errno == ERANGE)
+    throw base::Exception("Number out of range");
+
+  if (result < 0)
+    throw base::Exception("Negative value");
+
+  return result;
 }
 
 } // namespace crash

--- a/src/app/crash/session.cpp
+++ b/src/app/crash/session.cpp
@@ -164,7 +164,7 @@ bool Session::isOldSession()
                                0,
                                0);
     }
-    catch (std::exception& ex) {
+    catch (const std::exception& ex) {
       LOG(ERROR,
           "Failed to parse a date from '%s', error: %s",
           parts[0].c_str(),

--- a/src/app/crash/session.h
+++ b/src/app/crash/session.h
@@ -78,6 +78,7 @@ namespace crash {
     void markDocumentAsCorrectlyClosed(Doc* doc);
     void deleteDirectory(const std::string& dir);
     void fixFilename(Doc* doc);
+    int filenamePartToInt(const std::string& part) const;
 
     base::pid m_pid;
     std::string m_path;

--- a/src/app/extensions.cpp
+++ b/src/app/extensions.cpp
@@ -816,11 +816,8 @@ Extensions::Extensions()
     if (!base::is_directory(extensionsDir))
       continue;
 
-    for (auto& fn : base::list_files(extensionsDir)) {
+    for (const auto& fn : base::list_files(extensionsDir, base::ItemType::Directories)) {
       const auto dir = base::join_path(extensionsDir, fn);
-      if (!base::is_directory(dir))
-        continue;
-
       const bool isBuiltinExtension =
         (m_userExtensionsPath != base::get_file_path(dir));
 

--- a/src/app/font_path_unix.cpp
+++ b/src/app/font_path_unix.cpp
@@ -36,10 +36,9 @@ void get_font_dirs(base::paths& fontDirs)
 
     fontDirs.push_back(fontDir);
 
-    for (const auto& file : base::list_files(fontDir)) {
+    for (const auto& file : base::list_files(fontDir, base::ItemType::Directories)) {
       std::string fullpath = base::join_path(fontDir, file);
-      if (base::is_directory(fullpath))
-        q.push(fullpath); // Add subdirectory in the queue
+      q.push(fullpath); // Add subdirectory in the queue
     }
   }
 

--- a/src/app/i18n/strings.cpp
+++ b/src/app/i18n/strings.cpp
@@ -64,11 +64,7 @@ std::set<LangInfo> Strings::availableLanguages() const
     if (!base::is_directory(stringsPath))
       continue;
 
-    for (const auto& fn : base::list_files(stringsPath)) {
-      // Ignore README/LICENSE files.
-      if (base::get_file_extension(fn) != "ini")
-        continue;
-
+    for (const auto& fn : base::list_files(stringsPath, base::ItemType::Files, "*.ini")) {
       const std::string langId = base::get_file_title(fn);
       std::string path = base::join_path(stringsPath, fn);
       std::string displayName = langId;

--- a/src/app/res/palettes_loader_delegate.cpp
+++ b/src/app/res/palettes_loader_delegate.cpp
@@ -45,7 +45,7 @@ void PalettesLoaderDelegate::getResourcesPaths(std::map<std::string, std::string
     if (base::is_directory(rf.filename())) {
       path = rf.filename();
       path = base::fix_path_separators(path);
-      for (const auto& fn : base::list_files(path)) {
+      for (const auto& fn : base::list_files(path, base::ItemType::Files)) {
         // Ignore the default palette that is inside the palettes/ dir
         // in the user home dir.
         if (fn == "default.ase" ||
@@ -53,8 +53,7 @@ void PalettesLoaderDelegate::getResourcesPaths(std::map<std::string, std::string
           continue;
 
         std::string fullFn = base::join_path(path, fn);
-        if (base::is_file(fullFn))
-          idAndPath[base::get_file_title(fn)] = fullFn;
+        idAndPath[base::get_file_title(fn)] = fullFn;
       }
     }
   }

--- a/src/app/script/app_fs_object.cpp
+++ b/src/app/script/app_fs_object.cpp
@@ -110,7 +110,7 @@ int AppFS_listFiles(lua_State* L)
   lua_newtable(L);
   if (path) {
     int i = 0;
-    for (auto fn : base::list_files(path)) {
+    for (const auto& fn : base::list_files(path)) {
       lua_pushstring(L, fn.c_str());
       lua_seti(L, -2, ++i);
     }

--- a/src/app/sentry_wrapper.cpp
+++ b/src/app/sentry_wrapper.cpp
@@ -109,18 +109,15 @@ bool Sentry::areThereCrashesToReport()
 
   // At least one .dmp file in the completed/ directory means that
   // there was at least one crash in the past (this is for macOS).
-  for (auto f : base::list_files(base::join_path(m_dbdir, "completed"))) {
-    if (base::get_file_extension(f) == "dmp")
-      return true;
-  }
+  if (!base::join_path(m_dbdir, "completed"), base::ItemType::Files, "*.dmp").empty())
+    return true;
 
   // In case that "last_crash" doesn't exist we can check for some
   // .dmp file in the reports/ directory (it looks like the completed/
   // directory is not generated on Windows).
-  for (auto f : base::list_files(base::join_path(m_dbdir, "reports"))) {
-    if (base::get_file_extension(f) == "dmp")
-      return true;
-  }
+  if (!base::list_files(base::join_path(m_dbdir, "reports"), base::ItemType::Files, "*.dmp").empty())
+    return true;
+
   return false;
 }
 

--- a/src/app/ui/font_popup.cpp
+++ b/src/app/ui/font_popup.cpp
@@ -159,10 +159,8 @@ FontPopup::FontPopup()
   // directories (fontDirs)
   base::paths files;
   for (const auto& fontDir : fontDirs) {
-    for (const auto& file : base::list_files(fontDir)) {
-      std::string fullpath = base::join_path(fontDir, file);
-      if (base::is_file(fullpath))
-        files.push_back(fullpath);
+    for (const auto& file : base::list_files(fontDir, base::ItemType::Files)) {
+      files.push_back(base::join_path(fontDir, file));
     }
   }
 


### PR DESCRIPTION
Use the new filtering in `base::list_files` and sessions parse the filename dates to avoid overscanning when the directories are copy/pasted or their edit date changes for some reason.