### PR TITLE
Avoid crashing when applying a filter 

### DIFF
--- a/src/doc/image_iterator.h
+++ b/src/doc/image_iterator.h
@@ -182,7 +182,7 @@ namespace doc {
     }
 
     operator color_t() const {
-      return (*m_ptr & m_bit) ? 1: 0;
+      return m_ptr && (*m_ptr & m_bit) ? 1: 0;
     }
 
     BitPixelAccess& operator=(color_t value) {
@@ -319,6 +319,9 @@ namespace doc {
 
     ImageIteratorT& operator++() {
       ASSERT(m_image->bounds().contains(gfx::Point(m_x, m_y)));
+
+      if (!m_ptr)
+        return *this;
 
       ++m_x;
       ++m_subPixel;


### PR DESCRIPTION
This PR fixes #4496...kind of...because I wasn't able to reproduce the issue by using Aseprite, I had to put some code to force the issue while debugging the program. So the best I was able to do is to avoid the crash by adding some tests to prevent the usage of a null pointer member variable.
