### PR TITLE
Fix slice tool for tiles mode

### DIFF
--- a/src/app/tools/inks.h
+++ b/src/app/tools/inks.h
@@ -315,7 +315,7 @@ public:
   void inkHline(int x1, int y, int x2, ToolLoop* loop) override {
     // Map tile coords to canvas if needed
     gfx::Rect rc(BaseInk::tileSelectionToCanvas(
-      x1, y, x2, loop, false));
+      x1, y, x2, loop, !m_createSlice));
 
     if (m_createSlice)
       m_maxBounds |= rc;

--- a/src/app/tools/point_shape.cpp
+++ b/src/app/tools/point_shape.cpp
@@ -42,15 +42,6 @@ void PointShape::doInkHline(int x1, int y, int x2, ToolLoop* loop)
     x2 -= origin.x;
     y -= origin.y;
   }
-  // Without this fix, tiled slice preview won't be drawn
-  // correctly if the tilemap's origin is non-zero
-  else if (loop->getPointShape()->isTile() && ink->isSlice()) {
-    const gfx::Point& tileOffset = loop->getGrid().origin();
-    const gfx::Size& tileSize = loop->getGrid().tileSize();
-    x1 += std::ceil(float(tileOffset.x)/tileSize.w);
-    x2 += std::ceil(float(tileOffset.x)/tileSize.w);
-    y += std::ceil(float(tileOffset.y)/tileSize.h);
-  }
 
   // Tiled in Y axis
   if (int(tiledMode) & int(TiledMode::Y_AXIS)) {
@@ -96,16 +87,6 @@ void PointShape::doInkHline(int x1, int y, int x2, ToolLoop* loop)
 
     x1 = std::clamp(x1, 0, dstw-1);
     x2 = std::clamp(x2, 0, dstw-1);
-
-    // Undo the offset applied to tiled slices
-    if (loop->getPointShape()->isTile() && ink->isSlice()) {
-      const gfx::Point& tileOffset = loop->getGrid().origin();
-      const gfx::Size& tileSize = loop->getGrid().tileSize();
-      x1 -= std::ceil(float(tileOffset.x)/tileSize.w);
-      x2 -= std::ceil(float(tileOffset.x)/tileSize.w);
-      y -= std::ceil(float(tileOffset.y)/tileSize.h);
-    }
-
     ink->inkHline(x1, y, x2, loop);
   }
 }

--- a/src/app/tools/point_shape.cpp
+++ b/src/app/tools/point_shape.cpp
@@ -34,11 +34,14 @@ void PointShape::doInkHline(int x1, int y, int x2, ToolLoop* loop)
   const int dsth = loop->getDstImage()->height();
   int x, w, size; // width or height
 
-  // Without this fix, slice preview won't show when tilemap mode
-  // is 'tiles' and slicing at a negative grid index
+  // Without this fix, tiled slice preview won't show when
+  // slicing at a negative grid index
   gfx::Point limit(0,0);
-  if (ink->isSlice() && loop->getPointShape()->isTile())
+  if (ink->isSlice() && loop->getPointShape()->isTile()) {
     limit = -loop->getGrid().origin();
+    limit.x *= limit.x < 0;
+    limit.y *= limit.y < 0;
+  }
 
   // In case the ink needs original cel coordinates, we have to
   // translate the x1/y/x2 coordinate.

--- a/src/app/tools/point_shape.cpp
+++ b/src/app/tools/point_shape.cpp
@@ -34,6 +34,12 @@ void PointShape::doInkHline(int x1, int y, int x2, ToolLoop* loop)
   const int dsth = loop->getDstImage()->height();
   int x, w, size; // width or height
 
+  // Without this fix, slice preview won't show when tilemap mode
+  // is 'tiles' and slicing at a negative grid index
+  gfx::Point limit(0,0);
+  if (ink->isSlice() && loop->getPointShape()->isTile())
+    limit = -loop->getGrid().origin();
+
   // In case the ink needs original cel coordinates, we have to
   // translate the x1/y/x2 coordinate.
   if (loop->needsCelCoordinates()) {
@@ -48,7 +54,7 @@ void PointShape::doInkHline(int x1, int y, int x2, ToolLoop* loop)
     size = dsth;      // size = image height
     y = wrap_value(y, size);
   }
-  else if (y < 0 || y >= dsth) {
+  else if (y < limit.y || y >= dsth) {
     return;
   }
 
@@ -82,11 +88,11 @@ void PointShape::doInkHline(int x1, int y, int x2, ToolLoop* loop)
   }
   // Clipped in X axis
   else {
-    if (x2 < 0 || x1 >= dstw || x2-x1+1 < 1)
+    if (x2 < limit.x || x1 >= dstw || x2-x1+1 < limit.x+1)
       return;
 
-    x1 = std::clamp(x1, 0, dstw-1);
-    x2 = std::clamp(x2, 0, dstw-1);
+    x1 = std::clamp(x1, limit.x, dstw-1);
+    x2 = std::clamp(x2, limit.x, dstw-1);
     ink->inkHline(x1, y, x2, loop);
   }
 }

--- a/src/app/ui/editor/tool_loop_impl.cpp
+++ b/src/app/ui/editor/tool_loop_impl.cpp
@@ -226,7 +226,7 @@ public:
       //      tilemap layer to preview the selection, or 2) using a
       //      path to show the selection (so there is no preview layer
       //      at all and nor ExpandCelCanvas)
-      if (m_ink->isSelection())
+      if (m_ink->isSelection() || m_ink->isSlice())
         site.tilemapMode(TilemapMode::Pixels);
     }
 
@@ -762,7 +762,8 @@ static void adjust_ink_for_tilemaps(const Site& site,
                                     ToolLoopParams& params)
 {
   if (!params.ink->isSelection() &&
-      !params.ink->isEraser()) {
+      !params.ink->isEraser() &&
+      !params.ink->isSlice()) {
     params.ink = App::instance()->toolBox()->getInkById(tools::WellKnownInks::PaintCopy);
   }
 }

--- a/src/app/ui/editor/tool_loop_impl.cpp
+++ b/src/app/ui/editor/tool_loop_impl.cpp
@@ -529,7 +529,7 @@ public:
         ExpandCelCanvas::NeedsSource |
         (m_layer->isTilemap() &&
          (!m_tilesMode ||
-          m_ink->isSelection()) ? ExpandCelCanvas::PixelsBounds:
+          isSelectionPreview) ? ExpandCelCanvas::PixelsBounds:
                                   ExpandCelCanvas::None) |
         (m_layer->isTilemap() &&
          site.tilemapMode() == TilemapMode::Pixels &&


### PR DESCRIPTION
Makes the slice tool behave similarly to rectangular marquee when tilemap mode is set to tiles. Fix #4306.