### PR TITLE
Improve font search/selection from the context bar

### DIFF
--- a/src/app/commands/cmd_paste_text.cpp
+++ b/src/app/commands/cmd_paste_text.cpp
@@ -57,7 +57,7 @@ class PasteTextWindow : public app::gen::PasteText {
 public:
   PasteTextWindow(const FontInfo& fontInfo,
                   const app::Color& color) {
-    fontFace()->setInfo(fontInfo);
+    fontFace()->setInfo(fontInfo, FontEntry::From::Init);
     fontColor()->setColor(color);
   }
 

--- a/src/app/ui/context_bar.cpp
+++ b/src/app/ui/context_bar.cpp
@@ -1877,10 +1877,10 @@ class ContextBar::FontSelector : public FontEntry {
 public:
   FontSelector(ContextBar* contextBar) {
     // Load the font from the preferences
-    setInfo(FontInfo::getFromPreferences());
+    setInfo(FontInfo::getFromPreferences(), FontEntry::From::Init);
 
-    FontChange.connect([contextBar](){
-      contextBar->FontChange();
+    FontChange.connect([contextBar](const FontInfo& fontInfo, From from) {
+      contextBar->FontChange(fontInfo, from);
     });
   }
 

--- a/src/app/ui/context_bar.h
+++ b/src/app/ui/context_bar.h
@@ -17,6 +17,7 @@
 #include "app/tools/tool_loop_modifiers.h"
 #include "app/ui/context_bar_observer.h"
 #include "app/ui/doc_observer_widget.h"
+#include "app/ui/font_entry.h"
 #include "doc/brush.h"
 #include "obs/connection.h"
 #include "obs/observable.h"
@@ -103,7 +104,7 @@ namespace app {
 
     // Signals
     obs::signal<void()> BrushChange;
-    obs::signal<void()> FontChange;
+    obs::signal<void(const FontInfo&, FontEntry::From)> FontChange;
 
   protected:
     void onInitTheme(ui::InitThemeEvent& ev) override;

--- a/src/app/ui/editor/writing_text_state.cpp
+++ b/src/app/ui/editor/writing_text_state.cpp
@@ -505,9 +505,9 @@ void WritingTextState::onBeforeCommandExecution(CommandExecutionEvent& ev)
   }
 }
 
-void WritingTextState::onFontChange()
+void WritingTextState::onFontChange(const FontInfo& fontInfo,
+                                    FontEntry::From fromField)
 {
-  const FontInfo fontInfo = App::instance()->contextBar()->fontInfo();
   if (auto font = get_font_from_info(fontInfo)) {
     m_entry->setFont(font);
     m_entry->invalidate();
@@ -517,10 +517,10 @@ void WritingTextState::onFontChange()
     // immediately.
     auto dummy = m_entry->extraCel();
 
-    ui::execute_from_ui_thread([this]{
+    if (fromField == FontEntry::From::Popup) {
       if (m_entry)
         m_entry->requestFocus();
-    });
+    }
   }
 }
 

--- a/src/app/ui/editor/writing_text_state.h
+++ b/src/app/ui/editor/writing_text_state.h
@@ -10,11 +10,13 @@
 
 #include "app/ui/editor/delayed_mouse_move.h"
 #include "app/ui/editor/standby_state.h"
+#include "app/ui/font_entry.h"
 
 #include <memory>
 
 namespace app {
   class CommandExecutionEvent;
+  class FontInfo;
 
   class WritingTextState : public StandbyState
                          , DelayedMouseMoveDelegate {
@@ -47,7 +49,8 @@ namespace app {
 
     gfx::Rect calcEntryBounds();
     void onBeforeCommandExecution(CommandExecutionEvent& ev);
-    void onFontChange();
+    void onFontChange(const FontInfo& fontInfo,
+                      FontEntry::From fromField);
     void cancel();
     void drop();
 

--- a/src/app/ui/font_entry.h
+++ b/src/app/ui/font_entry.h
@@ -23,32 +23,36 @@ namespace app {
   class FontEntry : public ui::HBox {
   public:
     enum class From {
-      User,
+      Init,
       Face,
       Size,
       Style,
       Flags,
+      Popup,
     };
 
     FontEntry();
     ~FontEntry();
 
     FontInfo info() { return m_info; }
-    void setInfo(const FontInfo& info, From from = From::User);
+    void setInfo(const FontInfo& info, From from);
 
-    obs::signal<void(const FontInfo&)> FontChange;
+    obs::signal<void(const FontInfo&, From)> FontChange;
 
   private:
 
     class FontFace : public SearchEntry {
     public:
       FontFace();
-      obs::signal<void(const FontInfo&)> FontChange;
+      obs::signal<void(const FontInfo&, From)> FontChange;
     protected:
       bool onProcessMessage(ui::Message* msg) override;
       void onChange() override;
     private:
+      FontEntry* fontEntry() const { return static_cast<FontEntry*>(parent()); }
+
       std::unique_ptr<FontPopup> m_popup;
+      bool m_fromEntryChange = false;
     };
 
     class FontSize : public ui::ComboBox {
@@ -74,6 +78,7 @@ namespace app {
     FontStyle m_style;
     FontLigatures m_ligatures;
     ui::CheckBox m_antialias;
+    bool m_lockFace = false;
   };
 
 } // namespace app

--- a/src/app/ui/font_popup.cpp
+++ b/src/app/ui/font_popup.cpp
@@ -185,6 +185,14 @@ bool FontPopup::FontListBox::onProcessMessage(ui::Message* msg)
   return result;
 }
 
+bool FontPopup::FontListBox::onAcceptKeyInput()
+{
+  // Always accept a kKeyDownMessage so we can get Up/Down keyboard
+  // messages from the FontEntry field (when the user is editing the
+  // font name).
+  return true;
+}
+
 FontPopup::FontPopup(const FontInfo& fontInfo)
   : PopupWindow(std::string(),
                 ClickBehavior::CloseOnClickInOtherWindow,
@@ -299,11 +307,6 @@ FontPopup::~FontPopup()
   m_timer.stop();
 }
 
-void FontPopup::focusListBox()
-{
-  m_listBox.requestFocus();
-}
-
 void FontPopup::setSearchText(const std::string& searchText)
 {
   FontItem* firstItem = nullptr;
@@ -353,7 +356,7 @@ void FontPopup::onFontChange()
 {
   const FontInfo fontInfo = selectedFont();
   if (fontInfo.isValid())
-    ChangeFont(fontInfo);
+    FontChange(fontInfo);
 }
 
 void FontPopup::onLoadFont()
@@ -372,7 +375,7 @@ void FontPopup::onLoadFont()
     return;
 
   ASSERT(!face.empty());
-  ChangeFont(FontInfo(FontInfo::Type::File,
+  FontChange(FontInfo(FontInfo::Type::File,
                       face.front()));
 }
 

--- a/src/app/ui/font_popup.h
+++ b/src/app/ui/font_popup.h
@@ -31,24 +31,24 @@ namespace app {
     class FontListBox : public ui::ListBox {
     protected:
       bool onProcessMessage(ui::Message* msg) override;
+      bool onAcceptKeyInput() override;
     };
 
     FontPopup(const FontInfo& fontInfo);
     ~FontPopup();
 
-    void focusListBox();
     void setSearchText(const std::string& searchText);
 
     void showPopup(ui::Display* display,
                    const gfx::Rect& buttonBounds);
 
     FontListBox* getListBox() { return &m_listBox; }
+    FontInfo selectedFont();
 
-    obs::signal<void(const FontInfo&)> ChangeFont;
+    obs::signal<void(const FontInfo&)> FontChange;
     obs::signal<void()> EscKey;
 
   protected:
-    FontInfo currentFontInfo();
     void onFontChange();
     void onLoadFont();
     void onThumbnailGenerated();
@@ -56,8 +56,6 @@ namespace app {
     bool onProcessMessage(ui::Message* msg) override;
 
   private:
-    FontInfo selectedFont();
-
     gen::FontPopup* m_popup;
     FontListBox m_listBox;
     ui::Timer m_timer;

--- a/src/ui/listbox.cpp
+++ b/src/ui/listbox.cpp
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2019-2022  Igara Studio S.A.
+// Copyright (C) 2019-2024  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -283,7 +283,7 @@ bool ListBox::onProcessMessage(Message* msg)
     }
 
     case kKeyDownMessage:
-      if (hasFocus() && !children().empty()) {
+      if (onAcceptKeyInput() && !children().empty()) {
         int select = getSelectedIndex();
         int bottom = std::max(0, int(children().size()-1));
         View* view = View::getView(this);
@@ -418,6 +418,11 @@ void ListBox::onChange()
 void ListBox::onDoubleClickItem()
 {
   DoubleClickItem();
+}
+
+bool ListBox::onAcceptKeyInput()
+{
+  return hasFocus();
 }
 
 int ListBox::advanceIndexThroughVisibleItems(

--- a/src/ui/listbox.h
+++ b/src/ui/listbox.h
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2020-2022  Igara Studio S.A.
+// Copyright (C) 2020-2024  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -48,6 +48,7 @@ namespace ui {
     virtual void onSizeHint(SizeHintEvent& ev) override;
     virtual void onChange();
     virtual void onDoubleClickItem();
+    virtual bool onAcceptKeyInput();
 
     int advanceIndexThroughVisibleItems(
       int startIndex, int delta, const bool loop);


### PR DESCRIPTION
Part of #4692. Now it's easier to search for a specific font and go back to the Text tool box.