### PR TITLE
Add symmetry to image brushes

### DIFF
--- a/src/app/tools/ink.h
+++ b/src/app/tools/ink.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2022  Igara Studio S.A.
+// Copyright (C) 2018-2024  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This program is distributed under the terms of
@@ -104,7 +104,8 @@ namespace app {
       virtual void prepareForStrokes(ToolLoop* loop, Strokes& strokes) { }
 
       // Called for each point shape.
-      virtual void prepareForPointShape(ToolLoop* loop, bool firstPoint, int x, int y) { }
+      virtual void prepareForPointShape(ToolLoop* loop, bool firstPoint, int x, int y,
+                                        doc::SymmetryIndex summetry) { }
       virtual void prepareVForPointShape(ToolLoop* loop, int y) { }
       virtual void prepareUForPointShapeWholeScanline(ToolLoop* loop, int x1) { }
       virtual void prepareUForPointShapeSlicedScanline(ToolLoop* loop, bool leftSlice, int x1) { }

--- a/src/app/tools/inks.h
+++ b/src/app/tools/inks.h
@@ -31,9 +31,10 @@ public:
     m_proc->processScanline(x1, y, x2, loop);
   }
 
-  void prepareForPointShape(ToolLoop* loop, bool firstPoint, int x, int y) override {
+  void prepareForPointShape(ToolLoop* loop, bool firstPoint, int x, int y,
+                            doc::SymmetryIndex symmetry) override {
     ASSERT(m_proc);
-    m_proc->prepareForPointShape(loop, firstPoint, x, y);
+    m_proc->prepareForPointShape(loop, firstPoint, x, y, symmetry);
   }
 
   void prepareVForPointShape(ToolLoop* loop, int y) override {

--- a/src/app/tools/intertwiners.h
+++ b/src/app/tools/intertwiners.h
@@ -617,7 +617,7 @@ private:
   // IntertwineAsPixelPerfect.joinStroke() method.
   void savePointshapeStrokePtArea(ToolLoop* loop, const tools::Stroke::Pt& pt) {
     gfx::Rect r;
-    loop->getPointShape()->getModifiedArea(loop, pt.x, pt.y, r);
+    loop->getPointShape()->getModifiedArea(loop, pt.x, pt.y, pt.symmetry, r);
 
     gfx::Region rgn(r);
     // By wrapping the modified area's position when tiled mode is active, the
@@ -689,7 +689,7 @@ private:
     ASSERT(m_tempTileset);
 
     gfx::Rect r;
-    loop->getPointShape()->getModifiedArea(loop, pt.x, pt.y, r);
+    loop->getPointShape()->getModifiedArea(loop, pt.x, pt.y, pt.symmetry, r);
 
     r.offset(-loop->getCelOrigin());
     auto tilesPts = m_dstGrid.tilesInCanvasRegion(gfx::Region(r));

--- a/src/app/tools/point_shape.h
+++ b/src/app/tools/point_shape.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2020  Igara Studio S.A.
+// Copyright (C) 2020-2024  Igara Studio S.A.
 // Copyright (C) 2001-2016  David Capello
 //
 // This program is distributed under the terms of
@@ -28,7 +28,8 @@ namespace app {
 
       // The x, y position must be relative to the cel/src/dst image origin.
       virtual void transformPoint(ToolLoop* loop, const Stroke::Pt& pt) = 0;
-      virtual void getModifiedArea(ToolLoop* loop, int x, int y, gfx::Rect& area) = 0;
+      virtual void getModifiedArea(ToolLoop* loop, int x, int y,
+                                   doc::SymmetryIndex symmetry, gfx::Rect& area) = 0;
 
     protected:
       // Calls loop->getInk()->inkHline() function for each horizontal-scanline

--- a/src/app/tools/point_shapes.h
+++ b/src/app/tools/point_shapes.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2022  Igara Studio S.A.
+// Copyright (C) 2019-2024  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This program is distributed under the terms of
@@ -9,6 +9,7 @@
 
 #include "app/tools/ink.h"
 #include "doc/algorithm/flip_image.h"
+#include "doc/primitives.h"
 #include "render/gradient.h"
 
 #include <array>
@@ -23,7 +24,8 @@ public:
     // Do nothing
   }
 
-  void getModifiedArea(ToolLoop* loop, int x, int y, Rect& area) override {
+  void getModifiedArea(ToolLoop* loop, int x, int y,
+                       doc::SymmetryIndex symmetry, Rect& area) override {
     // Do nothing
   }
 };
@@ -33,11 +35,12 @@ public:
   bool isPixel() override { return true; }
 
   void transformPoint(ToolLoop* loop, const Stroke::Pt& pt) override {
-    loop->getInk()->prepareForPointShape(loop, true, pt.x, pt.y);
+    loop->getInk()->prepareForPointShape(loop, true, pt.x, pt.y, pt.symmetry);
     doInkHline(pt.x, pt.y, pt.x, loop);
   }
 
-  void getModifiedArea(ToolLoop* loop, int x, int y, Rect& area) override {
+  void getModifiedArea(ToolLoop* loop, int x, int y,
+                       doc::SymmetryIndex symmetry, Rect& area) override {
     area = Rect(x, y, 1, 1);
   }
 };
@@ -51,11 +54,12 @@ public:
     const doc::Grid& grid = loop->getGrid();
     gfx::Point newPos = grid.canvasToTile(pt.toPoint());
 
-    loop->getInk()->prepareForPointShape(loop, true, newPos.x, newPos.y);
+    loop->getInk()->prepareForPointShape(loop, true, newPos.x, newPos.y, pt.symmetry);
     doInkHline(newPos.x, newPos.y, newPos.x, loop);
   }
 
-  void getModifiedArea(ToolLoop* loop, int x, int y, Rect& area) override {
+  void getModifiedArea(ToolLoop* loop, int x, int y,
+                       doc::SymmetryIndex symmetry, Rect& area) override {
     const doc::Grid& grid = loop->getGrid();
     area = grid.alignBounds(Rect(x, y, 1, 1));
   }
@@ -241,7 +245,7 @@ public:
       y = wrap_value(y, loop->sprite()->height());
     }
 
-    ink->prepareForPointShape(loop, m_firstPoint, x, y);
+    ink->prepareForPointShape(loop, m_firstPoint, x, y, pt.symmetry);
 
     for (auto scanline : getCompressedImage(pt.symmetry)) {
       int u = x+scanline.x;
@@ -251,50 +255,20 @@ public:
     m_firstPoint = false;
   }
 
-  void getModifiedArea(ToolLoop* loop, int x, int y, Rect& area) override {
+  void getModifiedArea(ToolLoop* loop, int x, int y,
+                       doc::SymmetryIndex symmetry, Rect& area) override {
     area = loop->getBrush()->bounds();
     area.x += x;
     area.y += y;
   }
 
 private:
-  CompressedImage& getCompressedImage(gen::SymmetryMode symmetryMode) {
-    auto& compressPtr = m_compressedImages[int(symmetryMode)];
+  CompressedImage& getCompressedImage(doc::SymmetryIndex index) {//symmetryMode
+    auto& compressPtr = m_compressedImages[index];
     if (!compressPtr) {
-      switch (symmetryMode) {
-        case gen::SymmetryMode::NONE: {
-          compressPtr.reset(new CompressedImage(m_lastBrush->image(),
-                                                m_lastBrush->maskBitmap(),
-                                                false));
-          break;
-        }
-        case gen::SymmetryMode::HORIZONTAL:
-        case gen::SymmetryMode::VERTICAL: {
-          std::unique_ptr<Image> tempImage(Image::createCopy(m_lastBrush->image()));
-          doc::algorithm::FlipType flip =
-            (symmetryMode == gen::SymmetryMode::HORIZONTAL)?
-              doc::algorithm::FlipType::FlipHorizontal:
-              doc::algorithm::FlipType::FlipVertical;
-          doc::algorithm::flip_image(tempImage.get(), tempImage->bounds(), flip);
-          compressPtr.reset(new CompressedImage(tempImage.get(),
-                                                m_lastBrush->maskBitmap(),
-                                                false));
-          break;
-        }
-        case gen::SymmetryMode::BOTH: {
-          std::unique_ptr<Image> tempImage(Image::createCopy(m_lastBrush->image()));
-          doc::algorithm::flip_image(tempImage.get(),
-                                     tempImage->bounds(),
-                                     doc::algorithm::FlipType::FlipVertical);
-          doc::algorithm::flip_image(tempImage.get(),
-                                     tempImage->bounds(),
-                                     doc::algorithm::FlipType::FlipHorizontal);
-          compressPtr.reset(new CompressedImage(tempImage.get(),
-                                                m_lastBrush->maskBitmap(),
-                                                false));
-          break;
-        }
-      }
+      compressPtr.reset(new CompressedImage(m_lastBrush->getSymmetryImage(index),
+                                            m_lastBrush->getSymmetryMask(index),
+                                            false));
     }
     return *compressPtr;
   }
@@ -319,7 +293,7 @@ public:
                        wpt, true);
     }
 
-    loop->getInk()->prepareForPointShape(loop, true, wpt.x, wpt.y);
+    loop->getInk()->prepareForPointShape(loop, true, wpt.x, wpt.y, pt.symmetry);
 
     doc::algorithm::floodfill(
       srcImage,
@@ -334,7 +308,8 @@ public:
       loop, (AlgoHLine)doInkHline);
   }
 
-  void getModifiedArea(ToolLoop* loop, int x, int y, Rect& area) override {
+  void getModifiedArea(ToolLoop* loop, int x, int y,
+                       doc::SymmetryIndex symmetry, Rect& area) override {
     area = floodfillBounds(loop, x, y);
   }
 
@@ -387,7 +362,7 @@ public:
   }
 
   void transformPoint(ToolLoop* loop, const Stroke::Pt& pt) override {
-    loop->getInk()->prepareForPointShape(loop, true, pt.x, pt.y);
+    loop->getInk()->prepareForPointShape(loop, true, pt.x, pt.y, pt.symmetry);
 
     int spray_width = loop->getSprayWidth();
     int spray_speed = loop->getSpraySpeed();
@@ -418,15 +393,16 @@ public:
     }
   }
 
-  void getModifiedArea(ToolLoop* loop, int x, int y, Rect& area) override {
+  void getModifiedArea(ToolLoop* loop, int x, int y,
+                       doc::SymmetryIndex symmetry, Rect& area) override {
     int spray_width = loop->getSprayWidth();
     Point p1(x-spray_width, y-spray_width);
     Point p2(x+spray_width, y+spray_width);
 
     Rect area1;
     Rect area2;
-    m_subPointShape.getModifiedArea(loop, p1.x, p1.y, area1);
-    m_subPointShape.getModifiedArea(loop, p2.x, p2.y, area2);
+    m_subPointShape.getModifiedArea(loop, p1.x, p1.y, symmetry, area1);
+    m_subPointShape.getModifiedArea(loop, p2.x, p2.y, symmetry, area2);
 
     area = area1.createUnion(area2);
   }

--- a/src/app/tools/stroke.h
+++ b/src/app/tools/stroke.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2021  Igara Studio S.A.
+// Copyright (C) 2019-2024  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "app/pref/preferences.h"
+#include "doc/brush.h"
 #include "gfx/point.h"
 #include "gfx/rect.h"
 
@@ -26,7 +27,7 @@ namespace app {
         float size = 0.0f;
         float angle = 0.0f;
         float gradient = 0.0f;
-        gen::SymmetryMode symmetry = gen::SymmetryMode::NONE;
+        doc::SymmetryIndex symmetry = doc::SymmetryIndex::ORIGINAL;
         Pt() { }
         Pt(const gfx::Point& point) : x(point.x), y(point.y) { }
         Pt(int x, int y) : x(x), y(y) { }

--- a/src/app/tools/symmetry.cpp
+++ b/src/app/tools/symmetry.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2021  Igara Studio S.A.
+// Copyright (C) 2021-2024  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -12,6 +12,7 @@
 
  #include "app/tools/point_shape.h"
  #include "app/tools/tool_loop.h"
+ #include "doc/brush.h"
 
 namespace app {
 namespace tools {
@@ -28,21 +29,24 @@ void Symmetry::generateStrokes(const Stroke& stroke, Strokes& strokes,
       break;
 
     case gen::SymmetryMode::HORIZONTAL:
+      calculateSymmetricalStroke(stroke, stroke2, loop, doc::SymmetryIndex::FLIPPED_X);
+      strokes.push_back(stroke2);
+      break;
     case gen::SymmetryMode::VERTICAL:
-      calculateSymmetricalStroke(stroke, stroke2, loop, symmetryMode);
+      calculateSymmetricalStroke(stroke, stroke2, loop, doc::SymmetryIndex::FLIPPED_Y);
       strokes.push_back(stroke2);
       break;
 
     case gen::SymmetryMode::BOTH: {
-      calculateSymmetricalStroke(stroke, stroke2, loop, gen::SymmetryMode::HORIZONTAL);
+      calculateSymmetricalStroke(stroke, stroke2, loop, doc::SymmetryIndex::FLIPPED_X);
       strokes.push_back(stroke2);
 
       Stroke stroke3;
-      calculateSymmetricalStroke(stroke, stroke3, loop, gen::SymmetryMode::VERTICAL);
+      calculateSymmetricalStroke(stroke, stroke3, loop, doc::SymmetryIndex::FLIPPED_Y);
       strokes.push_back(stroke3);
 
       Stroke stroke4;
-      calculateSymmetricalStroke(stroke3, stroke4, loop, gen::SymmetryMode::BOTH);
+      calculateSymmetricalStroke(stroke3, stroke4, loop, doc::SymmetryIndex::FLIPPED_XY);
       strokes.push_back(stroke4);
       break;
     }
@@ -50,39 +54,35 @@ void Symmetry::generateStrokes(const Stroke& stroke, Strokes& strokes,
 }
 
 void Symmetry::calculateSymmetricalStroke(const Stroke& refStroke, Stroke& stroke,
-                                          ToolLoop* loop, gen::SymmetryMode symmetryMode)
+                                          ToolLoop* loop, doc::SymmetryIndex symmetry)
 {
-  int brushSize, brushCenter;
-  if (loop->getPointShape()->isFloodFill()) {
-    brushSize = 1;
-    brushCenter = 0;
-  }
-  else {
-    // TODO we should flip the brush center+image+bitmap or just do
-    //      the symmetry of all pixels
-    auto brush = loop->getBrush();
-    if (symmetryMode == gen::SymmetryMode::HORIZONTAL || symmetryMode == gen::SymmetryMode::BOTH) {
-      brushSize = brush->bounds().w;
-      brushCenter = brush->center().x;
-    }
-    else {
-      brushSize = brush->bounds().h;
-      brushCenter = brush->center().y;
-    }
+  gfx::Size brushSize(1, 1);
+  gfx::Point brushCenter(0, 0);
+  auto brush = loop->getBrush();
+  if (!loop->getPointShape()->isFloodFill()) {
+    brushSize = gfx::Size(brush->bounds().size().h,
+                          brush->bounds().size().w);
+    brushCenter = gfx::Point(brush->center().y,
+                              brush->center().x);
   }
 
   const bool isDynamic = loop->getDynamics().isDynamic();
   for (const auto& pt : refStroke) {
     if (isDynamic) {
-      brushSize = pt.size;
-      brushCenter = (brushSize - brushSize % 2) / 2;
+      brushSize = gfx::Size(pt.size, pt.size);
+      int center = (brushSize.w - brushSize.w % 2) / 2;
+      brushCenter = gfx::Point(center, center);
     }
     Stroke::Pt pt2 = pt;
-    pt2.symmetry = symmetryMode;
-    if (symmetryMode == gen::SymmetryMode::HORIZONTAL || symmetryMode == gen::SymmetryMode::BOTH)
-      pt2.x = 2 * (m_x + brushCenter) - pt2.x - brushSize;
-    else
-      pt2.y = 2 * (m_y + brushCenter) - pt2.y - brushSize;
+    pt2.symmetry = symmetry;
+    switch (symmetry) {
+      case doc::SymmetryIndex::FLIPPED_X:
+      case doc::SymmetryIndex::FLIPPED_XY:
+        pt2.x = 2 * (m_x + brushCenter.x) - pt.x - brushSize.w;
+        break;
+      default:
+        pt2.y = 2 * (m_y + brushCenter.y) - pt.y - brushSize.h;
+    }
     stroke.addPoint(pt2);
   }
 }

--- a/src/app/tools/symmetry.h
+++ b/src/app/tools/symmetry.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2021  Igara Studio S.A.
+// Copyright (C) 2021-2024  Igara Studio S.A.
 // Copyright (C) 2015  David Capello
 //
 // This program is distributed under the terms of
@@ -11,6 +11,7 @@
 
 #include "app/tools/stroke.h"
 #include "app/pref/preferences.h"
+#include "doc/brush.h"
 
 namespace app {
 namespace tools {
@@ -31,7 +32,7 @@ public:
 
 private:
   void calculateSymmetricalStroke(const Stroke& refStroke, Stroke& stroke,
-                                  ToolLoop* loop, gen::SymmetryMode symmetryMode);
+                                  ToolLoop* loop, doc::SymmetryIndex symmetry);
 
   gen::SymmetryMode m_symmetryMode;
   double m_x, m_y;

--- a/src/app/tools/tool_loop_manager.cpp
+++ b/src/app/tools/tool_loop_manager.cpp
@@ -44,8 +44,7 @@ using namespace filters;
 ToolLoopManager::ToolLoopManager(ToolLoop* toolLoop)
   : m_toolLoop(toolLoop)
   , m_canceled(false)
-  , m_brushSize0(toolLoop->getBrush()->size())
-  , m_brushAngle0(toolLoop->getBrush()->angle())
+  , m_brush0(toolLoop->getBrush())
   , m_dynamics(toolLoop->getDynamics())
 {
 }
@@ -209,7 +208,7 @@ void ToolLoopManager::movement(Pointer pointer)
   doLoopStep(false);
 }
 
-void ToolLoopManager::disableMouseStabilizer() 
+void ToolLoopManager::disableMouseStabilizer()
 {
   // Disable mouse stabilizer for the current ToolLoopManager
   m_dynamics.stabilizer = false;
@@ -341,12 +340,14 @@ void ToolLoopManager::calculateDirtyArea(const Strokes& strokes)
     m_toolLoop->getPointShape()->getModifiedArea(
       m_toolLoop,
       strokeBounds.x,
-      strokeBounds.y, r1);
+      strokeBounds.y,
+      stroke.firstPoint().symmetry, r1);
 
     m_toolLoop->getPointShape()->getModifiedArea(
       m_toolLoop,
       strokeBounds.x+strokeBounds.w-1,
-      strokeBounds.y+strokeBounds.h-1, r2);
+      strokeBounds.y+strokeBounds.h-1,
+      stroke.firstPoint().symmetry, r2);
 
     m_dirtyArea.createUnion(m_dirtyArea, Region(r1.createUnion(r2)));
   }
@@ -371,8 +372,8 @@ Stroke::Pt ToolLoopManager::getSpriteStrokePt(const Pointer& pointer)
 {
   // Convert the screen point to a sprite point
   Stroke::Pt spritePoint = pointer.point();
-  spritePoint.size = m_brushSize0;
-  spritePoint.angle = m_brushAngle0;
+  spritePoint.size = m_brush0->size();
+  spritePoint.angle = m_brush0->angle();
 
   // Center the input to some grid point if needed
   snapToGrid(spritePoint);

--- a/src/app/tools/tool_loop_manager.h
+++ b/src/app/tools/tool_loop_manager.h
@@ -99,10 +99,9 @@ private:
   Pointer m_lastPointer;
   gfx::Region m_dirtyArea;
   gfx::Region m_nextDirtyArea;
-  const int m_brushSize0;
-  const int m_brushAngle0;
   DynamicsOptions m_dynamics;
   gfx::PointF m_stabilizerCenter;
+  doc::Brush* m_brush0 = nullptr;
 };
 
 } // namespace tools

--- a/src/doc/brush.cpp
+++ b/src/doc/brush.cpp
@@ -326,17 +326,13 @@ static void algo_hline(int x1, int y, int x2, void *data)
 
 void Brush::resetSymmetries()
 {
-  if (type() != doc::kImageBrushType)
-    return;
   if (m_symmetryImages.size() == 0) {
-    TRACEARGS("resetSymmetries : se creo otro set de m_symmetry\n");
     for (int i=0; i<4; i++) {
       m_symmetryImages.push_back(ImageRef());
       m_symmetryMasks.push_back(ImageRef());
     }
   }
   else {
-    TRACEARGS("resetSymmetries : m_symmetry reset()\n");
     for (int i=0; i<4; i++) {
       m_symmetryImages[i].reset();
       m_symmetryMasks[i].reset();
@@ -348,6 +344,9 @@ Image* Brush::getSymmetryImage(const SymmetryIndex index)
 {
   if (index <= 0 || index > 3)
     return m_image.get();
+
+  if (m_symmetryImages.size() == 0)
+    resetSymmetries();
 
   if (!m_symmetryImages[index]) {
     switch (index) {

--- a/src/doc/brush.h
+++ b/src/doc/brush.h
@@ -22,6 +22,13 @@
 
 namespace doc {
 
+  enum SymmetryIndex {
+    ORIGINAL = 0,
+    FLIPPED_X = 1,
+    FLIPPED_Y = 2,
+    FLIPPED_XY = 3,
+  };
+
   class Brush;
   using BrushRef = std::shared_ptr<Brush>;
 
@@ -93,6 +100,10 @@ namespace doc {
       return m_image.get();
     }
 
+    void resetSymmetries();
+    Image* getSymmetryImage(const SymmetryIndex index);
+    Image* getSymmetryMask(const SymmetryIndex index);
+
   private:
     void clean();
     void regenerate();
@@ -111,6 +122,10 @@ namespace doc {
     gfx::Point m_patternOrigin;           // From what position the brush was taken
     ImageRef m_patternImage;
     int m_gen;
+
+    //Symmetry image/mask buffers
+    std::vector<ImageRef> m_symmetryImages;
+    std::vector<ImageRef> m_symmetryMasks;
 
     // Extra data used for setImageColor()
     ImageRef m_backupImage; // Backup image to avoid losing original brush colors/pattern


### PR DESCRIPTION
During diagonal symmetry development I implemented the flip of image brushes itself.
This is the version for 4 quadrant symmetry (current).
@dacap Can you give me an overview of the approach?

Note 1: I need to review the evidence, I will be more comfortable with the approval of the approach anyway.
Note 2: Tiled Mode need some fix in some cases.