### PR TITLE
Fix Sentry wrapper compilation

### DIFF
--- a/src/app/sentry_wrapper.cpp
+++ b/src/app/sentry_wrapper.cpp
@@ -109,7 +109,7 @@ bool Sentry::areThereCrashesToReport()
 
   // At least one .dmp file in the completed/ directory means that
   // there was at least one crash in the past (this is for macOS).
-  if (!base::join_path(m_dbdir, "completed"), base::ItemType::Files, "*.dmp").empty())
+  if (!base::list_files(base::join_path(m_dbdir, "completed"), base::ItemType::Files, "*.dmp").empty())
     return true;
 
   // In case that "last_crash" doesn't exist we can check for some


### PR DESCRIPTION
Accidentally broke this with #4660 and CI doesn't compile with sentry enabled (and neither did I until today!) so it didn't catch it