### PR TITLE
Fix MouseEnter and MouseLeave

### DIFF
--- a/src/ui/manager.cpp
+++ b/src/ui/manager.cpp
@@ -498,6 +498,7 @@ void Manager::generateMessagesFromOSEvents()
           set_mouse_cursor(kArrowCursor);
           mouse_display = display;
         });
+        msg->setRecipient(this);
         enqueueMessage(msg);
         lastMouseMoveEvent = osEvent;
         break;
@@ -513,7 +514,7 @@ void Manager::generateMessagesFromOSEvents()
             mouse_display = nullptr;
           }
         });
-
+        msg->setRecipient(this);
         enqueueMessage(msg);
 
         // To avoid calling kSetCursorMessage when the mouse leaves
@@ -1664,6 +1665,11 @@ bool Manager::onProcessMessage(Message* msg)
       }
       else
         return false;
+    }
+    case kCallbackMessage: {
+      CallbackMessage* callback = static_cast<CallbackMessage*>(msg);
+      callback->call();
+      return true;
     }
 
   }

--- a/src/ui/manager.cpp
+++ b/src/ui/manager.cpp
@@ -1666,11 +1666,6 @@ bool Manager::onProcessMessage(Message* msg)
       else
         return false;
     }
-    case kCallbackMessage: {
-      CallbackMessage* callback = static_cast<CallbackMessage*>(msg);
-      callback->call();
-      return true;
-    }
 
   }
 

--- a/src/ui/widget.cpp
+++ b/src/ui/widget.cpp
@@ -1604,6 +1604,11 @@ bool Widget::onProcessMessage(Message* msg)
         return true;
       }
       break;
+    case kCallbackMessage: {
+      CallbackMessage* callback = static_cast<CallbackMessage*>(msg);
+      callback->call();
+      return true;
+    }
 
   }
 


### PR DESCRIPTION
Callback messages were not being handled and since MouseEnter and MouseLeave events were wrapped into CallbackMessages they were lost and so never got called. 
Fix #4240.


