### PR TITLE
Add function to copy non-shared properties between cels

### DIFF
--- a/src/app/doc.cpp
+++ b/src/app/doc.cpp
@@ -528,7 +528,7 @@ void Doc::copyLayerContent(const Layer* sourceLayer0, Doc* destDoc, Layer* destL
       if (it != linked.end()) {
         newCel.reset(Cel::MakeLink(sourceCel->frame(),
                                    it->second));
-        newCel->setZIndex(sourceCel->zIndex());
+        newCel->copyNonsharedPropertiesFrom(sourceCel);
       }
       else {
         newCel.reset(create_cel_copy(nullptr, // TODO add undo information?

--- a/src/app/doc_api.cpp
+++ b/src/app/doc_api.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2021  Igara Studio S.A.
+// Copyright (C) 2019-2024  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -94,7 +94,7 @@ DocApi::HandleLinkedCels::HandleLinkedCels(
         // Copy data that belongs to the original Cel itself (no the
         // shared CelData) like the z-index.
         if (Cel* dstCel = dstLayer->cel(dstFrame)) {
-          dstCel->setZIndex(srcCel->zIndex());
+          dstCel->copyNonsharedPropertiesFrom(srcCel);
         }
 
         m_created = true;

--- a/src/app/util/cel_ops.cpp
+++ b/src/app/util/cel_ops.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2023  Igara Studio S.A.
+// Copyright (C) 2019-2024  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -339,7 +339,7 @@ Cel* create_cel_copy(CmdSequence* cmds,
     dstFrame, ImageRef(Image::create(dstPixelFormat, dstSize.w, dstSize.h)));
 
   dstCel->setOpacity(srcCel->opacity());
-  dstCel->setZIndex(srcCel->zIndex());
+  dstCel->copyNonsharedPropertiesFrom(srcCel);
   dstCel->data()->setUserData(srcCel->data()->userData());
 
   // Special case were we copy from a tilemap...

--- a/src/doc/cel.cpp
+++ b/src/doc/cel.cpp
@@ -1,5 +1,5 @@
 // Aseprite Document Library
-// Copyright (c) 2019-2023 Igara Studio S.A.
+// Copyright (c) 2019-2024 Igara Studio S.A.
 // Copyright (c) 2001-2016 David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -46,7 +46,7 @@ Cel* Cel::MakeCopy(const frame_t newFrame,
 
   cel->setPosition(other->position());
   cel->setOpacity(other->opacity());
-  cel->setZIndex(other->zIndex());
+  cel->copyNonsharedPropertiesFrom(other);
   return cel;
 }
 
@@ -55,7 +55,7 @@ Cel* Cel::MakeLink(const frame_t newFrame,
                    const Cel* other)
 {
   Cel* cel = new Cel(newFrame, other->dataRef());
-  cel->setZIndex(other->zIndex());
+  cel->copyNonsharedPropertiesFrom(other);
   return cel;
 }
 
@@ -168,6 +168,11 @@ Grid Cel::grid() const
       return m_layer->grid();
   }
   return Grid();
+}
+
+void Cel::copyNonsharedPropertiesFrom(const Cel* fromCel)
+{
+  setZIndex(fromCel->zIndex());
 }
 
 void Cel::fixupImage()

--- a/src/doc/cel.h
+++ b/src/doc/cel.h
@@ -1,5 +1,5 @@
 // Aseprite Document Library
-// Copyright (c) 2019-2023 Igara Studio S.A.
+// Copyright (c) 2019-2024 Igara Studio S.A.
 // Copyright (c) 2001-2016 David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -71,6 +71,10 @@ namespace doc {
 
     void setParentLayer(LayerImage* layer);
     Grid grid() const;
+
+    // Copies properties that are not shared between linked cels
+    // (CelData), like the z-index.
+    void copyNonsharedPropertiesFrom(const Cel* fromCel);
 
   private:
     void fixupImage();


### PR DESCRIPTION
At the moment it's the z-index, but if in the future we add new non-shared properties, we can move those here.