### PR TITLE
Fix kMouseEnterMessage and kMouseLeaveMessage handling 

### DIFF
--- a/src/ui/widget.cpp
+++ b/src/ui/widget.cpp
@@ -1622,11 +1622,11 @@ bool Widget::onProcessMessage(Message* msg)
 
     case kMouseEnterMessage:
       enableFlags(HAS_MOUSE);
-      return true;
+      break;
 
     case kMouseLeaveMessage:
       disableFlags(HAS_MOUSE);
-      return true;
+      break;
 
     case kSetCursorMessage:
       // Propagate the message to the parent.


### PR DESCRIPTION
It was returning immediately when handling kMouseEnterMessage and kMouseLeaveMessage instead of continuing with the propagation logic.
Fix #4753