### PR TITLE
Refactor MouseEnter and MouseLeave events

### DIFF
--- a/src/ui/manager.cpp
+++ b/src/ui/manager.cpp
@@ -488,34 +488,29 @@ void Manager::generateMessagesFromOSEvents()
       }
 
       case os::Event::MouseEnter: {
-        auto msg = new CallbackMessage([osEvent, display]{
-          if (get_multiple_displays()) {
-            if (osEvent.window()) {
-              ASSERT(display != nullptr);
-              _internal_set_mouse_display(display);
-            }
+        if (get_multiple_displays()) {
+          if (osEvent.window()) {
+            ASSERT(display != nullptr);
+            _internal_set_mouse_display(display);
           }
-          set_mouse_cursor(kArrowCursor);
-          mouse_display = display;
-        });
-        msg->setRecipient(this);
-        enqueueMessage(msg);
+        }
+        set_mouse_cursor(kArrowCursor);
+        mouse_display = display;
+
+        auto* widget = pick(osEvent.position());
+        setMouse(widget);
         lastMouseMoveEvent = osEvent;
         break;
       }
 
       case os::Event::MouseLeave: {
-        auto msg = new CallbackMessage([this, display]{
-          if (mouse_display == display) {
-            set_mouse_cursor(kOutsideDisplay);
-            setMouse(nullptr);
+        if (mouse_display == display) {
+          set_mouse_cursor(kOutsideDisplay);
+          setMouse(nullptr);
 
-            _internal_no_mouse_position();
-            mouse_display = nullptr;
-          }
-        });
-        msg->setRecipient(this);
-        enqueueMessage(msg);
+          _internal_no_mouse_position();
+          mouse_display = nullptr;
+        }
 
         // To avoid calling kSetCursorMessage when the mouse leaves
         // the window.

--- a/src/ui/manager.cpp
+++ b/src/ui/manager.cpp
@@ -1012,13 +1012,6 @@ void Manager::setMouse(Widget* widget)
     msg->setPropagateToParent(true);
     msg->setCommonAncestor(commonAncestor);
     enqueueMessage(msg);
-
-    // Remove HAS_MOUSE from all the hierarchy
-    auto a = mouse_widget;
-    while (a && a != commonAncestor) {
-      a->disableFlags(HAS_MOUSE);
-      a = a->parent();
-    }
   }
 
   // If the mouse is captured, we can just put the HAS_MOUSE flag in
@@ -1049,13 +1042,6 @@ void Manager::setMouse(Widget* widget)
                              mousePos,
                              kKeyUninitializedModifier,
                              PointerType::Unknown);
-
-    // Add HAS_MOUSE to all the hierarchy
-    auto a = mouse_widget;
-    while (a && a != commonAncestor) {
-      a->enableFlags(HAS_MOUSE);
-      a = a->parent();
-    }
   }
 }
 

--- a/src/ui/tooltips.cpp
+++ b/src/ui/tooltips.cpp
@@ -85,7 +85,7 @@ bool TooltipManager::onProcessMessage(Message* msg)
           m_timer->start();
         }
       }
-      break;
+      return false;
     }
 
     case kKeyDownMessage:

--- a/src/ui/widget.cpp
+++ b/src/ui/widget.cpp
@@ -1620,6 +1620,14 @@ bool Widget::onProcessMessage(Message* msg)
       else
         break;
 
+    case kMouseEnterMessage:
+      enableFlags(HAS_MOUSE);
+      return true;
+
+    case kMouseLeaveMessage:
+      disableFlags(HAS_MOUSE);
+      return true;
+
     case kSetCursorMessage:
       // Propagate the message to the parent.
       if (parent())


### PR DESCRIPTION
Instead of wrapping the MouseEnter and MouseLeave OS events handling inside a UI CallbackMessage, we now enqueue the corresponding kMouseEnterMessage and kMouseLeaveMessage.
This is actually almost the same we were doing before using the CallbackMessage, but here I'm adding a couple of lines to set the mouse widget (and thus enqueue the UI message) when a `os::Event::MouseEnter` is received.
Also, the HAS_MOUSE flag setting was moved to the Widget class, making it simpler because it takes advantage of the fact that the MouseEnterMessage/MouseLeaveMessage are propagated to the parent already, so each widget can set the state of its own flag. This also has the benefit that we avoid to disable the HAS_MOUSE flag before the MouseLeaveMessage is handled by the widgets, so they have a chance to know if they had the mouse before the MouseLeaveMessage. 
 