### PR TITLE
Show multiplied grid cell index

### DIFF
--- a/src/app/ui/editor/standby_state.cpp
+++ b/src/app/ui/editor/standby_state.cpp
@@ -601,17 +601,6 @@ bool StandbyState::onUpdateStatusBar(Editor* editor)
         gfx::Point pt = grid.canvasToTile(gfx::Point(spritePos));
         buf += fmt::format(" :grid: {} {}", pt.x, pt.y);
 
-        // Show the grid cell index
-        int columns = int(std::floor(
-          sprite->bounds().w/grid.tileSize().w));
-        int rows = int(std::floor(
-          sprite->bounds().h/grid.tileSize().h));
-        int column = pt.x%columns;
-        int row = pt.y%rows;
-        if (row < 0) row = row + rows;
-        if (column < 0) column = column + columns;
-        buf += fmt::format(" :arrow_down: {}", column+row*columns);
-
         // Show the tile index of this specific tile
         if (site.layer() &&
             site.layer()->isTilemap() &&
@@ -624,6 +613,21 @@ bool StandbyState::onUpdateStatusBar(Editor* editor)
             build_tile_flags_string(tf, str);
             buf += fmt::format(" [{}{}]", ti, str);
           }
+        }
+        // Show the grid cell index
+        else if ((!site.layer() ||
+            !site.layer()->isTilemap()) &&
+            (spritePos.x >= 0 && spritePos.x <= sprite->width() &&
+            spritePos.y >= 0 && spritePos.y <= sprite->height())) {
+          int columns = int(std::floor(
+            sprite->bounds().w/grid.tileSize().w));
+          int rows = int(std::floor(
+            sprite->bounds().h/grid.tileSize().h));
+          int column = pt.x%columns;
+          int row = pt.y%rows;
+          if (row < 0) row = row + rows;
+          if (column < 0) column = column + columns;
+          buf += fmt::format(" [{}]", column+row*columns);
         }
       }
     }

--- a/src/app/ui/editor/standby_state.cpp
+++ b/src/app/ui/editor/standby_state.cpp
@@ -601,6 +601,17 @@ bool StandbyState::onUpdateStatusBar(Editor* editor)
         gfx::Point pt = grid.canvasToTile(gfx::Point(spritePos));
         buf += fmt::format(" :grid: {} {}", pt.x, pt.y);
 
+        // Show the grid cell index
+        int columns = int(std::floor(
+          sprite->bounds().w/grid.tileSize().w));
+        int rows = int(std::floor(
+          sprite->bounds().h/grid.tileSize().h));
+        int column = pt.x%columns;
+        int row = pt.y%rows;
+        if (row < 0) row = row + rows;
+        if (column < 0) column = column + columns;
+        buf += fmt::format(" :arrow_down: {}", column+row*columns);
+
         // Show the tile index of this specific tile
         if (site.layer() &&
             site.layer()->isTilemap() &&

--- a/src/app/ui/editor/standby_state.cpp
+++ b/src/app/ui/editor/standby_state.cpp
@@ -615,19 +615,16 @@ bool StandbyState::onUpdateStatusBar(Editor* editor)
           }
         }
         // Show the grid cell index
-        else if ((!site.layer() ||
-            !site.layer()->isTilemap()) &&
-            (spritePos.x >= 0 && spritePos.x <= sprite->width() &&
-            spritePos.y >= 0 && spritePos.y <= sprite->height())) {
+        if (sprite->bounds().contains(gfx::Point(spritePos))) {
           int columns = int(std::floor(
             sprite->bounds().w/grid.tileSize().w));
           int rows = int(std::floor(
             sprite->bounds().h/grid.tileSize().h));
-          int column = pt.x%columns;
-          int row = pt.y%rows;
+          int column = (columns ? pt.x%columns: 0);
+          int row = (rows ? pt.y%rows: 0);
           if (row < 0) row = row + rows;
           if (column < 0) column = column + columns;
-          buf += fmt::format(" [{}]", column+row*columns);
+          buf += fmt::format(" :search: {}", column+row*columns);
         }
       }
     }


### PR DESCRIPTION
Implements #2082. The cell index is displayed in the same way the tile index is shown for a tilemap layer, as both values serve more or less the same purpose.

To try and avoid confusion, I've made it so the cell index only appears if the active layer is not a tilemap, else the tile index logic is used. I'd like some feedback on this as I'm not entirely sure how obvious this would be from the user's perspective.

Perhaps it'd be more clear if both values are displayed? I thought of using `()` parentheses for the cell index rather than `[]` brackets, so as to differentiate them. Maybe this could be done only when both indices are displayed.