### PR TITLE
Fix locking a layer reverts changes (fix #4586)

### DIFF
--- a/src/app/commands/cmd_layer_lock.cpp
+++ b/src/app/commands/cmd_layer_lock.cpp
@@ -1,11 +1,12 @@
 // Aseprite
+// Copyright (C) 2024  Igara Studio S.A.
 // Copyright (C) 2017  David Capello
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
 
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+  #include "config.h"
 #endif
 
 #include "app/app.h"
@@ -44,8 +45,7 @@ bool LayerLockCommand::onEnabled(Context* context)
 bool LayerLockCommand::onChecked(Context* context)
 {
   const ContextReader reader(context);
-  if (!reader.document() ||
-      !reader.layer())
+  if (!reader.document() || !reader.layer())
     return false;
 
   SelectedLayers selLayers;
@@ -67,6 +67,7 @@ bool LayerLockCommand::onChecked(Context* context)
 void LayerLockCommand::onExecute(Context* context)
 {
   ContextWriter writer(context);
+  Doc* doc = writer.document();
   SelectedLayers selLayers;
   auto range = App::instance()->timeline()->range();
   if (range.enabled()) {
@@ -80,9 +81,8 @@ void LayerLockCommand::onExecute(Context* context)
     if (!layer->isEditable())
       anyLock = true;
   }
-  for (auto layer : selLayers) {
-    layer->setEditable(anyLock);
-  }
+  for (auto layer : selLayers)
+    doc->setLayerEditableWithNotifications(layer, anyLock);
 
   update_screen_for_document(writer.document());
 }
@@ -92,4 +92,4 @@ Command* CommandFactory::createLayerLockCommand()
   return new LayerLockCommand;
 }
 
-} // namespace app
+}  // namespace app

--- a/src/app/doc.h
+++ b/src/app/doc.h
@@ -30,270 +30,283 @@
 #include <string>
 
 namespace doc {
-  class Cel;
-  class Layer;
-  class LayerTilemap;
-  class Mask;
-  class Sprite;
-  class Tileset;
-}
+class Cel;
+class Layer;
+class LayerTilemap;
+class Mask;
+class Sprite;
+class Tileset;
+}  // namespace doc
 
 namespace gfx {
-  class Region;
+class Region;
 }
 
 namespace app {
 
-  class Context;
-  class DocApi;
-  class DocUndo;
-  class Transaction;
+class Context;
+class DocApi;
+class DocUndo;
+class Transaction;
 
-  using namespace doc;
+using namespace doc;
 
-  enum DuplicateType {
-    DuplicateExactCopy,
-    DuplicateWithFlattenLayers,
+enum DuplicateType {
+  DuplicateExactCopy,
+  DuplicateWithFlattenLayers,
+};
+
+// An application document. It is the class used to contain one file
+// opened and being edited by the user (a sprite).
+class Doc : public doc::Document,
+            public obs::observable<DocObserver> {
+  enum Flags {
+    kAssociatedToFile =
+      1,               // This sprite is associated to a file in the file-system
+    kMaskVisible = 2,  // The mask wasn't hidden by the user
+    kInhibitBackup = 4,  // Inhibit the backup process
+    kFullyBackedUp = 8,  // Full backup was done
+    kReadOnly = 16,      // This document is read-only
   };
 
-  // An application document. It is the class used to contain one file
-  // opened and being edited by the user (a sprite).
-  class Doc : public doc::Document,
-              public obs::observable<DocObserver> {
-    enum Flags {
-      kAssociatedToFile = 1, // This sprite is associated to a file in the file-system
-      kMaskVisible      = 2, // The mask wasn't hidden by the user
-      kInhibitBackup    = 4, // Inhibit the backup process
-      kFullyBackedUp    = 8, // Full backup was done
-      kReadOnly         = 16,// This document is read-only
-    };
-  public:
-    using LockResult = base::RWLock::LockResult;
+public:
+  using LockResult = base::RWLock::LockResult;
 
-    Doc(Sprite* sprite);
-    ~Doc();
+  Doc(Sprite* sprite);
+  ~Doc();
 
-    Context* context() const { return m_ctx; }
-    void setContext(Context* ctx);
+  Context* context() const { return m_ctx; }
+  void setContext(Context* ctx);
 
-    // Lock/unlock API (RWLock wrapper)
-    bool canWriteLockFromRead() const;
-    LockResult readLock(int timeout);
-    LockResult writeLock(int timeout);
-    LockResult upgradeToWrite(int timeout);
-    void downgradeToRead(LockResult lockResult);
-    void unlock(LockResult lockResult);
+  // Lock/unlock API (RWLock wrapper)
+  bool canWriteLockFromRead() const;
+  LockResult readLock(int timeout);
+  LockResult writeLock(int timeout);
+  LockResult upgradeToWrite(int timeout);
+  void downgradeToRead(LockResult lockResult);
+  void unlock(LockResult lockResult);
 
-    bool weakLock(std::atomic<base::RWLock::WeakLock>* weak_lock_flag);
-    void weakUnlock();
+  bool weakLock(std::atomic<base::RWLock::WeakLock>* weak_lock_flag);
+  void weakUnlock();
 
-    // Sets active/running transaction.
-    void setTransaction(Transaction* transaction);
-    Transaction* transaction() { return m_transaction; }
+  // Sets active/running transaction.
+  void setTransaction(Transaction* transaction);
+  Transaction* transaction() { return m_transaction; }
 
-    // Returns a high-level API: observable and undoable methods.
-    DocApi getApi(Transaction& transaction);
+  // Returns a high-level API: observable and undoable methods.
+  DocApi getApi(Transaction& transaction);
 
-    //////////////////////////////////////////////////////////////////////
-    // Main properties
+  //////////////////////////////////////////////////////////////////////
+  // Main properties
 
-    const DocUndo* undoHistory() const { return m_undo.get(); }
-    DocUndo* undoHistory() { return m_undo.get(); }
+  const DocUndo* undoHistory() const { return m_undo.get(); }
+  DocUndo* undoHistory() { return m_undo.get(); }
 
-    bool isUndoing() const;
+  bool isUndoing() const;
 
-    color_t bgColor() const;
-    color_t bgColor(Layer* layer) const;
+  color_t bgColor() const;
+  color_t bgColor(Layer* layer) const;
 
-    os::ColorSpaceRef osColorSpace() const { return m_osColorSpace; }
+  os::ColorSpaceRef osColorSpace() const { return m_osColorSpace; }
 
-    //////////////////////////////////////////////////////////////////////
-    // Modifications with notifications
+  //////////////////////////////////////////////////////////////////////
+  // Modifications with notifications
 
-    // Use this function to change the layer visibility and notify all
-    // DocObservers about this change (e.g. so the Editor can be
-    // invalidated/redrawn, MovingPixelsState can drop pixels, etc.)
-    void setLayerVisibilityWithNotifications(Layer* layer, const bool visible);
+  // Use this function to change the layer visibility and notify all
+  // DocObservers about this change (e.g. so the Editor can be
+  // invalidated/redrawn, MovingPixelsState can drop pixels, etc.)
+  void setLayerVisibilityWithNotifications(Layer* layer, const bool visible);
 
-    //////////////////////////////////////////////////////////////////////
-    // Notifications
+  // Use this function to change the layer editable flag and
+  // notify all DocObservers about this change (e.g. so the Editor
+  // can be invalidated/redrawn, MovingPixelsState can drop pixels,
+  // etc.)
+  void setLayerEditableWithNotifications(Layer* layer, const bool editable);
 
-    void notifyGeneralUpdate();
-    void notifyColorSpaceChanged();
-    void notifyPaletteChanged();
-    void notifySpritePixelsModified(Sprite* sprite, const gfx::Region& region, frame_t frame);
-    void notifyExposeSpritePixels(Sprite* sprite, const gfx::Region& region);
-    void notifyLayerMergedDown(Layer* srcLayer, Layer* targetLayer);
-    void notifyBeforeLayerVisibilityChange(Layer* layer, bool newState);
-    void notifyAfterLayerVisibilityChange(Layer* layer);
-    void notifyCelMoved(Layer* fromLayer, frame_t fromFrame, Layer* toLayer, frame_t toFrame);
-    void notifyCelCopied(Layer* fromLayer, frame_t fromFrame, Layer* toLayer, frame_t toFrame);
-    void notifySelectionChanged();
-    void notifySelectionBoundariesChanged();
-    void notifyTilesetChanged(Tileset* tileset);
-    void notifyLayerGroupCollapseChange(Layer* layer);
-    void notifyAfterAddTile(LayerTilemap* layer, frame_t frame, tile_index ti);
+  //////////////////////////////////////////////////////////////////////
+  // Notifications
 
-    //////////////////////////////////////////////////////////////////////
-    // File related properties
+  void notifyGeneralUpdate();
+  void notifyColorSpaceChanged();
+  void notifyPaletteChanged();
+  void notifySpritePixelsModified(Sprite* sprite,
+                                  const gfx::Region& region,
+                                  frame_t frame);
+  void notifyExposeSpritePixels(Sprite* sprite, const gfx::Region& region);
+  void notifyLayerMergedDown(Layer* srcLayer, Layer* targetLayer);
+  void notifyBeforeLayerVisibilityChange(Layer* layer, bool newState);
+  void notifyAfterLayerVisibilityChange(Layer* layer);
+  void notifyBeforeLayerEditableChange(Layer* layer, bool newState);
+  void notifyCelMoved(Layer* fromLayer,
+                      frame_t fromFrame,
+                      Layer* toLayer,
+                      frame_t toFrame);
+  void notifyCelCopied(Layer* fromLayer,
+                       frame_t fromFrame,
+                       Layer* toLayer,
+                       frame_t toFrame);
+  void notifySelectionChanged();
+  void notifySelectionBoundariesChanged();
+  void notifyTilesetChanged(Tileset* tileset);
+  void notifyLayerGroupCollapseChange(Layer* layer);
+  void notifyAfterAddTile(LayerTilemap* layer, frame_t frame, tile_index ti);
 
-    bool isModified() const;
-    bool isAssociatedToFile() const;
-    void markAsSaved();
+  //////////////////////////////////////////////////////////////////////
+  // File related properties
 
-    // You can use this to indicate that we've destroyed (or we cannot
-    // trust) the file associated with the document (e.g. when we
-    // cancel a Save operation in the middle). So it's impossible to
-    // back to the saved state using the UndoHistory.
-    void impossibleToBackToSavedState();
+  bool isModified() const;
+  bool isAssociatedToFile() const;
+  void markAsSaved();
 
-    // Returns true if it does make sense to create a backup in this
-    // document. For example, it doesn't make sense to create a backup
-    // for an unmodified document.
-    bool needsBackup() const;
+  // You can use this to indicate that we've destroyed (or we cannot
+  // trust) the file associated with the document (e.g. when we
+  // cancel a Save operation in the middle). So it's impossible to
+  // back to the saved state using the UndoHistory.
+  void impossibleToBackToSavedState();
 
-    // Can be used to avoid creating a backup when the file is in a
-    // unusual temporary state (e.g. when the file is resized to be
-    // exported with other size)
-    bool inhibitBackup() const;
-    void setInhibitBackup(const bool inhibitBackup);
+  // Returns true if it does make sense to create a backup in this
+  // document. For example, it doesn't make sense to create a backup
+  // for an unmodified document.
+  bool needsBackup() const;
 
-    void markAsBackedUp();
-    bool isFullyBackedUp() const;
+  // Can be used to avoid creating a backup when the file is in a
+  // unusual temporary state (e.g. when the file is resized to be
+  // exported with other size)
+  bool inhibitBackup() const;
+  void setInhibitBackup(const bool inhibitBackup);
 
-    // TODO This read-only flag might be confusing because it
-    //      indicates that the file was loaded from an incompatible
-    //      version (future unknown feature) and it's preferable to
-    //      mark the sprite as read-only to avoid overwriting unknown
-    //      data. If in the future we want to add the possibility to
-    //      mark a regular file as read-only, this flag'll need a new
-    //      name.
-    void markAsReadOnly();
-    bool isReadOnly() const;
-    void removeReadOnlyMark();
+  void markAsBackedUp();
+  bool isFullyBackedUp() const;
 
-    //////////////////////////////////////////////////////////////////////
-    // Loaded options from file
+  // TODO This read-only flag might be confusing because it
+  //      indicates that the file was loaded from an incompatible
+  //      version (future unknown feature) and it's preferable to
+  //      mark the sprite as read-only to avoid overwriting unknown
+  //      data. If in the future we want to add the possibility to
+  //      mark a regular file as read-only, this flag'll need a new
+  //      name.
+  void markAsReadOnly();
+  bool isReadOnly() const;
+  void removeReadOnlyMark();
 
-    void setFormatOptions(const FormatOptionsPtr& format_options);
-    FormatOptionsPtr formatOptions() const { return m_format_options; }
+  //////////////////////////////////////////////////////////////////////
+  // Loaded options from file
 
-    //////////////////////////////////////////////////////////////////////
-    // Boundaries
+  void setFormatOptions(const FormatOptionsPtr& format_options);
+  FormatOptionsPtr formatOptions() const { return m_format_options; }
 
-    void destroyMaskBoundaries();
-    void generateMaskBoundaries(const Mask* mask = nullptr);
+  //////////////////////////////////////////////////////////////////////
+  // Boundaries
 
-    const MaskBoundaries& maskBoundaries() const {
-      return m_maskBoundaries;
-    }
+  void destroyMaskBoundaries();
+  void generateMaskBoundaries(const Mask* mask = nullptr);
 
-    MaskBoundaries& maskBoundaries() {
-      return m_maskBoundaries;
-    }
+  const MaskBoundaries& maskBoundaries() const { return m_maskBoundaries; }
 
-    bool hasMaskBoundaries() const {
-      return !m_maskBoundaries.isEmpty();
-    }
+  MaskBoundaries& maskBoundaries() { return m_maskBoundaries; }
 
-    //////////////////////////////////////////////////////////////////////
-    // Extra Cel (it is used to draw pen preview, pixels in movement, etc.)
+  bool hasMaskBoundaries() const { return !m_maskBoundaries.isEmpty(); }
 
-    ExtraCelRef extraCel() const { return m_extraCel; }
-    void setExtraCel(const ExtraCelRef& extraCel) { m_extraCel = extraCel; }
+  //////////////////////////////////////////////////////////////////////
+  // Extra Cel (it is used to draw pen preview, pixels in movement, etc.)
 
-    //////////////////////////////////////////////////////////////////////
-    // Mask
+  ExtraCelRef extraCel() const { return m_extraCel; }
+  void setExtraCel(const ExtraCelRef& extraCel) { m_extraCel = extraCel; }
 
-    // Returns the current mask, it can be empty. The mask could be not
-    // empty but hidden to the user if the setMaskVisible(false) was
-    // used called before.
-    Mask* mask() const { return m_mask.get(); }
+  //////////////////////////////////////////////////////////////////////
+  // Mask
 
-    // Sets the current mask. The new mask will be visible by default,
-    // so you don't need to call setMaskVisible(true).
-    void setMask(const Mask* mask);
+  // Returns the current mask, it can be empty. The mask could be not
+  // empty but hidden to the user if the setMaskVisible(false) was
+  // used called before.
+  Mask* mask() const { return m_mask.get(); }
 
-    // Returns true only when the mask is not empty, and was not yet
-    // hidden using setMaskVisible (e.g. when the user "deselect the
-    // mask").
-    bool isMaskVisible() const;
+  // Sets the current mask. The new mask will be visible by default,
+  // so you don't need to call setMaskVisible(true).
+  void setMask(const Mask* mask);
 
-    // Changes the visibility state of the mask (it is useful only if
-    // the getMask() is not empty and the user can see that the mask is
-    // being hidden and shown to him).
-    void setMaskVisible(bool visible);
+  // Returns true only when the mask is not empty, and was not yet
+  // hidden using setMaskVisible (e.g. when the user "deselect the
+  // mask").
+  bool isMaskVisible() const;
 
-    //////////////////////////////////////////////////////////////////////
-    // Transformation
+  // Changes the visibility state of the mask (it is useful only if
+  // the getMask() is not empty and the user can see that the mask is
+  // being hidden and shown to him).
+  void setMaskVisible(bool visible);
 
-    Transformation getTransformation() const;
-    void setTransformation(const Transformation& transform);
-    void resetTransformation();
+  //////////////////////////////////////////////////////////////////////
+  // Transformation
 
-    //////////////////////////////////////////////////////////////////////
-    // Last point used to draw straight lines using freehand tools + Shift key
-    // (EditorCustomizationDelegate::isStraightLineFromLastPoint() modifier)
+  Transformation getTransformation() const;
+  void setTransformation(const Transformation& transform);
+  void resetTransformation();
 
-    static gfx::Point NoLastDrawingPoint();
-    gfx::Point lastDrawingPoint() const { return m_lastDrawingPoint; }
-    void setLastDrawingPoint(const gfx::Point& pos) { m_lastDrawingPoint = pos; }
+  //////////////////////////////////////////////////////////////////////
+  // Last point used to draw straight lines using freehand tools + Shift key
+  // (EditorCustomizationDelegate::isStraightLineFromLastPoint() modifier)
 
-    //////////////////////////////////////////////////////////////////////
-    // Copying
+  static gfx::Point NoLastDrawingPoint();
+  gfx::Point lastDrawingPoint() const { return m_lastDrawingPoint; }
+  void setLastDrawingPoint(const gfx::Point& pos) { m_lastDrawingPoint = pos; }
 
-    void copyLayerContent(const Layer* sourceLayer, Doc* destDoc, Layer* destLayer) const;
-    Doc* duplicate(DuplicateType type) const;
+  //////////////////////////////////////////////////////////////////////
+  // Copying
 
-    void close();
+  void copyLayerContent(const Layer* sourceLayer,
+                        Doc* destDoc,
+                        Layer* destLayer) const;
+  Doc* duplicate(DuplicateType type) const;
 
-  protected:
-    void onFileNameChange() override;
-    virtual void onContextChanged();
+  void close();
 
-  private:
-    void removeFromContext();
-    void updateOSColorSpace(bool appWideSignal);
+protected:
+  void onFileNameChange() override;
+  virtual void onContextChanged();
 
-    // The document is in the collection of documents of this context.
-    Context* m_ctx;
+private:
+  void removeFromContext();
+  void updateOSColorSpace(bool appWideSignal);
 
-    // Internal states of the document.
-    int m_flags;
+  // The document is in the collection of documents of this context.
+  Context* m_ctx;
 
-    // Read-Write locks.
-    base::RWLock m_rwLock;
+  // Internal states of the document.
+  int m_flags;
 
-    // Undo and redo information about the document.
-    std::unique_ptr<DocUndo> m_undo;
+  // Read-Write locks.
+  base::RWLock m_rwLock;
 
-    // Current transaction for this document (when this is commit(), a
-    // new undo command is added to m_undo).
-    Transaction* m_transaction;
+  // Undo and redo information about the document.
+  std::unique_ptr<DocUndo> m_undo;
 
-    // Selected mask region boundaries
-    doc::MaskBoundaries m_maskBoundaries;
+  // Current transaction for this document (when this is commit(), a
+  // new undo command is added to m_undo).
+  Transaction* m_transaction;
 
-    // Data to save the file in the same format that it was loaded
-    FormatOptionsPtr m_format_options;
+  // Selected mask region boundaries
+  doc::MaskBoundaries m_maskBoundaries;
 
-    // Extra cel used to draw extra stuff (e.g. editor's pen preview, pixels in movement, etc.)
-    ExtraCelRef m_extraCel;
+  // Data to save the file in the same format that it was loaded
+  FormatOptionsPtr m_format_options;
 
-    // Current mask.
-    std::unique_ptr<doc::Mask> m_mask;
+  // Extra cel used to draw extra stuff (e.g. editor's pen preview, pixels in movement, etc.)
+  ExtraCelRef m_extraCel;
 
-    // Current transformation.
-    Transformation m_transformation;
+  // Current mask.
+  std::unique_ptr<doc::Mask> m_mask;
 
-    gfx::Point m_lastDrawingPoint;
+  // Current transformation.
+  Transformation m_transformation;
 
-    // Last used color space to render a sprite.
-    os::ColorSpaceRef m_osColorSpace;
+  gfx::Point m_lastDrawingPoint;
 
-    DISABLE_COPYING(Doc);
-  };
+  // Last used color space to render a sprite.
+  os::ColorSpaceRef m_osColorSpace;
 
-} // namespace app
+  DISABLE_COPYING(Doc);
+};
+
+}  // namespace app
 
 #endif

--- a/src/app/doc_observer.h
+++ b/src/app/doc_observer.h
@@ -10,118 +10,121 @@
 #pragma once
 
 namespace doc {
-  class Remap;
+class Remap;
 }
 
 namespace app {
-  class Doc;
-  class DocEvent;
+class Doc;
+class DocEvent;
 
-  class DocObserver {
-  public:
-    virtual ~DocObserver() { }
+class DocObserver {
+public:
+  virtual ~DocObserver() { }
 
-    virtual void onCloseDocument(Doc* doc) { }
-    virtual void onFileNameChanged(Doc* doc) { }
+  virtual void onCloseDocument(Doc* doc) { }
+  virtual void onFileNameChanged(Doc* doc) { }
 
-    // General update. If an observer receives this event, it's because
-    // anything in the document could be changed.
-    virtual void onGeneralUpdate(DocEvent& ev) { }
+  // General update. If an observer receives this event, it's because
+  // anything in the document could be changed.
+  virtual void onGeneralUpdate(DocEvent& ev) { }
 
-    virtual void onColorSpaceChanged(DocEvent& ev) { }
-    virtual void onPixelFormatChanged(DocEvent& ev) { }
-    virtual void onPaletteChanged(DocEvent& ev) { }
+  virtual void onColorSpaceChanged(DocEvent& ev) { }
+  virtual void onPixelFormatChanged(DocEvent& ev) { }
+  virtual void onPaletteChanged(DocEvent& ev) { }
 
-    virtual void onAddLayer(DocEvent& ev) { }
-    virtual void onAddFrame(DocEvent& ev) { }
-    virtual void onAddCel(DocEvent& ev) { }
-    virtual void onAddSlice(DocEvent& ev) { }
-    virtual void onAddTag(DocEvent& ev) { }
+  virtual void onAddLayer(DocEvent& ev) { }
+  virtual void onAddFrame(DocEvent& ev) { }
+  virtual void onAddCel(DocEvent& ev) { }
+  virtual void onAddSlice(DocEvent& ev) { }
+  virtual void onAddTag(DocEvent& ev) { }
 
-    virtual void onBeforeRemoveLayer(DocEvent& ev) { }
-    virtual void onAfterRemoveLayer(DocEvent& ev) { }
+  virtual void onBeforeRemoveLayer(DocEvent& ev) { }
+  virtual void onAfterRemoveLayer(DocEvent& ev) { }
 
-    // Called when a frame is removed. It's called after the frame was
-    // removed, and the sprite's total number of frames is modified.
-    virtual void onRemoveFrame(DocEvent& ev) { }
-    virtual void onRemoveTag(DocEvent& ev) { }
-    virtual void onBeforeRemoveCel(DocEvent& ev) { }
-    virtual void onAfterRemoveCel(DocEvent& ev) { }
-    virtual void onRemoveSlice(DocEvent& ev) { }
+  // Called when a frame is removed. It's called after the frame was
+  // removed, and the sprite's total number of frames is modified.
+  virtual void onRemoveFrame(DocEvent& ev) { }
+  virtual void onRemoveTag(DocEvent& ev) { }
+  virtual void onBeforeRemoveCel(DocEvent& ev) { }
+  virtual void onAfterRemoveCel(DocEvent& ev) { }
+  virtual void onRemoveSlice(DocEvent& ev) { }
 
-    virtual void onSpriteSizeChanged(DocEvent& ev) { }
-    virtual void onSpriteTransparentColorChanged(DocEvent& ev) { }
-    virtual void onSpritePixelRatioChanged(DocEvent& ev) { }
-    virtual void onSpriteGridBoundsChanged(DocEvent& ev) { }
+  virtual void onSpriteSizeChanged(DocEvent& ev) { }
+  virtual void onSpriteTransparentColorChanged(DocEvent& ev) { }
+  virtual void onSpritePixelRatioChanged(DocEvent& ev) { }
+  virtual void onSpriteGridBoundsChanged(DocEvent& ev) { }
 
-    virtual void onLayerNameChange(DocEvent& ev) { }
-    virtual void onLayerOpacityChange(DocEvent& ev) { }
-    virtual void onLayerBlendModeChange(DocEvent& ev) { }
-    virtual void onLayerRestacked(DocEvent& ev) { }
-    virtual void onLayerMergedDown(DocEvent& ev) { }
+  virtual void onLayerNameChange(DocEvent& ev) { }
+  virtual void onLayerOpacityChange(DocEvent& ev) { }
+  virtual void onLayerBlendModeChange(DocEvent& ev) { }
+  virtual void onLayerRestacked(DocEvent& ev) { }
+  virtual void onLayerMergedDown(DocEvent& ev) { }
 
-    virtual void onCelMoved(DocEvent& ev) { }
-    virtual void onCelCopied(DocEvent& ev) { }
-    virtual void onCelFrameChanged(DocEvent& ev) { }
-    virtual void onCelPositionChanged(DocEvent& ev) { }
-    virtual void onCelOpacityChange(DocEvent& ev) { }
-    virtual void onCelZIndexChange(DocEvent& ev) { }
+  virtual void onCelMoved(DocEvent& ev) { }
+  virtual void onCelCopied(DocEvent& ev) { }
+  virtual void onCelFrameChanged(DocEvent& ev) { }
+  virtual void onCelPositionChanged(DocEvent& ev) { }
+  virtual void onCelOpacityChange(DocEvent& ev) { }
+  virtual void onCelZIndexChange(DocEvent& ev) { }
 
-    virtual void onUserDataChange(DocEvent& ev) { }
+  virtual void onUserDataChange(DocEvent& ev) { }
 
-    virtual void onFrameDurationChanged(DocEvent& ev) { }
+  virtual void onFrameDurationChanged(DocEvent& ev) { }
 
-    virtual void onImagePixelsModified(DocEvent& ev) { }
-    virtual void onSpritePixelsModified(DocEvent& ev) { }
-    virtual void onExposeSpritePixels(DocEvent& ev) { }
+  virtual void onImagePixelsModified(DocEvent& ev) { }
+  virtual void onSpritePixelsModified(DocEvent& ev) { }
+  virtual void onExposeSpritePixels(DocEvent& ev) { }
 
-    // When the number of total frames available is modified.
-    virtual void onTotalFramesChanged(DocEvent& ev) { }
+  // When the number of total frames available is modified.
+  virtual void onTotalFramesChanged(DocEvent& ev) { }
 
-    // The selection has changed.
-    virtual void onSelectionChanged(DocEvent& ev) { }
-    virtual void onSelectionBoundariesChanged(DocEvent& ev) { }
+  // The selection has changed.
+  virtual void onSelectionChanged(DocEvent& ev) { }
+  virtual void onSelectionBoundariesChanged(DocEvent& ev) { }
 
-    // When the tag range changes
-    virtual void onTagChange(DocEvent& ev) { }
+  // When the tag range changes
+  virtual void onTagChange(DocEvent& ev) { }
 
-    // When the tag is renamed
-    virtual void onTagRename(DocEvent& ev) { }
+  // When the tag is renamed
+  virtual void onTagRename(DocEvent& ev) { }
 
-    // Slices
-    virtual void onSliceNameChange(DocEvent& ev) { }
+  // Slices
+  virtual void onSliceNameChange(DocEvent& ev) { }
 
-    // The tileset has changed.
-    virtual void onTilesetChanged(DocEvent& ev) { }
+  // The tileset has changed.
+  virtual void onTilesetChanged(DocEvent& ev) { }
 
-    // The collapsed/expanded flag of a specific layer changed.
-    virtual void onLayerCollapsedChanged(DocEvent& ev) { }
+  // The collapsed/expanded flag of a specific layer changed.
+  virtual void onLayerCollapsedChanged(DocEvent& ev) { }
 
-    // The visibility flag of a specific layer is going to change/changed.
-    virtual void onBeforeLayerVisibilityChange(DocEvent& ev, bool newState) { }
-    virtual void onAfterLayerVisibilityChange(DocEvent& ev) { }
+  // The visibility flag of a specific layer is going to change/changed.
+  virtual void onBeforeLayerVisibilityChange(DocEvent& ev, bool newState) { }
 
-    // The tileset was remapped (e.g. when tiles are re-ordered).
-    virtual void onRemapTileset(DocEvent& ev, const doc::Remap& remap) { }
+  // The editable flag of a specific layer is going to change/changed.
+  virtual void onBeforeLayerEditableChange(DocEvent& ev, bool newState) { }
 
-    // When the tile management plugin property is changed.
-    virtual void onTileManagementPluginChange(DocEvent& ev) { }
+  virtual void onAfterLayerVisibilityChange(DocEvent& ev) { }
 
-    // When a new tilemap cel/tile is created in certain situations,
-    // like after drawing in an empty tilemap cel, or when we paste a
-    // cel into an empty tilemap cel, so a new tile is created.
-    //
-    // This is useful for a tile management plugin to know when a new
-    // tile is added automatically by the editor or the timeline
-    // through draw_image_into_new_tilemap_cel(), and the plugin can
-    // do some extra work with it.
-    //
-    // Warning: This must be triggered from the UI thread (because
-    // scripts will listen this event).
-    virtual void onAfterAddTile(DocEvent& ev) { }
+  // The tileset was remapped (e.g. when tiles are re-ordered).
+  virtual void onRemapTileset(DocEvent& ev, const doc::Remap& remap) { }
 
-  };
+  // When the tile management plugin property is changed.
+  virtual void onTileManagementPluginChange(DocEvent& ev) { }
 
-} // namespace app
+  // When a new tilemap cel/tile is created in certain situations,
+  // like after drawing in an empty tilemap cel, or when we paste a
+  // cel into an empty tilemap cel, so a new tile is created.
+  //
+  // This is useful for a tile management plugin to know when a new
+  // tile is added automatically by the editor or the timeline
+  // through draw_image_into_new_tilemap_cel(), and the plugin can
+  // do some extra work with it.
+  //
+  // Warning: This must be triggered from the UI thread (because
+  // scripts will listen this event).
+  virtual void onAfterAddTile(DocEvent& ev) { }
+};
+
+}  // namespace app
 
 #endif

--- a/src/app/ui/editor/editor.cpp
+++ b/src/app/ui/editor/editor.cpp
@@ -6,7 +6,7 @@
 // the End-User License Agreement for Aseprite.
 
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+  #include "config.h"
 #endif
 
 #include "app/ui/editor/editor.h"
@@ -89,18 +89,16 @@ class EditorPostRenderImpl : public EditorPostRender {
 public:
   EditorPostRenderImpl(Editor* editor, Graphics* g)
     : m_editor(editor)
-    , m_g(g) {
+    , m_g(g)
+  {
   }
 
-  Editor* getEditor() override {
-    return m_editor;
-  }
+  Editor* getEditor() override { return m_editor; }
 
-  Graphics* getGraphics() override {
-    return m_g;
-  }
+  Graphics* getGraphics() override { return m_g; }
 
-  void drawLine(gfx::Color color, int x1, int y1, int x2, int y2) override {
+  void drawLine(gfx::Color color, int x1, int y1, int x2, int y2) override
+  {
     gfx::Point a(x1, y1);
     gfx::Point b(x2, y2);
     a = m_editor->editorToScreen(a);
@@ -113,7 +111,8 @@ public:
     m_g->drawLine(color, a, b);
   }
 
-  void drawRect(gfx::Color color, const gfx::Rect& rc) override {
+  void drawRect(gfx::Color color, const gfx::Rect& rc) override
+  {
     gfx::Rect rc2 = m_editor->editorToScreen(rc);
     gfx::Rect bounds = m_editor->bounds();
     rc2.x -= bounds.x;
@@ -121,7 +120,8 @@ public:
     m_g->drawRect(color, rc2);
   }
 
-  void fillRect(gfx::Color color, const gfx::Rect& rc) override {
+  void fillRect(gfx::Color color, const gfx::Rect& rc) override
+  {
     gfx::Rect rc2 = m_editor->editorToScreen(rc);
     gfx::Rect bounds = m_editor->bounds();
     rc2.x -= bounds.x;
@@ -142,7 +142,7 @@ std::unique_ptr<EditorRender> Editor::m_renderEngine = nullptr;
 
 Editor::Editor(Doc* document, EditorFlags flags, EditorStatePtr state)
   : Widget(Editor::Type())
-  , m_state(state == nullptr ? std::make_shared<StandbyState>(): state)
+  , m_state(state == nullptr ? std::make_shared<StandbyState>() : state)
   , m_decorator(NULL)
   , m_document(document)
   , m_sprite(m_document->sprite())
@@ -180,15 +180,15 @@ Editor::Editor(Doc* document, EditorFlags flags, EditorStatePtr state)
 
   m_fgColorChangeConn =
     Preferences::instance().colorBar.fgColor.AfterChange.connect(
-      [this]{ onFgColorChange(); });
+      [this] { onFgColorChange(); });
 
   m_samplingChangeConn =
     Preferences::instance().editor.downsampling.AfterChange.connect(
-      [this]{ onSamplingChange(); });
+      [this] { onSamplingChange(); });
 
   m_contextBarBrushChangeConn =
     App::instance()->contextBar()->BrushChange.connect(
-      [this]{ onContextBarBrushChange(); });
+      [this] { onContextBarBrushChange(); });
 
   // Restore last site in preferences
   {
@@ -202,16 +202,21 @@ Editor::Editor(Doc* document, EditorFlags flags, EditorStatePtr state)
       setLayer(layers[layerIndex]);
   }
 
-  m_tiledConnBefore = m_docPref.tiled.BeforeChange.connect([this]{ onTiledModeBeforeChange(); });
-  m_tiledConn = m_docPref.tiled.AfterChange.connect([this]{ onTiledModeChange(); });
-  m_gridConn = m_docPref.grid.AfterChange.connect([this]{ invalidate(); });
-  m_pixelGridConn = m_docPref.pixelGrid.AfterChange.connect([this]{ invalidate(); });
-  m_bgConn = m_docPref.bg.AfterChange.connect([this]{ invalidate(); });
-  m_onionskinConn = m_docPref.onionskin.AfterChange.connect([this]{ invalidate(); });
-  m_symmetryModeConn = Preferences::instance().symmetryMode.enabled.AfterChange.connect([this]{ invalidateIfActive(); });
+  m_tiledConnBefore =
+    m_docPref.tiled.BeforeChange.connect([this] { onTiledModeBeforeChange(); });
+  m_tiledConn =
+    m_docPref.tiled.AfterChange.connect([this] { onTiledModeChange(); });
+  m_gridConn = m_docPref.grid.AfterChange.connect([this] { invalidate(); });
+  m_pixelGridConn =
+    m_docPref.pixelGrid.AfterChange.connect([this] { invalidate(); });
+  m_bgConn = m_docPref.bg.AfterChange.connect([this] { invalidate(); });
+  m_onionskinConn =
+    m_docPref.onionskin.AfterChange.connect([this] { invalidate(); });
+  m_symmetryModeConn =
+    Preferences::instance().symmetryMode.enabled.AfterChange.connect(
+      [this] { invalidateIfActive(); });
   m_showExtrasConn =
-    m_docPref.show.AfterChange.connect(
-      [this]{ onShowExtrasChange(); });
+    m_docPref.show.AfterChange.connect([this] { onShowExtrasChange(); });
 
   m_document->add_observer(this);
 
@@ -251,14 +256,12 @@ bool Editor::isUsingNewRenderEngine() const
     // TODO add an option to the ShaderRenderer to work as the "old"
     //      engine (screen pixel by screen pixel) or as the "new"
     //      engine (sprite pixel by sprite pixel)
-    (m_renderEngine->type() == EditorRender::Type::kShaderRenderer)
-    ||
+    (m_renderEngine->type() == EditorRender::Type::kShaderRenderer) ||
     (Preferences::instance().experimental.newRenderEngine()
      // Reference layers + zoom > 100% need the old render engine for
      // sub-pixel rendering.
-     && (!m_sprite->hasVisibleReferenceLayers()
-         || (m_proj.scaleX() <= 1.0
-             && m_proj.scaleY() <= 1.0)));
+     && (!m_sprite->hasVisibleReferenceLayers() ||
+         (m_proj.scaleX() <= 1.0 && m_proj.scaleY() <= 1.0)));
 }
 
 // static
@@ -348,7 +351,7 @@ void Editor::getInvalidDecoratoredRegion(gfx::Region& region)
     if (!m_perfInfoBounds.isEmpty())
       region |= gfx::Region(m_perfInfoBounds);
   }
-#endif // ENABLE_DEVMODE
+#endif  // ENABLE_DEVMODE
 }
 
 void Editor::setLayer(const Layer* layer)
@@ -379,18 +382,17 @@ void Editor::setLayer(const Layer* layer)
     newGrid = getSite().grid();
 
   if (m_document && changed) {
-    if (// If the onion skinning depends on the active layer
-        m_docPref.onionskin.currentLayer() ||
-        // If the user want to see the active layer edges...
-        m_docPref.show.layerEdges() ||
-        // If there is a different opacity for nonactive-layers
-        otherLayersOpacity() < 255 ||
-        // If the automatic cel guides are visible...
-        m_showGuidesThisCel ||
-        // If grid settings changed
-        (gridVisible &&
-         (oldGrid.tileSize() != newGrid.tileSize() ||
-          oldGrid.origin() != newGrid.origin()))) {
+    if (  // If the onion skinning depends on the active layer
+      m_docPref.onionskin.currentLayer() ||
+      // If the user want to see the active layer edges...
+      m_docPref.show.layerEdges() ||
+      // If there is a different opacity for nonactive-layers
+      otherLayersOpacity() < 255 ||
+      // If the automatic cel guides are visible...
+      m_showGuidesThisCel ||
+      // If grid settings changed
+      (gridVisible && (oldGrid.tileSize() != newGrid.tileSize() ||
+                       oldGrid.origin() != newGrid.origin()))) {
       // We've to redraw the whole editor
       invalidate();
     }
@@ -431,16 +433,13 @@ void Editor::getSite(Site* site) const
   site->layer(m_layer);
   site->frame(m_frame);
 
-  if (!m_selectedSlices.empty() &&
-      getCurrentEditorInk()->isSlice()) {
+  if (!m_selectedSlices.empty() && getCurrentEditorInk()->isSlice()) {
     site->selectedSlices(m_selectedSlices);
   }
 
   // TODO we should not access timeline directly here
   Timeline* timeline = App::instance()->timeline();
-  if (timeline &&
-      timeline->isVisible() &&
-      timeline->range().enabled()) {
+  if (timeline && timeline->isVisible() && timeline->range().enabled()) {
     site->range(timeline->range());
   }
 
@@ -497,9 +496,8 @@ void Editor::setScrollToCenter()
   gfx::Size canvas = canvasSize();
 
   setEditorScroll(
-    gfx::Point(
-      m_padding.x - vp.w/2 + m_proj.applyX(canvas.w)/2,
-      m_padding.y - vp.h/2 + m_proj.applyY(canvas.h)/2));
+    gfx::Point(m_padding.x - vp.w / 2 + m_proj.applyX(canvas.w) / 2,
+               m_padding.y - vp.h / 2 + m_proj.applyY(canvas.h) / 2));
 }
 
 void Editor::setScrollAndZoomToFitScreen()
@@ -509,8 +507,7 @@ void Editor::setScrollAndZoomToFitScreen()
   gfx::Size canvas = canvasSize();
   Zoom zoom = m_proj.zoom();
 
-  if (float(vp.w) / float(canvas.w) <
-      float(vp.h) / float(canvas.h)) {
+  if (float(vp.w) / float(canvas.w) < float(vp.h) / float(canvas.h)) {
     if (vp.w < m_proj.applyX(canvas.w)) {
       while (vp.w < m_proj.applyX(canvas.w)) {
         if (!zoom.out())
@@ -559,9 +556,8 @@ void Editor::setScrollAndZoomToFitScreen()
 
   updateEditor(false);
   setEditorScroll(
-    gfx::Point(
-      m_padding.x - vp.w/2 + m_proj.applyX(canvas.w)/2,
-      m_padding.y - vp.h/2 + m_proj.applyY(canvas.h)/2));
+    gfx::Point(m_padding.x - vp.w / 2 + m_proj.applyX(canvas.w) / 2,
+               m_padding.y - vp.h / 2 + m_proj.applyY(canvas.h) / 2));
 }
 
 // Sets the scroll position of the editor
@@ -573,8 +569,7 @@ void Editor::setEditorScroll(const gfx::Point& scroll)
 void Editor::setEditorZoom(const render::Zoom& zoom)
 {
   setZoomAndCenterInMouse(
-    zoom, mousePosInDisplay(),
-    Editor::ZoomBehavior::CENTER);
+    zoom, mousePosInDisplay(), Editor::ZoomBehavior::CENTER);
 }
 
 void Editor::updateEditor(const bool restoreScrollPos)
@@ -582,14 +577,16 @@ void Editor::updateEditor(const bool restoreScrollPos)
   View::getView(this)->updateView(restoreScrollPos);
 }
 
-void Editor::drawOneSpriteUnclippedRect(ui::Graphics* g, const gfx::Rect& spriteRectToDraw, int dx, int dy)
+void Editor::drawOneSpriteUnclippedRect(ui::Graphics* g,
+                                        const gfx::Rect& spriteRectToDraw,
+                                        int dx,
+                                        int dy)
 {
   // Clip from sprite and apply zoom
   gfx::Rect rc = m_sprite->bounds().createIntersection(spriteRectToDraw);
   rc = m_proj.apply(rc);
 
-  gfx::Rect dest(dx + m_padding.x + rc.x,
-                 dy + m_padding.y + rc.y, 0, 0);
+  gfx::Rect dest(dx + m_padding.x + rc.x, dy + m_padding.y + rc.y, 0, 0);
 
   // Clip from graphics/screen
   const gfx::Rect& clip = g->getClipBounds();
@@ -603,11 +600,11 @@ void Editor::drawOneSpriteUnclippedRect(ui::Graphics* g, const gfx::Rect& sprite
     rc.h -= clip.y - dest.y;
     dest.y = clip.y;
   }
-  if (dest.x+rc.w > clip.x+clip.w) {
-    rc.w = clip.x+clip.w-dest.x;
+  if (dest.x + rc.w > clip.x + clip.w) {
+    rc.w = clip.x + clip.w - dest.x;
   }
-  if (dest.y+rc.h > clip.y+clip.h) {
-    rc.h = clip.y+clip.h-dest.y;
+  if (dest.y + rc.h > clip.y + clip.h) {
+    rc.h = clip.y + clip.h - dest.y;
   }
 
   if (rc.isEmpty())
@@ -622,7 +619,7 @@ void Editor::drawOneSpriteUnclippedRect(ui::Graphics* g, const gfx::Rect& sprite
   // rendering process depending on each cel position.
   // E.g. when we are drawing in a cel with position < (0,0)
   if (m_proj.scaleX() < 1.0)
-    expose.enlargeXW(int(1./m_proj.scaleX()));
+    expose.enlargeXW(int(1. / m_proj.scaleX()));
   // If the zoom level is more than %100 we add an extra pixel to
   // expose just in case the zoom requires to display it.  Note:
   // this is really necessary to avoid showing invalid destination
@@ -631,14 +628,14 @@ void Editor::drawOneSpriteUnclippedRect(ui::Graphics* g, const gfx::Rect& sprite
     expose.enlargeXW(1);
 
   if (m_proj.scaleY() < 1.0)
-    expose.enlargeYH(int(1./m_proj.scaleY()));
+    expose.enlargeYH(int(1. / m_proj.scaleY()));
   else if (m_proj.scaleY() > 1.0)
     expose.enlargeYH(1);
 
   expose &= m_sprite->bounds();
 
-  const int maxw = std::max(0, m_sprite->width()-expose.x);
-  const int maxh = std::max(0, m_sprite->height()-expose.y);
+  const int maxw = std::max(0, m_sprite->width() - expose.x);
+  const int maxh = std::max(0, m_sprite->height() - expose.y);
   expose.w = std::clamp(expose.w, 0, maxw);
   expose.h = std::clamp(expose.h, 0, maxh);
   if (expose.isEmpty())
@@ -649,20 +646,21 @@ void Editor::drawOneSpriteUnclippedRect(ui::Graphics* g, const gfx::Rect& sprite
   const bool newEngine = isUsingNewRenderEngine();
   gfx::Rect rc2;
   if (newEngine) {
-    rc2 = expose;               // New engine, exposed rectangle (without zoom)
+    rc2 = expose;  // New engine, exposed rectangle (without zoom)
     dest.x = dx + m_padding.x + m_proj.applyX(rc2.x);
     dest.y = dy + m_padding.y + m_proj.applyY(rc2.y);
     dest.w = m_proj.applyX(rc2.w);
     dest.h = m_proj.applyY(rc2.h);
   }
   else {
-    rc2 = rc;                   // Old engine, same rectangle with zoom
+    rc2 = rc;  // Old engine, same rectangle with zoom
     dest.w = rc.w;
     dest.h = rc.h;
   }
 
   // Convert the render to a os::Surface
-  static os::SurfaceRef rendered = nullptr; // TODO move this to other centralized place
+  static os::SurfaceRef rendered =
+    nullptr;  // TODO move this to other centralized place
   const auto& renderProperties = m_renderEngine->properties();
   try {
     // Generate a "expose sprite pixels" notification. This is used by
@@ -681,17 +679,18 @@ void Editor::drawOneSpriteUnclippedRect(ui::Graphics* g, const gfx::Rect& sprite
       if (m_docPref.onionskin.active()) {
         OnionskinOptions opts(
           (m_docPref.onionskin.type() == app::gen::OnionskinType::MERGE ?
-           render::OnionskinType::MERGE:
-           (m_docPref.onionskin.type() == app::gen::OnionskinType::RED_BLUE_TINT ?
-            render::OnionskinType::RED_BLUE_TINT:
-            render::OnionskinType::NONE)));
+             render::OnionskinType::MERGE :
+             (m_docPref.onionskin.type() ==
+                  app::gen::OnionskinType::RED_BLUE_TINT ?
+                render::OnionskinType::RED_BLUE_TINT :
+                render::OnionskinType::NONE)));
 
         opts.position(m_docPref.onionskin.position());
         opts.prevFrames(m_docPref.onionskin.prevFrames());
         opts.nextFrames(m_docPref.onionskin.nextFrames());
         opts.opacityBase(m_docPref.onionskin.opacityBase());
         opts.opacityStep(m_docPref.onionskin.opacityStep());
-        opts.layer(m_docPref.onionskin.currentLayer() ? m_layer: nullptr);
+        opts.layer(m_docPref.onionskin.currentLayer() ? m_layer : nullptr);
 
         Tag* tag = nullptr;
         if (m_docPref.onionskin.loopTag())
@@ -703,18 +702,17 @@ void Editor::drawOneSpriteUnclippedRect(ui::Graphics* g, const gfx::Rect& sprite
     }
 
     ExtraCelRef extraCel = m_document->extraCel();
-    if (extraCel &&
-        extraCel->type() != render::ExtraType::NONE &&
+    if (extraCel && extraCel->type() != render::ExtraType::NONE &&
         // We render the extra cel if:
-        (// 1) it doesn't contains the brush preview (e.g. the user
-         // is transforming the selection),
-         extraCel->purpose() != ExtraCel::Purpose::BrushPreview
-         // 2) we are drawing the brush preview in a regular editor,
-         || !m_docView->isPreview()
-         // 3) we are drawing the brush preview in a preview editor
-         // and preferences (brushPreviewInPreview) says that we
-         // should do that.
-         || m_docPref.show.brushPreviewInPreview())) {
+        (  // 1) it doesn't contains the brush preview (e.g. the user
+          // is transforming the selection),
+          extraCel->purpose() != ExtraCel::Purpose::BrushPreview
+          // 2) we are drawing the brush preview in a regular editor,
+          || !m_docView->isPreview()
+          // 3) we are drawing the brush preview in a preview editor
+          // and preferences (brushPreviewInPreview) says that we
+          // should do that.
+          || m_docPref.show.brushPreviewInPreview())) {
       m_renderEngine->setExtraImage(extraCel->type(),
                                     extraCel->cel(),
                                     extraCel->image(),
@@ -737,18 +735,15 @@ void Editor::drawOneSpriteUnclippedRect(ui::Graphics* g, const gfx::Rect& sprite
     }
 
     // Create a temporary surface to draw the sprite on it
-    if (!rendered ||
-        rendered->width() < rc2.w ||
-        rendered->height() < rc2.h ||
+    if (!rendered || rendered->width() < rc2.w || rendered->height() < rc2.h ||
         rendered->colorSpace() != m_document->osColorSpace()) {
-      const int maxw = std::max(rc2.w, rendered ? rendered->width(): 0);
-      const int maxh = std::max(rc2.h, rendered ? rendered->height(): 0);
-      rendered = os::instance()->makeRgbaSurface(
-        maxw, maxh, m_document->osColorSpace());
+      const int maxw = std::max(rc2.w, rendered ? rendered->width() : 0);
+      const int maxh = std::max(rc2.h, rendered ? rendered->height() : 0);
+      rendered =
+        os::instance()->makeRgbaSurface(maxw, maxh, m_document->osColorSpace());
     }
 
-    m_renderEngine->setProjection(
-      newEngine ? render::Projection(): m_proj);
+    m_renderEngine->setProjection(newEngine ? render::Projection() : m_proj);
     m_renderEngine->renderSprite(
       rendered.get(), m_sprite, m_frame, gfx::Clip(0, 0, rc2));
 
@@ -767,7 +762,7 @@ void Editor::drawOneSpriteUnclippedRect(ui::Graphics* g, const gfx::Rect& sprite
     os::Paint p;
     if (newEngine) {
       os::Sampling sampling;
-      p.srcEdges(os::Paint::SrcEdges::Fast); // Enable mipmaps if possible
+      p.srcEdges(os::Paint::SrcEdges::Fast);  // Enable mipmaps if possible
 
       if (m_proj.scaleX() < 1.0) {
         switch (pref.editor.downsampling()) {
@@ -793,11 +788,8 @@ void Editor::drawOneSpriteUnclippedRect(ui::Graphics* g, const gfx::Rect& sprite
       else
         p.blendMode(os::BlendMode::Src);
 
-      g->drawSurface(rendered.get(),
-                     gfx::Rect(0, 0, rc2.w, rc2.h),
-                     dest,
-                     sampling,
-                     &p);
+      g->drawSurface(
+        rendered.get(), gfx::Rect(0, 0, rc2.w, rc2.h), dest, sampling, &p);
     }
     else {
       g->drawSurface(rendered.get(),
@@ -810,11 +802,10 @@ void Editor::drawOneSpriteUnclippedRect(ui::Graphics* g, const gfx::Rect& sprite
 
   // Draw grids
   {
-    gfx::Rect enclosingRect(
-      m_padding.x + dx,
-      m_padding.y + dy,
-      m_proj.applyX(m_sprite->width()),
-      m_proj.applyY(m_sprite->height()));
+    gfx::Rect enclosingRect(m_padding.x + dx,
+                            m_padding.y + dy,
+                            m_proj.applyX(m_sprite->width()),
+                            m_proj.applyY(m_sprite->height()));
 
     IntersectClip clip(g, dest);
     if (clip) {
@@ -823,12 +814,15 @@ void Editor::drawOneSpriteUnclippedRect(ui::Graphics* g, const gfx::Rect& sprite
         int alpha = m_docPref.pixelGrid.opacity();
 
         if (m_docPref.pixelGrid.autoOpacity()) {
-          alpha = int(alpha * (m_proj.zoom().scale()-2.) / (16.-2.));
+          alpha = int(alpha * (m_proj.zoom().scale() - 2.) / (16. - 2.));
           alpha = std::clamp(alpha, 0, 255);
         }
 
-        drawGrid(g, enclosingRect, Rect(0, 0, 1, 1),
-                 m_docPref.pixelGrid.color(), alpha);
+        drawGrid(g,
+                 enclosingRect,
+                 Rect(0, 0, 1, 1),
+                 m_docPref.pixelGrid.color(),
+                 alpha);
 
         // Save all pixel grid settings that are unset
         m_docPref.pixelGrid.forceSection();
@@ -841,20 +835,18 @@ void Editor::drawOneSpriteUnclippedRect(ui::Graphics* g, const gfx::Rect& sprite
         if (!m_state->getGridBounds(this, gridrc))
           gridrc = getSite().gridBounds();
 
-        if (m_proj.applyX(gridrc.w) > 2 &&
-            m_proj.applyY(gridrc.h) > 2) {
+        if (m_proj.applyX(gridrc.w) > 2 && m_proj.applyY(gridrc.h) > 2) {
           int alpha = m_docPref.grid.opacity();
 
           if (m_docPref.grid.autoOpacity()) {
-            double len = (m_proj.applyX(gridrc.w) +
-                          m_proj.applyY(gridrc.h)) / 2.;
+            double len =
+              (m_proj.applyX(gridrc.w) + m_proj.applyY(gridrc.h)) / 2.;
             alpha = int(alpha * len / 32.);
             alpha = std::clamp(alpha, 0, 255);
           }
 
           if (alpha > 8) {
-            drawGrid(g, enclosingRect, gridrc,
-                     m_docPref.grid.color(), alpha);
+            drawGrid(g, enclosingRect, gridrc, m_docPref.grid.color(), alpha);
           }
         }
 
@@ -895,15 +887,16 @@ void Editor::drawSpriteUnclippedRect(ui::Graphics* g, const gfx::Rect& _rc)
   gfx::Rect rc = _rc;
   // For odd zoom scales minor than 100% we have to add an extra window
   // just to make sure the whole rectangle is drawn.
-  if (m_proj.scaleX() < 1.0) rc.w += int(1./m_proj.scaleX());
-  if (m_proj.scaleY() < 1.0) rc.h += int(1./m_proj.scaleY());
+  if (m_proj.scaleX() < 1.0)
+    rc.w += int(1. / m_proj.scaleX());
+  if (m_proj.scaleY() < 1.0)
+    rc.h += int(1. / m_proj.scaleY());
 
   gfx::Rect client = clientBounds();
-  gfx::Rect spriteRect(
-    client.x + m_padding.x,
-    client.y + m_padding.y,
-    m_proj.applyX(m_sprite->width()),
-    m_proj.applyY(m_sprite->height()));
+  gfx::Rect spriteRect(client.x + m_padding.x,
+                       client.y + m_padding.y,
+                       m_proj.applyX(m_sprite->width()),
+                       m_proj.applyY(m_sprite->height()));
   gfx::Rect enclosingRect = spriteRect;
 
   // Draw the main sprite at the center.
@@ -912,27 +905,28 @@ void Editor::drawSpriteUnclippedRect(ui::Graphics* g, const gfx::Rect& _rc)
   // Document preferences
   if (int(m_docPref.tiled.mode()) & int(filters::TiledMode::X_AXIS)) {
     drawOneSpriteUnclippedRect(g, rc, spriteRect.w, 0);
-    drawOneSpriteUnclippedRect(g, rc, spriteRect.w*2, 0);
+    drawOneSpriteUnclippedRect(g, rc, spriteRect.w * 2, 0);
 
-    enclosingRect = gfx::Rect(spriteRect.x, spriteRect.y, spriteRect.w*3, spriteRect.h);
+    enclosingRect =
+      gfx::Rect(spriteRect.x, spriteRect.y, spriteRect.w * 3, spriteRect.h);
   }
 
   if (int(m_docPref.tiled.mode()) & int(filters::TiledMode::Y_AXIS)) {
     drawOneSpriteUnclippedRect(g, rc, 0, spriteRect.h);
-    drawOneSpriteUnclippedRect(g, rc, 0, spriteRect.h*2);
+    drawOneSpriteUnclippedRect(g, rc, 0, spriteRect.h * 2);
 
-    enclosingRect = gfx::Rect(spriteRect.x, spriteRect.y, spriteRect.w, spriteRect.h*3);
+    enclosingRect =
+      gfx::Rect(spriteRect.x, spriteRect.y, spriteRect.w, spriteRect.h * 3);
   }
 
   if (m_docPref.tiled.mode() == filters::TiledMode::BOTH) {
-    drawOneSpriteUnclippedRect(g, rc, spriteRect.w,   spriteRect.h);
-    drawOneSpriteUnclippedRect(g, rc, spriteRect.w*2, spriteRect.h);
-    drawOneSpriteUnclippedRect(g, rc, spriteRect.w,   spriteRect.h*2);
-    drawOneSpriteUnclippedRect(g, rc, spriteRect.w*2, spriteRect.h*2);
+    drawOneSpriteUnclippedRect(g, rc, spriteRect.w, spriteRect.h);
+    drawOneSpriteUnclippedRect(g, rc, spriteRect.w * 2, spriteRect.h);
+    drawOneSpriteUnclippedRect(g, rc, spriteRect.w, spriteRect.h * 2);
+    drawOneSpriteUnclippedRect(g, rc, spriteRect.w * 2, spriteRect.h * 2);
 
-    enclosingRect = gfx::Rect(
-      spriteRect.x, spriteRect.y,
-      spriteRect.w*3, spriteRect.h*3);
+    enclosingRect =
+      gfx::Rect(spriteRect.x, spriteRect.y, spriteRect.w * 3, spriteRect.h * 3);
   }
 
   // Draw slices
@@ -940,8 +934,7 @@ void Editor::drawSpriteUnclippedRect(ui::Graphics* g, const gfx::Rect& _rc)
     drawSlices(g);
 
   // Symmetry mode
-  if (isActive() &&
-      (m_flags & Editor::kShowSymmetryLine) &&
+  if (isActive() && (m_flags & Editor::kShowSymmetryLine) &&
       Preferences::instance().symmetryMode.enabled()) {
     int mode = int(m_docPref.symmetry.mode());
     if (mode & int(app::gen::SymmetryMode::HORIZONTAL)) {
@@ -949,7 +942,8 @@ void Editor::drawSpriteUnclippedRect(ui::Graphics* g, const gfx::Rect& _rc)
       if (x > 0) {
         gfx::Color color = color_utils::color_for_ui(m_docPref.grid.color());
         g->drawVLine(color,
-                     spriteRect.x + m_proj.applyX(mainTilePosition().x) + int(m_proj.applyX<double>(x)),
+                     spriteRect.x + m_proj.applyX(mainTilePosition().x) +
+                       int(m_proj.applyX<double>(x)),
                      enclosingRect.y,
                      enclosingRect.h);
       }
@@ -960,7 +954,8 @@ void Editor::drawSpriteUnclippedRect(ui::Graphics* g, const gfx::Rect& _rc)
         gfx::Color color = color_utils::color_for_ui(m_docPref.grid.color());
         g->drawHLine(color,
                      enclosingRect.x,
-                     spriteRect.y + m_proj.applyY(mainTilePosition().y) + int(m_proj.applyY<double>(y)),
+                     spriteRect.y + m_proj.applyY(mainTilePosition().y) +
+                       int(m_proj.applyY<double>(y)),
                      enclosingRect.w);
       }
     }
@@ -971,20 +966,19 @@ void Editor::drawSpriteUnclippedRect(ui::Graphics* g, const gfx::Rect& _rc)
       // Show layer edges and possibly cel guides only on states that
       // allows it (e.g scrolling state)
       m_state->allowLayerEdges()) {
-    Cel* cel = (m_layer ? m_layer->cel(m_frame): nullptr);
+    Cel* cel = (m_layer ? m_layer->cel(m_frame) : nullptr);
     if (cel) {
-      gfx::Color color = color_utils::color_for_ui(Preferences::instance().guides.layerEdgesColor());
+      gfx::Color color = color_utils::color_for_ui(
+        Preferences::instance().guides.layerEdgesColor());
       drawCelBounds(g, cel, color);
 
       // Draw tile numbers
-      if (m_docPref.show.tileNumbers() &&
-          cel->layer()->isTilemap()) {
+      if (m_docPref.show.tileNumbers() && cel->layer()->isTilemap()) {
         drawTileNumbers(g, cel);
       }
 
       // Draw auto-guides to other cel
-      if (m_showAutoCelGuides &&
-          m_showGuidesThisCel != cel) {
+      if (m_showAutoCelGuides && m_showGuidesThisCel != cel) {
         drawCelGuides(g, cel, m_showGuidesThisCel);
       }
     }
@@ -1027,8 +1021,7 @@ void Editor::drawSpriteClipped(const gfx::Region& updateRegion)
  */
 void Editor::drawMask(Graphics* g)
 {
-  if ((m_flags & kShowMask) == 0 ||
-      !m_docPref.show.selectionEdges())
+  if ((m_flags & kShowMask) == 0 || !m_docPref.show.selectionEdges())
     return;
 
   ASSERT(m_document->hasMaskBoundaries());
@@ -1043,7 +1036,8 @@ void Editor::drawMask(Graphics* g)
 
   ui::Paint paint;
   paint.style(ui::Paint::Stroke);
-  set_checkered_paint_mode(paint, m_antsOffset,
+  set_checkered_paint_mode(paint,
+                           m_antsOffset,
                            gfx::rgba(0, 0, 0, 255),
                            gfx::rgba(255, 255, 255, 255));
 
@@ -1060,9 +1054,7 @@ void Editor::drawMaskSafe()
   if ((m_flags & kShowMask) == 0)
     return;
 
-  if (isVisible() &&
-      m_document &&
-      m_document->hasMaskBoundaries()) {
+  if (isVisible() && m_document && m_document->hasMaskBoundaries()) {
     Region region;
     getDrawableRegion(region, kCutTopWindows);
     region.offset(-bounds().origin());
@@ -1078,7 +1070,11 @@ void Editor::drawMaskSafe()
   }
 }
 
-void Editor::drawGrid(Graphics* g, const gfx::Rect& spriteBounds, const Rect& gridBounds, const app::Color& color, int alpha)
+void Editor::drawGrid(Graphics* g,
+                      const gfx::Rect& spriteBounds,
+                      const Rect& gridBounds,
+                      const app::Color& color,
+                      int alpha)
 {
   if ((m_flags & kShowGrid) == 0)
     return;
@@ -1089,14 +1085,17 @@ void Editor::drawGrid(Graphics* g, const gfx::Rect& spriteBounds, const Rect& gr
     return;
 
   // Move the grid bounds to a non-negative position.
-  if (grid.x < 0) grid.x += (ABS(grid.x)/grid.w+1) * grid.w;
-  if (grid.y < 0) grid.y += (ABS(grid.y)/grid.h+1) * grid.h;
+  if (grid.x < 0)
+    grid.x += (ABS(grid.x) / grid.w + 1) * grid.w;
+  if (grid.y < 0)
+    grid.y += (ABS(grid.y) / grid.h + 1) * grid.h;
 
   // Change the grid position to the first grid's tile
-  grid.setOrigin(Point((grid.x % grid.w) - grid.w,
-                       (grid.y % grid.h) - grid.h));
-  if (grid.x < 0) grid.x += grid.w;
-  if (grid.y < 0) grid.y += grid.h;
+  grid.setOrigin(Point((grid.x % grid.w) - grid.w, (grid.y % grid.h) - grid.h));
+  if (grid.x < 0)
+    grid.x += grid.w;
+  if (grid.y < 0)
+    grid.y += grid.h;
 
   // Convert the "grid" rectangle to screen coordinates
   RectF gridF(grid);
@@ -1108,15 +1107,15 @@ void Editor::drawGrid(Graphics* g, const gfx::Rect& spriteBounds, const Rect& gr
   gfx::Rect bounds = this->bounds();
   gridF.offset(-bounds.origin());
 
-  while (gridF.x-gridF.w >= spriteBounds.x) gridF.x -= gridF.w;
-  while (gridF.y-gridF.h >= spriteBounds.y) gridF.y -= gridF.h;
+  while (gridF.x - gridF.w >= spriteBounds.x)
+    gridF.x -= gridF.w;
+  while (gridF.y - gridF.h >= spriteBounds.y)
+    gridF.y -= gridF.h;
 
   // Get the grid's color
   gfx::Color grid_color = color_utils::color_for_ui(color);
   grid_color = gfx::rgba(
-    gfx::getr(grid_color),
-    gfx::getg(grid_color),
-    gfx::getb(grid_color), alpha);
+    gfx::getr(grid_color), gfx::getg(grid_color), gfx::getb(grid_color), alpha);
 
   // Draw horizontal lines
   int x1 = spriteBounds.x;
@@ -1124,14 +1123,14 @@ void Editor::drawGrid(Graphics* g, const gfx::Rect& spriteBounds, const Rect& gr
   int x2 = spriteBounds.x + spriteBounds.w;
   int y2 = spriteBounds.y + spriteBounds.h;
 
-  for (double c=y1; c<=y2; c+=gridF.h)
+  for (double c = y1; c <= y2; c += gridF.h)
     g->drawHLine(grid_color, x1, c, spriteBounds.w);
 
   // Draw vertical lines
   x1 = gridF.x;
   y1 = spriteBounds.y;
 
-  for (double c=x1; c<=x2; c+=gridF.w)
+  for (double c = x1; c <= x2; c += gridF.w)
     g->drawVLine(grid_color, c, y1, spriteBounds.h);
 }
 
@@ -1165,12 +1164,12 @@ void Editor::drawSlices(ui::Graphics* g)
     if (key->hasCenter()) {
       gfx::Rect in =
         editorToScreen(gfx::Rect(key->center()).offset(key->bounds().origin()))
-        .offset(-bounds().origin());
+          .offset(-bounds().origin());
 
       auto in_color = gfx::rgba(gfx::getr(color),
                                 gfx::getg(color),
                                 gfx::getb(color),
-                                doc::rgba_geta(docColor)/4);
+                                doc::rgba_geta(docColor) / 4);
       if (in.y > out.y && in.y < out.y2())
         g->drawHLine(in_color, out.x, in.y, out.w);
       if (in.y2() > out.y && in.y2() < out.y2())
@@ -1183,22 +1182,20 @@ void Editor::drawSlices(ui::Graphics* g)
 
     // Pivot
     if (key->hasPivot()) {
-      gfx::Rect in =
-        editorToScreen(gfx::Rect(key->pivot(), gfx::Size(1, 1)).offset(key->bounds().origin()))
-        .offset(-bounds().origin());
+      gfx::Rect in = editorToScreen(gfx::Rect(key->pivot(), gfx::Size(1, 1))
+                                      .offset(key->bounds().origin()))
+                       .offset(-bounds().origin());
 
       auto in_color = gfx::rgba(gfx::getr(color),
                                 gfx::getg(color),
                                 gfx::getb(color),
-                                doc::rgba_geta(docColor)/4);
+                                doc::rgba_geta(docColor) / 4);
       g->drawRect(in_color, in);
     }
 
-    if (isSliceSelected(slice) &&
-        getCurrentEditorInk()->isSlice()) {
+    if (isSliceSelected(slice) && getCurrentEditorInk()->isSlice()) {
       PaintWidgetPartInfo info;
-      theme->paintWidgetPart(
-        g, theme->styles.colorbarSelection(), out, info);
+      theme->paintWidgetPart(g, theme->styles.colorbarSelection(), out, info);
     }
     else {
       g->drawRect(color, out);
@@ -1208,25 +1205,26 @@ void Editor::drawSlices(ui::Graphics* g)
 
 void Editor::drawTileNumbers(ui::Graphics* g, const Cel* cel)
 {
-  gfx::Color color = color_utils::color_for_ui(Preferences::instance().guides.autoGuidesColor());
+  gfx::Color color =
+    color_utils::color_for_ui(Preferences::instance().guides.autoGuidesColor());
   gfx::Color fgColor = color_utils::blackandwhite_neg(color);
 
   const doc::Grid grid = getSite().grid();
-  const gfx::Size tileSize = editorToScreen(grid.tileToCanvas(gfx::Rect(0, 0, 1, 1))).size();
+  const gfx::Size tileSize =
+    editorToScreen(grid.tileToCanvas(gfx::Rect(0, 0, 1, 1))).size();
   const int th = g->font()->height();
   if (tileSize.h > th) {
     const gfx::Point offset =
-      gfx::Point(tileSize.w/2,
-                 tileSize.h/2 - g->font()->height()/2)
-      + mainTilePosition();
+      gfx::Point(tileSize.w / 2, tileSize.h / 2 - g->font()->height() / 2) +
+      mainTilePosition();
 
     int ti_offset =
       static_cast<LayerTilemap*>(cel->layer())->tileset()->baseIndex() - 1;
 
     const doc::Image* image = cel->image();
     std::string text;
-    for (int y=0; y<image->height(); ++y) {
-      for (int x=0; x<image->width(); ++x) {
+    for (int y = 0; y < image->height(); ++y) {
+      for (int x = 0; x < image->width(); ++x) {
         doc::tile_t t = image->getPixel(x, y);
         if (t != doc::notile) {
           const doc::tile_index ti = doc::tile_geti(t);
@@ -1239,15 +1237,15 @@ void Editor::drawTileNumbers(ui::Graphics* g, const Cel* cel)
           text = fmt::format("{}", ti + ti_offset);
 
           gfx::Point pt2(pt);
-          pt2.x -= g->measureUIText(text).w/2;
+          pt2.x -= g->measureUIText(text).w / 2;
           g->drawText(text, fgColor, color, pt2);
 
-          if (tf && tileSize.h > 2*th) {
+          if (tf && tileSize.h > 2 * th) {
             text.clear();
             build_tile_flags_string(tf, text);
 
             const gfx::Size tsize = g->measureUIText(text);
-            pt.x -= tsize.w/2;
+            pt.x -= tsize.w / 2;
             pt.y += tsize.h;
             g->drawText(text, fgColor, color, pt);
           }
@@ -1257,102 +1255,147 @@ void Editor::drawTileNumbers(ui::Graphics* g, const Cel* cel)
   }
 }
 
-void Editor::drawCelBounds(ui::Graphics* g, const Cel* cel, const gfx::Color color)
+void Editor::drawCelBounds(ui::Graphics* g,
+                           const Cel* cel,
+                           const gfx::Color color)
 {
   g->drawRect(color, getCelScreenBounds(cel));
 }
 
 void Editor::drawCelGuides(ui::Graphics* g, const Cel* cel, const Cel* mouseCel)
 {
-  gfx::Rect
-    sprCelBounds = cel->bounds(),
-    scrCelBounds = getCelScreenBounds(cel),
-    scrCmpBounds, sprCmpBounds;
+  gfx::Rect sprCelBounds = cel->bounds(),
+            scrCelBounds = getCelScreenBounds(cel), scrCmpBounds, sprCmpBounds;
   if (mouseCel) {
     scrCmpBounds = getCelScreenBounds(mouseCel);
     sprCmpBounds = mouseCel->bounds();
 
-    const gfx::Color color = color_utils::color_for_ui(Preferences::instance().guides.autoGuidesColor());
+    const gfx::Color color = color_utils::color_for_ui(
+      Preferences::instance().guides.autoGuidesColor());
     drawCelBounds(g, mouseCel, color);
   }
   // Use whole canvas
   else {
     sprCmpBounds = m_sprite->bounds();
     scrCmpBounds =
-      editorToScreen(
-        gfx::Rect(sprCmpBounds).offset(mainTilePosition()))
-      .offset(gfx::Point(-bounds().origin()));
+      editorToScreen(gfx::Rect(sprCmpBounds).offset(mainTilePosition()))
+        .offset(gfx::Point(-bounds().origin()));
   }
 
-  const int midX = scrCelBounds.x+scrCelBounds.w/2;
-  const int midY = scrCelBounds.y+scrCelBounds.h/2;
+  const int midX = scrCelBounds.x + scrCelBounds.w / 2;
+  const int midY = scrCelBounds.y + scrCelBounds.h / 2;
 
   if (sprCelBounds.x2() < sprCmpBounds.x) {
     drawCelHGuide(g,
-                  sprCelBounds.x2(), sprCmpBounds.x,
-                  scrCelBounds.x2(), scrCmpBounds.x, midY,
-                  scrCelBounds, scrCmpBounds, scrCmpBounds.x);
+                  sprCelBounds.x2(),
+                  sprCmpBounds.x,
+                  scrCelBounds.x2(),
+                  scrCmpBounds.x,
+                  midY,
+                  scrCelBounds,
+                  scrCmpBounds,
+                  scrCmpBounds.x);
   }
   else if (sprCelBounds.x > sprCmpBounds.x2()) {
     drawCelHGuide(g,
-                  sprCmpBounds.x2(), sprCelBounds.x,
-                  scrCmpBounds.x2(), scrCelBounds.x, midY,
-                  scrCelBounds, scrCmpBounds, scrCmpBounds.x2()-1);
+                  sprCmpBounds.x2(),
+                  sprCelBounds.x,
+                  scrCmpBounds.x2(),
+                  scrCelBounds.x,
+                  midY,
+                  scrCelBounds,
+                  scrCmpBounds,
+                  scrCmpBounds.x2() - 1);
   }
   else {
     if (sprCelBounds.x != sprCmpBounds.x &&
         sprCelBounds.x2() != sprCmpBounds.x) {
       drawCelHGuide(g,
-                    sprCmpBounds.x, sprCelBounds.x,
-                    scrCmpBounds.x, scrCelBounds.x, midY,
-                    scrCelBounds, scrCmpBounds, scrCmpBounds.x);
+                    sprCmpBounds.x,
+                    sprCelBounds.x,
+                    scrCmpBounds.x,
+                    scrCelBounds.x,
+                    midY,
+                    scrCelBounds,
+                    scrCmpBounds,
+                    scrCmpBounds.x);
     }
     if (sprCelBounds.x != sprCmpBounds.x2() &&
         sprCelBounds.x2() != sprCmpBounds.x2()) {
       drawCelHGuide(g,
-                    sprCmpBounds.x2(), sprCelBounds.x2(),
-                    scrCmpBounds.x2(), scrCelBounds.x2(), midY,
-                    scrCelBounds, scrCmpBounds, scrCmpBounds.x2()-1);
+                    sprCmpBounds.x2(),
+                    sprCelBounds.x2(),
+                    scrCmpBounds.x2(),
+                    scrCelBounds.x2(),
+                    midY,
+                    scrCelBounds,
+                    scrCmpBounds,
+                    scrCmpBounds.x2() - 1);
     }
   }
 
   if (sprCelBounds.y2() < sprCmpBounds.y) {
     drawCelVGuide(g,
-                  sprCelBounds.y2(), sprCmpBounds.y,
-                  scrCelBounds.y2(), scrCmpBounds.y, midX,
-                  scrCelBounds, scrCmpBounds, scrCmpBounds.y);
+                  sprCelBounds.y2(),
+                  sprCmpBounds.y,
+                  scrCelBounds.y2(),
+                  scrCmpBounds.y,
+                  midX,
+                  scrCelBounds,
+                  scrCmpBounds,
+                  scrCmpBounds.y);
   }
   else if (sprCelBounds.y > sprCmpBounds.y2()) {
     drawCelVGuide(g,
-                  sprCmpBounds.y2(), sprCelBounds.y,
-                  scrCmpBounds.y2(), scrCelBounds.y, midX,
-                  scrCelBounds, scrCmpBounds, scrCmpBounds.y2()-1);
+                  sprCmpBounds.y2(),
+                  sprCelBounds.y,
+                  scrCmpBounds.y2(),
+                  scrCelBounds.y,
+                  midX,
+                  scrCelBounds,
+                  scrCmpBounds,
+                  scrCmpBounds.y2() - 1);
   }
   else {
     if (sprCelBounds.y != sprCmpBounds.y &&
         sprCelBounds.y2() != sprCmpBounds.y) {
       drawCelVGuide(g,
-                    sprCmpBounds.y, sprCelBounds.y,
-                    scrCmpBounds.y, scrCelBounds.y, midX,
-                    scrCelBounds, scrCmpBounds, scrCmpBounds.y);
+                    sprCmpBounds.y,
+                    sprCelBounds.y,
+                    scrCmpBounds.y,
+                    scrCelBounds.y,
+                    midX,
+                    scrCelBounds,
+                    scrCmpBounds,
+                    scrCmpBounds.y);
     }
     if (sprCelBounds.y != sprCmpBounds.y2() &&
         sprCelBounds.y2() != sprCmpBounds.y2()) {
       drawCelVGuide(g,
-                    sprCmpBounds.y2(), sprCelBounds.y2(),
-                    scrCmpBounds.y2(), scrCelBounds.y2(), midX,
-                    scrCelBounds, scrCmpBounds, scrCmpBounds.y2()-1);
+                    sprCmpBounds.y2(),
+                    sprCelBounds.y2(),
+                    scrCmpBounds.y2(),
+                    scrCelBounds.y2(),
+                    midX,
+                    scrCelBounds,
+                    scrCmpBounds,
+                    scrCmpBounds.y2() - 1);
     }
   }
 }
 
 void Editor::drawCelHGuide(ui::Graphics* g,
-                           const int sprX1, const int sprX2,
-                           const int scrX1, const int scrX2, const int scrY,
-                           const gfx::Rect& scrCelBounds, const gfx::Rect& scrCmpBounds,
+                           const int sprX1,
+                           const int sprX2,
+                           const int scrX1,
+                           const int scrX2,
+                           const int scrY,
+                           const gfx::Rect& scrCelBounds,
+                           const gfx::Rect& scrCmpBounds,
                            const int dottedX)
 {
-  gfx::Color color = color_utils::color_for_ui(Preferences::instance().guides.autoGuidesColor());
+  gfx::Color color =
+    color_utils::color_for_ui(Preferences::instance().guides.autoGuidesColor());
   g->drawHLine(color, std::min(scrX1, scrX2), scrY, std::abs(scrX2 - scrX1));
 
   // Vertical guide to touch the horizontal line
@@ -1362,25 +1405,35 @@ void Editor::drawCelHGuide(ui::Graphics* g,
     paint.color(color);
 
     if (scrY < scrCmpBounds.y)
-      g->drawVLine(dottedX, scrCelBounds.y, scrCmpBounds.y - scrCelBounds.y, paint);
+      g->drawVLine(
+        dottedX, scrCelBounds.y, scrCmpBounds.y - scrCelBounds.y, paint);
     else if (scrY > scrCmpBounds.y2())
-      g->drawVLine(dottedX, scrCmpBounds.y2(), scrCelBounds.y2() - scrCmpBounds.y2(), paint);
+      g->drawVLine(dottedX,
+                   scrCmpBounds.y2(),
+                   scrCelBounds.y2() - scrCmpBounds.y2(),
+                   paint);
   }
 
   auto text = fmt::format("{}px", ABS(sprX2 - sprX1));
   const int textW = Graphics::measureUITextLength(text, font());
   g->drawText(text,
-              color_utils::blackandwhite_neg(color), color,
-              gfx::Point((scrX1+scrX2)/2-textW/2, scrY-textHeight()));
+              color_utils::blackandwhite_neg(color),
+              color,
+              gfx::Point((scrX1 + scrX2) / 2 - textW / 2, scrY - textHeight()));
 }
 
 void Editor::drawCelVGuide(ui::Graphics* g,
-                           const int sprY1, const int sprY2,
-                           const int scrY1, const int scrY2, const int scrX,
-                           const gfx::Rect& scrCelBounds, const gfx::Rect& scrCmpBounds,
+                           const int sprY1,
+                           const int sprY2,
+                           const int scrY1,
+                           const int scrY2,
+                           const int scrX,
+                           const gfx::Rect& scrCelBounds,
+                           const gfx::Rect& scrCmpBounds,
                            const int dottedY)
 {
-  gfx::Color color = color_utils::color_for_ui(Preferences::instance().guides.autoGuidesColor());
+  gfx::Color color =
+    color_utils::color_for_ui(Preferences::instance().guides.autoGuidesColor());
   g->drawVLine(color, scrX, std::min(scrY1, scrY2), std::abs(scrY2 - scrY1));
 
   // Horizontal guide to touch the vertical line
@@ -1390,15 +1443,20 @@ void Editor::drawCelVGuide(ui::Graphics* g,
     paint.color(color);
 
     if (scrX < scrCmpBounds.x)
-      g->drawHLine(scrCelBounds.x, dottedY, scrCmpBounds.x - scrCelBounds.x, paint);
+      g->drawHLine(
+        scrCelBounds.x, dottedY, scrCmpBounds.x - scrCelBounds.x, paint);
     else if (scrX > scrCmpBounds.x2())
-      g->drawHLine(scrCmpBounds.x2(), dottedY, scrCelBounds.x2() - scrCmpBounds.x2(), paint);
+      g->drawHLine(scrCmpBounds.x2(),
+                   dottedY,
+                   scrCelBounds.x2() - scrCmpBounds.x2(),
+                   paint);
   }
 
   auto text = fmt::format("{}px", ABS(sprY2 - sprY1));
   g->drawText(text,
-              color_utils::blackandwhite_neg(color), color,
-              gfx::Point(scrX, (scrY1+scrY2)/2-textHeight()/2));
+              color_utils::blackandwhite_neg(color),
+              color,
+              gfx::Point(scrX, (scrY1 + scrY2) / 2 - textHeight() / 2));
 }
 
 gfx::Rect Editor::getCelScreenBounds(const Cel* cel)
@@ -1408,15 +1466,12 @@ gfx::Rect Editor::getCelScreenBounds(const Cel* cel)
   if (m_layer->isReference()) {
     layerEdges =
       editorToScreenF(
-        gfx::RectF(cel->boundsF()).offset(mainOffset.x,
-                                          mainOffset.y))
-      .offset(gfx::PointF(-bounds().origin()));
+        gfx::RectF(cel->boundsF()).offset(mainOffset.x, mainOffset.y))
+        .offset(gfx::PointF(-bounds().origin()));
   }
   else {
-    layerEdges =
-      editorToScreen(
-        gfx::Rect(cel->bounds()).offset(mainOffset))
-      .offset(-bounds().origin());
+    layerEdges = editorToScreen(gfx::Rect(cel->bounds()).offset(mainOffset))
+                   .offset(-bounds().origin());
   }
   return layerEdges;
 }
@@ -1446,8 +1501,7 @@ void Editor::flashCurrentLayer()
   }
 }
 
-gfx::Point Editor::autoScroll(const ui::MouseMessage* msg,
-                              const AutoScroll dir)
+gfx::Point Editor::autoScroll(const ui::MouseMessage* msg, const AutoScroll dir)
 {
   gfx::Point mousePos = msg->position();
   if (!Preferences::instance().editor.autoScroll())
@@ -1462,13 +1516,13 @@ gfx::Point Editor::autoScroll(const ui::MouseMessage* msg,
     gfx::Point delta = (mousePos - m_oldPos);
     gfx::Point deltaScroll = delta;
 
-    if (!((mousePos.x <  vp.x      && delta.x < 0) ||
-          (mousePos.x >= vp.x+vp.w && delta.x > 0))) {
+    if (!((mousePos.x < vp.x && delta.x < 0) ||
+          (mousePos.x >= vp.x + vp.w && delta.x > 0))) {
       delta.x = 0;
     }
 
-    if (!((mousePos.y <  vp.y      && delta.y < 0) ||
-          (mousePos.y >= vp.y+vp.h && delta.y > 0))) {
+    if (!((mousePos.y < vp.y && delta.y < 0) ||
+          (mousePos.y >= vp.y + vp.h && delta.y > 0))) {
       delta.y = 0;
     }
 
@@ -1482,13 +1536,11 @@ gfx::Point Editor::autoScroll(const ui::MouseMessage* msg,
     setEditorScroll(scroll);
 
     mousePos -= delta;
-    ui::set_mouse_position(mousePos,
-                           display());
+    ui::set_mouse_position(mousePos, display());
 
     m_oldPos = mousePos;
-    mousePos = gfx::Point(
-      std::clamp(mousePos.x, vp.x, vp.x2()-1),
-      std::clamp(mousePos.y, vp.y, vp.y2()-1));
+    mousePos = gfx::Point(std::clamp(mousePos.x, vp.x, vp.x2() - 1),
+                          std::clamp(mousePos.y, vp.y, vp.y2() - 1));
   }
   else
     m_oldPos = mousePos;
@@ -1524,9 +1576,8 @@ gfx::Point Editor::screenToEditor(const gfx::Point& pt) const
   View* view = View::getView(this);
   Rect vp = view->viewportBounds();
   Point scroll = view->viewScroll();
-  return gfx::Point(
-    m_proj.removeX(pt.x - vp.x + scroll.x - m_padding.x),
-    m_proj.removeY(pt.y - vp.y + scroll.y - m_padding.y));
+  return gfx::Point(m_proj.removeX(pt.x - vp.x + scroll.x - m_padding.x),
+                    m_proj.removeY(pt.y - vp.y + scroll.y - m_padding.y));
 }
 
 gfx::Point Editor::screenToEditorCeiling(const gfx::Point& pt) const
@@ -1538,7 +1589,6 @@ gfx::Point Editor::screenToEditorCeiling(const gfx::Point& pt) const
     m_proj.removeXCeiling(pt.x - vp.x + scroll.x - m_padding.x),
     m_proj.removeYCeiling(pt.y - vp.y + scroll.y - m_padding.y));
 }
-
 
 gfx::PointF Editor::screenToEditorF(const gfx::Point& pt) const
 {
@@ -1555,9 +1605,8 @@ Point Editor::editorToScreen(const gfx::Point& pt) const
   View* view = View::getView(this);
   Rect vp = view->viewportBounds();
   Point scroll = view->viewScroll();
-  return Point(
-    (vp.x - scroll.x + m_padding.x + m_proj.applyX(pt.x)),
-    (vp.y - scroll.y + m_padding.y + m_proj.applyY(pt.y)));
+  return Point((vp.x - scroll.x + m_padding.x + m_proj.applyX(pt.x)),
+               (vp.y - scroll.y + m_padding.y + m_proj.applyY(pt.y)));
 }
 
 gfx::PointF Editor::editorToScreenF(const gfx::PointF& pt) const
@@ -1565,30 +1614,24 @@ gfx::PointF Editor::editorToScreenF(const gfx::PointF& pt) const
   View* view = View::getView(this);
   Rect vp = view->viewportBounds();
   Point scroll = view->viewScroll();
-  return PointF(
-    (vp.x - scroll.x + m_padding.x + m_proj.applyX<double>(pt.x)),
-    (vp.y - scroll.y + m_padding.y + m_proj.applyY<double>(pt.y)));
+  return PointF((vp.x - scroll.x + m_padding.x + m_proj.applyX<double>(pt.x)),
+                (vp.y - scroll.y + m_padding.y + m_proj.applyY<double>(pt.y)));
 }
 
 Rect Editor::screenToEditor(const Rect& rc) const
 {
-  return gfx::Rect(
-    screenToEditor(rc.origin()),
-    screenToEditorCeiling(rc.point2()));
+  return gfx::Rect(screenToEditor(rc.origin()),
+                   screenToEditorCeiling(rc.point2()));
 }
 
 Rect Editor::editorToScreen(const Rect& rc) const
 {
-  return gfx::Rect(
-    editorToScreen(rc.origin()),
-    editorToScreen(rc.point2()));
+  return gfx::Rect(editorToScreen(rc.origin()), editorToScreen(rc.point2()));
 }
 
 gfx::RectF Editor::editorToScreenF(const gfx::RectF& rc) const
 {
-  return gfx::RectF(
-    editorToScreenF(rc.origin()),
-    editorToScreenF(rc.point2()));
+  return gfx::RectF(editorToScreenF(rc.origin()), editorToScreenF(rc.point2()));
 }
 
 void Editor::add_observer(EditorObserver* observer)
@@ -1641,9 +1684,8 @@ void Editor::centerInSpritePoint(const gfx::PointF& spritePos)
   View* view = View::getView(this);
   Rect vp = view->viewportBounds();
 
-  gfx::Point scroll(
-    m_padding.x - (vp.w/2) + m_proj.applyX(spritePos.x),
-    m_padding.y - (vp.h/2) + m_proj.applyY(spritePos.y));
+  gfx::Point scroll(m_padding.x - (vp.w / 2) + m_proj.applyX(spritePos.x),
+                    m_padding.y - (vp.h / 2) + m_proj.applyY(spritePos.y));
 
   updateEditor(false);
   setEditorScroll(scroll);
@@ -1652,16 +1694,14 @@ void Editor::centerInSpritePoint(const gfx::PointF& spritePos)
 
 void Editor::centerInSpritePoint(const gfx::Point& spritePos)
 {
-  centerInSpritePoint(gfx::PointF(spritePos.x + 0.5,
-                                  spritePos.y + 0.5));
+  centerInSpritePoint(gfx::PointF(spritePos.x + 0.5, spritePos.y + 0.5));
 }
 
 gfx::PointF Editor::spritePointInCenter() const
 {
   View* view = View::getView(this);
   Rect vp = view->viewportBounds();
-  gfx::Point screenPos(vp.x + vp.w/2,
-                       vp.y + vp.h/2);
+  gfx::Point screenPos(vp.x + vp.w / 2, vp.y + vp.h / 2);
   return screenToEditorF(screenPos);
 }
 
@@ -1683,7 +1723,8 @@ void Editor::updateQuicktool()
     // Don't change quicktools if we are in a selection tool and using
     // the selection modifiers.
     if (selectedTool->getInk(0)->isSelection() &&
-        int(m_customizationDelegate->getPressedKeyAction(KeyContext::SelectionTool)) != 0) {
+        int(m_customizationDelegate->getPressedKeyAction(
+          KeyContext::SelectionTool)) != 0) {
       if (atm->quickTool())
         atm->newQuickToolSelectedFromEditor(nullptr);
       return;
@@ -1733,12 +1774,13 @@ void Editor::updateToolLoopModifiersIndicators(const bool firstFromMouseDown)
                      int(tools::ToolLoopModifiers::kIntersectSelection)));
 
       tools::Tool* tool = atm->selectedTool();
-      tools::Controller* controller = (tool ? tool->getController(0): nullptr);
-      tools::Ink* ink = (tool ? tool->getInk(0): nullptr);
+      tools::Controller* controller = (tool ? tool->getController(0) : nullptr);
+      tools::Ink* ink = (tool ? tool->getInk(0) : nullptr);
 
       // Shape tools modifiers (line, curves, rectangles, etc.)
       if (controller && controller->isTwoPoints()) {
-        action = m_customizationDelegate->getPressedKeyAction(KeyContext::ShapeTool);
+        action =
+          m_customizationDelegate->getPressedKeyAction(KeyContext::ShapeTool);
 
         // For two-points-selection-like tools (Rectangular/Elliptical
         // Marquee) we prefer to activate the
@@ -1749,8 +1791,7 @@ void Editor::updateToolLoopModifiersIndicators(const bool firstFromMouseDown)
         // again, or Alt+Shift+selection tool will subtract the
         // selection but will not start the rotation until we release
         // and press the Alt key again.
-        if (!firstFromMouseDown ||
-            !ink || !ink->isSelection()) {
+        if (!firstFromMouseDown || !ink || !ink->isSelection()) {
           if (int(action & KeyAction::MoveOrigin))
             modifiers |= int(tools::ToolLoopModifiers::kMoveOrigin);
           if (int(action & KeyAction::SquareAspect))
@@ -1764,21 +1805,22 @@ void Editor::updateToolLoopModifiersIndicators(const bool firstFromMouseDown)
 
       // Freehand modifiers
       if (controller && controller->isFreehand()) {
-        action = m_customizationDelegate->getPressedKeyAction(KeyContext::FreehandTool);
+        action = m_customizationDelegate->getPressedKeyAction(
+          KeyContext::FreehandTool);
         if (int(action & KeyAction::AngleSnapFromLastPoint))
           modifiers |= int(tools::ToolLoopModifiers::kSquareAspect);
       }
     }
     else {
       // We update the selection mode only if we're not selecting.
-      action = m_customizationDelegate->getPressedKeyAction(KeyContext::SelectionTool);
+      action =
+        m_customizationDelegate->getPressedKeyAction(KeyContext::SelectionTool);
 
       gen::SelectionMode mode = Preferences::instance().selection.mode();
       if (int(action & KeyAction::SubtractSelection) ||
           // Don't use "subtract" mode if the selection was activated
           // with the "right click mode = a selection-like tool"
-          (m_secondaryButton &&
-           atm->selectedTool() &&
+          (m_secondaryButton && atm->selectedTool() &&
            atm->selectedTool()->getInk(0)->isSelection())) {
         mode = gen::SelectionMode::SUBTRACT;
       }
@@ -1789,16 +1831,26 @@ void Editor::updateToolLoopModifiersIndicators(const bool firstFromMouseDown)
         mode = gen::SelectionMode::ADD;
       }
       switch (mode) {
-        case gen::SelectionMode::DEFAULT:   modifiers |= int(tools::ToolLoopModifiers::kReplaceSelection);  break;
-        case gen::SelectionMode::ADD:       modifiers |= int(tools::ToolLoopModifiers::kAddSelection);      break;
-        case gen::SelectionMode::SUBTRACT:  modifiers |= int(tools::ToolLoopModifiers::kSubtractSelection); break;
-        case gen::SelectionMode::INTERSECT: modifiers |= int(tools::ToolLoopModifiers::kIntersectSelection); break;
+        case gen::SelectionMode::DEFAULT:
+          modifiers |= int(tools::ToolLoopModifiers::kReplaceSelection);
+          break;
+        case gen::SelectionMode::ADD:
+          modifiers |= int(tools::ToolLoopModifiers::kAddSelection);
+          break;
+        case gen::SelectionMode::SUBTRACT:
+          modifiers |= int(tools::ToolLoopModifiers::kSubtractSelection);
+          break;
+        case gen::SelectionMode::INTERSECT:
+          modifiers |= int(tools::ToolLoopModifiers::kIntersectSelection);
+          break;
       }
 
       // For move tool
-      action = m_customizationDelegate->getPressedKeyAction(KeyContext::MoveTool);
+      action =
+        m_customizationDelegate->getPressedKeyAction(KeyContext::MoveTool);
       if (int(action & KeyAction::AutoSelectLayer))
-        newAutoSelectLayer = Preferences::instance().editor.autoSelectLayerQuick();
+        newAutoSelectLayer =
+          Preferences::instance().editor.autoSelectLayerQuick();
       else
         newAutoSelectLayer = Preferences::instance().editor.autoSelectLayer();
     }
@@ -1829,8 +1881,7 @@ app::Color Editor::getColorByPosition(const gfx::Point& mousePos)
 
     ColorPicker picker;
     site.tilemapMode(TilemapMode::Pixels);
-    picker.pickColor(site, editorPos, m_proj,
-                     ColorPicker::FromComposition);
+    picker.pickColor(site, editorPos, m_proj, ColorPicker::FromComposition);
     return picker.color();
   }
   else
@@ -1845,8 +1896,7 @@ doc::tile_t Editor::getTileByPosition(const gfx::Point& mousePos)
 
     ColorPicker picker;
     site.tilemapMode(TilemapMode::Tiles);
-    picker.pickColor(site, editorPos, m_proj,
-                     ColorPicker::FromComposition);
+    picker.pickColor(site, editorPos, m_proj, ColorPicker::FromComposition);
 
     return picker.tile();
   }
@@ -1858,16 +1908,15 @@ bool Editor::startStraightLineWithFreehandTool(const tools::Pointer* pointer)
 {
   tools::Tool* tool = App::instance()->activeToolManager()->selectedTool();
   // TODO add support for more buttons (X1, X2, etc.)
-  int i = (pointer && pointer->button() == tools::Pointer::Button::Right ? 1: 0);
-  return
-    (isActive() &&
-     (hasMouse() || hasCapture()) &&
-     tool &&
-     tool->getController(i)->isFreehand() &&
-     tool->getInk(i)->isPaint() &&
-     (getCustomizationDelegate()
-      ->getPressedKeyAction(KeyContext::FreehandTool) & KeyAction::StraightLineFromLastPoint) == KeyAction::StraightLineFromLastPoint &&
-     document()->lastDrawingPoint() != Doc::NoLastDrawingPoint());
+  int i =
+    (pointer && pointer->button() == tools::Pointer::Button::Right ? 1 : 0);
+  return (
+    isActive() && (hasMouse() || hasCapture()) && tool &&
+    tool->getController(i)->isFreehand() && tool->getInk(i)->isPaint() &&
+    (getCustomizationDelegate()->getPressedKeyAction(KeyContext::FreehandTool) &
+     KeyAction::StraightLineFromLastPoint) ==
+      KeyAction::StraightLineFromLastPoint &&
+    document()->lastDrawingPoint() != Doc::NoLastDrawingPoint());
 }
 
 bool Editor::isSliceSelected(const doc::Slice* slice) const
@@ -1935,12 +1984,11 @@ void Editor::showUnhandledException(const std::exception& ex,
 
   Console console;
   Console::showException(ex);
-  console.printf(
-    "\nInternal details:\n"
-    "- Message type: %d\n"
-    "- Editor state: %s\n",
-    (msg ? msg->type(): -1),
-    (state ? typeid(*state).name(): "None"));
+  console.printf("\nInternal details:\n"
+                 "- Message type: %d\n"
+                 "- Editor state: %s\n",
+                 (msg ? msg->type() : -1),
+                 (state ? typeid(*state).name() : "None"));
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1953,7 +2001,6 @@ bool Editor::onProcessMessage(Message* msg)
     m_deletedStates.clear();
 
   switch (msg->type()) {
-
     case kTimerMessage:
       if (static_cast<TimerMessage*>(msg)->timer() == &m_antsTimer) {
         if (isVisible() && m_sprite) {
@@ -2026,8 +2073,8 @@ bool Editor::onProcessMessage(Message* msg)
         updateQuicktool();
         setCursor(mouseMsg->position());
 
-        App::instance()->activeToolManager()
-          ->pressButton(pointer_from_msg(this, mouseMsg));
+        App::instance()->activeToolManager()->pressButton(
+          pointer_from_msg(this, mouseMsg));
 
         EditorStatePtr holdState(m_state);
         bool state = m_state->onMouseDown(this, mouseMsg);
@@ -2108,9 +2155,10 @@ bool Editor::onProcessMessage(Message* msg)
         //      new engine allows to disable the bilinear mipmapping
         //      interpolation) as we still need the "old" engine to
         //      render reference layers
-        auto& newRenderEngine = Preferences::instance().experimental.newRenderEngine;
+        auto& newRenderEngine =
+          Preferences::instance().experimental.newRenderEngine;
 
-#if SK_ENABLE_SKSL
+  #if SK_ENABLE_SKSL
         // Simple (new) -> Simple (old) -> Shader -> Simple (new) -> ...
         if (m_renderEngine->type() == EditorRender::Type::kShaderRenderer) {
           newRenderEngine(true);
@@ -2125,19 +2173,21 @@ bool Editor::onProcessMessage(Message* msg)
             m_renderEngine->setType(EditorRender::Type::kShaderRenderer);
           }
         }
-#else
+  #else
         // Simple (new) <-> Simple (old)
         newRenderEngine(!newRenderEngine());
-#endif
+  #endif
 
         switch (m_renderEngine->type()) {
           case EditorRender::Type::kSimpleRenderer:
             StatusBar::instance()->showTip(
-              1000, fmt::format("Simple Renderer ({})", newRenderEngine() ? "new": "old"));
+              1000,
+              fmt::format("Simple Renderer ({})",
+                          newRenderEngine() ? "new" : "old"));
             break;
           case EditorRender::Type::kShaderRenderer:
-            StatusBar::instance()->showTip(
-              1000, fmt::format("Shader Renderer"));
+            StatusBar::instance()->showTip(1000,
+                                           fmt::format("Shader Renderer"));
             break;
         }
 
@@ -2190,13 +2240,11 @@ bool Editor::onProcessMessage(Message* msg)
     case kSetCursorMessage:
       setCursor(static_cast<MouseMessage*>(msg)->position());
       return true;
-
   }
 
   bool result = Widget::onProcessMessage(msg);
 
-  if (msg->type() == kPaintMessage &&
-      m_flashing != Flashing::None) {
+  if (msg->type() == kPaintMessage && m_flashing != Flashing::None) {
     const PaintMessage* ptmsg = static_cast<const PaintMessage*>(msg);
     if (ptmsg->count() == 0) {
       if (m_flashing == Flashing::WithFlashExtraCel) {
@@ -2212,7 +2260,7 @@ bool Editor::onProcessMessage(Message* msg)
         if (m_brushPreview.onScreen()) {
           m_brushPreview.hide();
 
-          // Destroy the extra cel explicitly (it could happend
+          // Destroy the extra cel explicitly (it could happen
           // automatically by the m_brushPreview.show()) just in case
           // that the brush preview will not use the extra cel
           // (e.g. in the case of the Eraser tool).
@@ -2226,7 +2274,8 @@ bool Editor::onProcessMessage(Message* msg)
 
         // Redraw all editors (without this the preview editor will
         // still show the flashing layer).
-        for (auto editor : UIContext::instance()->getAllEditorsIncludingPreview(m_document)) {
+        for (auto editor :
+             UIContext::instance()->getAllEditorsIncludingPreview(m_document)) {
           editor->invalidateCanvas();
 
           // Re-generate painting messages just right now (it looks
@@ -2247,8 +2296,8 @@ void Editor::onSizeHint(SizeHintEvent& ev)
   if (m_sprite) {
     gfx::Point padding = calcExtraPadding(m_proj);
     gfx::Size canvas = canvasSize();
-    sz.w = m_proj.applyX(canvas.w) + padding.x*2;
-    sz.h = m_proj.applyY(canvas.h) + padding.y*2;
+    sz.w = m_proj.applyX(canvas.w) + padding.x * 2;
+    sz.h = m_proj.applyY(canvas.h) + padding.y * 2;
   }
   else {
     sz.w = 4;
@@ -2298,7 +2347,8 @@ void Editor::onPaint(ui::PaintEvent& ev)
       // Draw the sprite in the editor
       renderChrono.reset();
       drawBackground(g);
-      drawSpriteUnclippedRect(g, gfx::Rect(0, 0, m_sprite->width(), m_sprite->height()));
+      drawSpriteUnclippedRect(
+        g, gfx::Rect(0, 0, m_sprite->width(), m_sprite->height()));
       renderElapsed = renderChrono.elapsed();
 
 #if ENABLE_DEVMODE
@@ -2306,20 +2356,19 @@ void Editor::onPaint(ui::PaintEvent& ev)
       if (Preferences::instance().perf.showRenderTime()) {
         View* view = View::getView(this);
         gfx::Rect vp = view->viewportBounds();
-        std::string buf =
-          fmt::format("{:c} {:.4g}s",
-                      Preferences::instance().experimental.newRenderEngine() ? 'N': 'O',
-                      renderElapsed);
-        g->drawText(
-          buf,
-          gfx::rgba(255, 255, 255, 255),
-          gfx::rgba(0, 0, 0, 255),
-          vp.origin() - bounds().origin());
+        std::string buf = fmt::format(
+          "{:c} {:.4g}s",
+          Preferences::instance().experimental.newRenderEngine() ? 'N' : 'O',
+          renderElapsed);
+        g->drawText(buf,
+                    gfx::rgba(255, 255, 255, 255),
+                    gfx::rgba(0, 0, 0, 255),
+                    vp.origin() - bounds().origin());
 
         m_perfInfoBounds.setOrigin(vp.origin());
         m_perfInfoBounds.setSize(g->measureUIText(buf));
       }
-#endif // ENABLE_DEVMODE
+#endif  // ENABLE_DEVMODE
 
       // Draw the mask boundaries
       if (m_document->hasMaskBoundaries()) {
@@ -2358,8 +2407,7 @@ void Editor::onActiveToolChange(tools::Tool* tool)
 
 void Editor::onSamplingChange()
 {
-  if (m_proj.scaleX() < 1.0 &&
-      m_proj.scaleY() < 1.0 &&
+  if (m_proj.scaleX() < 1.0 && m_proj.scaleY() < 1.0 &&
       isUsingNewRenderEngine()) {
     invalidate();
   }
@@ -2390,8 +2438,7 @@ void Editor::onTiledModeChange()
   // restore this with the new tiled mode in the main tile.
   View* view = View::getView(this);
   gfx::Rect vp = view->viewportBounds();
-  gfx::Point screenPos(vp.x + vp.w/2,
-                       vp.y + vp.h/2);
+  gfx::Point screenPos(vp.x + vp.w / 2, vp.y + vp.h / 2);
   gfx::Point spritePos(screenToEditor(screenPos));
   spritePos -= m_oldMainTilePos;
 
@@ -2463,8 +2510,7 @@ void Editor::onRemoveTag(DocEvent& ev)
 void Editor::onRemoveSlice(DocEvent& ev)
 {
   ASSERT(ev.slice());
-  if (ev.slice() &&
-      m_selectedSlices.contains(ev.slice()->id())) {
+  if (ev.slice() && m_selectedSlices.contains(ev.slice()->id())) {
     m_selectedSlices.erase(ev.slice()->id());
   }
 }
@@ -2473,6 +2519,12 @@ void Editor::onBeforeLayerVisibilityChange(DocEvent& ev, bool newState)
 {
   if (m_state)
     m_state->onBeforeLayerVisibilityChange(this, ev.layer(), newState);
+}
+
+void Editor::onBeforeLayerEditableChange(DocEvent& ev, bool newState)
+{
+  if (m_state)
+    m_state->onBeforeLayerEditableChange(this, ev.layer(), newState);
 }
 
 void Editor::setCursor(const gfx::Point& mouseDisplayPos)
@@ -2491,12 +2543,9 @@ void Editor::setCursor(const gfx::Point& mouseDisplayPos)
 
 bool Editor::canDraw()
 {
-  return (m_layer != NULL &&
-          m_layer->isImage() &&
-          m_layer->isVisibleHierarchy() &&
-          m_layer->isEditableHierarchy() &&
-          !m_layer->isReference() &&
-          !m_document->isReadOnly());
+  return (m_layer != NULL && m_layer->isImage() &&
+          m_layer->isVisibleHierarchy() && m_layer->isEditableHierarchy() &&
+          !m_layer->isReference() && !m_document->isReadOnly());
 }
 
 bool Editor::isInsideSelection()
@@ -2504,28 +2553,30 @@ bool Editor::isInsideSelection()
   gfx::Point spritePos = screenToEditor(mousePosInDisplay());
   spritePos -= mainTilePosition();
 
-  KeyAction action = m_customizationDelegate->getPressedKeyAction(KeyContext::SelectionTool);
-  return
-    (action == KeyAction::None) &&
-    m_document &&
-    m_document->isMaskVisible() &&
-    m_document->mask()->containsPoint(spritePos.x, spritePos.y);
+  KeyAction action =
+    m_customizationDelegate->getPressedKeyAction(KeyContext::SelectionTool);
+  return (action == KeyAction::None) && m_document &&
+         m_document->isMaskVisible() &&
+         m_document->mask()->containsPoint(spritePos.x, spritePos.y);
 }
 
 bool Editor::canStartMovingSelectionPixels()
 {
-  return
-    isInsideSelection() &&
-    // We cannot move the selection when add/subtract modes are
-    // enabled (we prefer to modify the selection on those modes
-    // instead of moving pixels).
-    ((int(m_toolLoopModifiers) & int(tools::ToolLoopModifiers::kReplaceSelection)) ||
-     // We can move the selection on add mode if the preferences says so.
-     ((int(m_toolLoopModifiers) & int(tools::ToolLoopModifiers::kAddSelection)) &&
-      Preferences::instance().selection.moveOnAddMode()) ||
-     // We can move the selection when the Copy selection key (Ctrl) is pressed.
-     (m_customizationDelegate &&
-      int(m_customizationDelegate->getPressedKeyAction(KeyContext::TranslatingSelection) & KeyAction::CopySelection)));
+  return isInsideSelection() &&
+         // We cannot move the selection when add/subtract modes are
+         // enabled (we prefer to modify the selection on those modes
+         // instead of moving pixels).
+         ((int(m_toolLoopModifiers) &
+           int(tools::ToolLoopModifiers::kReplaceSelection)) ||
+          // We can move the selection on add mode if the preferences says so.
+          ((int(m_toolLoopModifiers) &
+            int(tools::ToolLoopModifiers::kAddSelection)) &&
+           Preferences::instance().selection.moveOnAddMode()) ||
+          // We can move the selection when the Copy selection key (Ctrl) is pressed.
+          (m_customizationDelegate &&
+           int(m_customizationDelegate->getPressedKeyAction(
+                 KeyContext::TranslatingSelection) &
+               KeyAction::CopySelection)));
 }
 
 bool Editor::keepTimelineRange()
@@ -2558,12 +2609,11 @@ EditorHit Editor::calcHit(const gfx::Point& mouseScreenPos)
 
             // Move bounds
             if (bounds.contains(mouseScreenPos) &&
-                !bounds.shrink(5*guiscale()).contains(mouseScreenPos)) {
-              int border =
-                (mouseScreenPos.x <= bounds.x ? LEFT: 0) |
-                (mouseScreenPos.y <= bounds.y ? TOP: 0) |
-                (mouseScreenPos.x >= bounds.x2() ? RIGHT: 0) |
-                (mouseScreenPos.y >= bounds.y2() ? BOTTOM: 0);
+                !bounds.shrink(5 * guiscale()).contains(mouseScreenPos)) {
+              int border = (mouseScreenPos.x <= bounds.x ? LEFT : 0) |
+                           (mouseScreenPos.y <= bounds.y ? TOP : 0) |
+                           (mouseScreenPos.x >= bounds.x2() ? RIGHT : 0) |
+                           (mouseScreenPos.y >= bounds.y2() ? BOTTOM : 0);
 
               EditorHit hit(EditorHit::SliceBounds);
               hit.setBorder(border);
@@ -2573,24 +2623,34 @@ EditorHit Editor::calcHit(const gfx::Point& mouseScreenPos)
 
             // Move center
             if (!center.isEmpty()) {
-              center = editorToScreen(
-                center.offset(key->bounds().origin()));
+              center = editorToScreen(center.offset(key->bounds().origin()));
 
-              bool horz1 = gfx::Rect(bounds.x, center.y-2*guiscale(), bounds.w, 5*guiscale()).contains(mouseScreenPos);
-              bool horz2 = gfx::Rect(bounds.x, center.y2()-2*guiscale(), bounds.w, 5*guiscale()).contains(mouseScreenPos);
-              bool vert1 = gfx::Rect(center.x-2*guiscale(), bounds.y, 5*guiscale(), bounds.h).contains(mouseScreenPos);
-              bool vert2 = gfx::Rect(center.x2()-2*guiscale(), bounds.y, 5*guiscale(), bounds.h).contains(mouseScreenPos);
+              bool horz1 =
+                gfx::Rect(
+                  bounds.x, center.y - 2 * guiscale(), bounds.w, 5 * guiscale())
+                  .contains(mouseScreenPos);
+              bool horz2 = gfx::Rect(bounds.x,
+                                     center.y2() - 2 * guiscale(),
+                                     bounds.w,
+                                     5 * guiscale())
+                             .contains(mouseScreenPos);
+              bool vert1 =
+                gfx::Rect(
+                  center.x - 2 * guiscale(), bounds.y, 5 * guiscale(), bounds.h)
+                  .contains(mouseScreenPos);
+              bool vert2 = gfx::Rect(center.x2() - 2 * guiscale(),
+                                     bounds.y,
+                                     5 * guiscale(),
+                                     bounds.h)
+                             .contains(mouseScreenPos);
 
               if (horz1 || horz2 || vert1 || vert2) {
-                int border =
-                  (horz1 ? TOP: 0) |
-                  (horz2 ? BOTTOM: 0) |
-                  (vert1 ? LEFT: 0) |
-                  (vert2 ? RIGHT: 0);
+                int border = (horz1 ? TOP : 0) | (horz2 ? BOTTOM : 0) |
+                             (vert1 ? LEFT : 0) | (vert2 ? RIGHT : 0);
                 EditorHit hit(EditorHit::SliceCenter);
                 hit.setBorder(border);
                 hit.setSlice(slice);
-              return hit;
+                return hit;
               }
             }
 
@@ -2626,8 +2686,7 @@ void Editor::setZoomAndCenterInMouse(const Zoom& zoom,
 
   switch (zoomBehavior) {
     case ZoomBehavior::CENTER:
-      screenPos = gfx::Point(vp.x + vp.w/2,
-                             vp.y + vp.h/2);
+      screenPos = gfx::Point(vp.x + vp.w / 2, vp.y + vp.h / 2);
       break;
     case ZoomBehavior::MOUSE:
       screenPos = mousePos;
@@ -2637,10 +2696,15 @@ void Editor::setZoomAndCenterInMouse(const Zoom& zoom,
   // Limit zooming screen position to the visible sprite bounds (we
   // use canvasSize() because if the tiled mode is enabled, we need
   // extra space for the zoom)
-  gfx::Rect visibleBounds = editorToScreen(
-    getViewportBounds().createIntersection(gfx::Rect(gfx::Point(0, 0), canvasSize())));
-  screenPos.x = std::clamp(screenPos.x, visibleBounds.x, std::max(visibleBounds.x, visibleBounds.x2()-1));
-  screenPos.y = std::clamp(screenPos.y, visibleBounds.y, std::max(visibleBounds.y, visibleBounds.y2()-1));
+  gfx::Rect visibleBounds =
+    editorToScreen(getViewportBounds().createIntersection(
+      gfx::Rect(gfx::Point(0, 0), canvasSize())));
+  screenPos.x = std::clamp(screenPos.x,
+                           visibleBounds.x,
+                           std::max(visibleBounds.x, visibleBounds.x2() - 1));
+  screenPos.y = std::clamp(screenPos.y,
+                           visibleBounds.y,
+                           std::max(visibleBounds.y, visibleBounds.y2() - 1));
 
   spritePos = screenToEditor(screenPos);
 
@@ -2651,7 +2715,7 @@ void Editor::setZoomAndCenterInMouse(const Zoom& zoom,
       subpixelPos.x = (0.5 + screenPos.x - screenPos2.x) / m_proj.scaleX();
       if (proj.scaleX() > m_proj.scaleX()) {
         double t = 1.0 / proj.scaleX();
-        if (subpixelPos.x >= 0.5-t && subpixelPos.x <= 0.5+t)
+        if (subpixelPos.x >= 0.5 - t && subpixelPos.x <= 0.5 + t)
           subpixelPos.x = 0.5;
       }
     }
@@ -2660,16 +2724,19 @@ void Editor::setZoomAndCenterInMouse(const Zoom& zoom,
       subpixelPos.y = (0.5 + screenPos.y - screenPos2.y) / m_proj.scaleY();
       if (proj.scaleY() > m_proj.scaleY()) {
         double t = 1.0 / proj.scaleY();
-        if (subpixelPos.y >= 0.5-t && subpixelPos.y <= 0.5+t)
+        if (subpixelPos.y >= 0.5 - t && subpixelPos.y <= 0.5 + t)
           subpixelPos.y = 0.5;
       }
     }
   }
 
   gfx::Point padding = calcExtraPadding(proj);
-  gfx::Point scrollPos(
-    padding.x - (screenPos.x-vp.x) + proj.applyX(spritePos.x+proj.removeX(1)/2) + int(proj.applyX(subpixelPos.x)),
-    padding.y - (screenPos.y-vp.y) + proj.applyY(spritePos.y+proj.removeY(1)/2) + int(proj.applyY(subpixelPos.y)));
+  gfx::Point scrollPos(padding.x - (screenPos.x - vp.x) +
+                         proj.applyX(spritePos.x + proj.removeX(1) / 2) +
+                         int(proj.applyX(subpixelPos.x)),
+                       padding.y - (screenPos.y - vp.y) +
+                         proj.applyY(spritePos.y + proj.removeY(1) / 2) +
+                         int(proj.applyY(subpixelPos.y)));
 
   setZoom(zoom);
 
@@ -2692,9 +2759,10 @@ void Editor::pasteImage(const Image* image,
 
     temp_mask.reset(new Mask);
     temp_mask->replace(
-      gfx::Rect(visibleBounds.x + visibleBounds.w/2 - imageBounds.w/2,
-                visibleBounds.y + visibleBounds.h/2 - imageBounds.h/2,
-                imageBounds.w, imageBounds.h));
+      gfx::Rect(visibleBounds.x + visibleBounds.w / 2 - imageBounds.w / 2,
+                visibleBounds.y + visibleBounds.h / 2 - imageBounds.h / 2,
+                imageBounds.w,
+                imageBounds.h));
 
     mask = temp_mask.get();
   }
@@ -2704,8 +2772,8 @@ void Editor::pasteImage(const Image* image,
   // not compatible with the drawing cursor preview which overwrite
   // the extra cel.
   if (!getCurrentEditorInk()->isSelection()) {
-    tools::Tool* defaultSelectionTool =
-      App::instance()->toolBox()->getToolById(tools::WellKnownTools::RectangularMarquee);
+    tools::Tool* defaultSelectionTool = App::instance()->toolBox()->getToolById(
+      tools::WellKnownTools::RectangularMarquee);
 
     ToolBar::instance()->selectTool(defaultSelectionTool);
   }
@@ -2717,29 +2785,30 @@ void Editor::pasteImage(const Image* image,
   int y = (position ? position->y : mask->bounds().y);
   {
     const Rect visibleBounds = getViewportBounds();
-    const Point maskCenter = mask->bounds().center() +
-      (position ? gfx::Point(position->x - mask->bounds().x,
-                             position->y - mask->bounds().y)
-                : gfx::Point());
+    const Point maskCenter =
+      mask->bounds().center() + (position ?
+                                   gfx::Point(position->x - mask->bounds().x,
+                                              position->y - mask->bounds().y) :
+                                   gfx::Point());
 
     // If the pasted image original location center point isn't
     // visible, we center the image in the editor's visible bounds.
-    if (maskCenter.x < visibleBounds.x ||
-        maskCenter.x >= visibleBounds.x2()) {
-      x = visibleBounds.x + visibleBounds.w/2 - image->width()/2;
+    if (maskCenter.x < visibleBounds.x || maskCenter.x >= visibleBounds.x2()) {
+      x = visibleBounds.x + visibleBounds.w / 2 - image->width() / 2;
     }
     // In other case, if the center is visible, we put the pasted
     // image in its original location.
     else {
-      x = std::clamp(x, visibleBounds.x-image->width(), visibleBounds.x2()-1);
+      x =
+        std::clamp(x, visibleBounds.x - image->width(), visibleBounds.x2() - 1);
     }
 
-    if (maskCenter.y < visibleBounds.y ||
-        maskCenter.y >= visibleBounds.y2()) {
-      y = visibleBounds.y + visibleBounds.h/2 - image->height()/2;
+    if (maskCenter.y < visibleBounds.y || maskCenter.y >= visibleBounds.y2()) {
+      y = visibleBounds.y + visibleBounds.h / 2 - image->height() / 2;
     }
     else {
-      y = std::clamp(y, visibleBounds.y-image->height(), visibleBounds.y2()-1);
+      y = std::clamp(
+        y, visibleBounds.y - image->height(), visibleBounds.y2() - 1);
     }
 
     // Limit the image inside the sprite's bounds.
@@ -2750,8 +2819,8 @@ void Editor::pasteImage(const Image* image,
     }
     else {
       // Also we always limit the 1 image pixel inside the sprite's bounds.
-      x = std::clamp(x, -image->width()+1, sprite->width()-1);
-      y = std::clamp(y, -image->height()+1, sprite->height()-1);
+      x = std::clamp(x, -image->width() + 1, sprite->width() - 1);
+      y = std::clamp(y, -image->height() + 1, sprite->height() - 1);
     }
   }
 
@@ -2761,9 +2830,8 @@ void Editor::pasteImage(const Image* image,
   // TODO should we move this to PixelsMovement or MovingPixelsState?
   if (site.tilemapMode() == TilemapMode::Tiles) {
     gfx::Rect gridBounds = site.gridBounds();
-    gfx::Point pt = snap_to_grid(gridBounds,
-                                 gfx::Point(x, y),
-                                 PreferSnapTo::ClosestGridVertex);
+    gfx::Point pt = snap_to_grid(
+      gridBounds, gfx::Point(x, y), PreferSnapTo::ClosestGridVertex);
     x = pt.x;
     y = pt.y;
   }
@@ -2773,14 +2841,13 @@ void Editor::pasteImage(const Image* image,
   m_brushPreview.hide();
 
   Mask mask2(*mask);
-  position ? mask2.setOrigin(position->x, position->y)
-           : mask2.setOrigin(x, y);
+  position ? mask2.setOrigin(position->x, position->y) : mask2.setOrigin(x, y);
 
   PixelsMovementPtr pixelsMovement(
-    new PixelsMovement(UIContext::instance(), site,
-                       image, &mask2, "Paste"));
+    new PixelsMovement(UIContext::instance(), site, image, &mask2, "Paste"));
 
-  setState(EditorStatePtr(new MovingPixelsState(this, NULL, pixelsMovement, NoHandle)));
+  setState(EditorStatePtr(
+    new MovingPixelsState(this, NULL, pixelsMovement, NoHandle)));
 }
 
 void Editor::startSelectionTransformation(const gfx::Point& move, double angle)
@@ -2835,7 +2902,9 @@ bool Editor::checkForScroll(ui::MouseMessage* msg)
   tools::Ink* clickedInk = getCurrentEditorInk();
 
   // Start scroll loop
-  if (msg->middle() || clickedInk->isScrollMovement()) { // TODO msg->middle() should be customizable
+  if (msg->middle() ||
+      clickedInk
+        ->isScrollMovement()) {  // TODO msg->middle() should be customizable
     startScrollingState(msg);
     return true;
   }
@@ -2882,9 +2951,7 @@ void Editor::play(const bool playOnce,
     stop();
 
   m_isPlaying = true;
-  setState(EditorStatePtr(new PlayState(playOnce,
-                                        playAll,
-                                        playSubtags)));
+  setState(EditorStatePtr(new PlayState(playOnce, playAll, playSubtags)));
 }
 
 void Editor::stop()
@@ -2948,8 +3015,7 @@ void Editor::setAnimationSpeedMultiplier(double speed)
   m_aniSpeed = speed;
 }
 
-void Editor::showMouseCursor(CursorType cursorType,
-                             const Cursor* cursor)
+void Editor::showMouseCursor(CursorType cursorType, const Cursor* cursor)
 {
   m_brushPreview.hide();
   ui::set_mouse_cursor(cursorType, cursor);
@@ -2966,9 +3032,8 @@ gfx::Point Editor::calcExtraPadding(const Projection& proj)
   if (view) {
     Rect vp = view->viewportBounds();
     gfx::Size canvas = canvasSize();
-    return gfx::Point(
-      std::max<int>(vp.w/2, vp.w - proj.applyX(canvas.w)),
-      std::max<int>(vp.h/2, vp.h - proj.applyY(canvas.h)));
+    return gfx::Point(std::max<int>(vp.w / 2, vp.w - proj.applyX(canvas.w)),
+                      std::max<int>(vp.h / 2, vp.h - proj.applyY(canvas.h)));
   }
   else
     return gfx::Point(0, 0);
@@ -3019,7 +3084,6 @@ void Editor::invalidateCanvas()
 
 void Editor::invalidateIfActive()
 {
-
   if (isActive())
     invalidate();
 }
@@ -3029,26 +3093,25 @@ void Editor::updateAutoCelGuides(ui::Message* msg)
   Cel* oldShowGuidesThisCel = m_showGuidesThisCel;
   bool oldShowAutoCelGuides = m_showAutoCelGuides;
 
-  m_showAutoCelGuides = (
-    msg &&
-    getCurrentEditorInk()->isCelMovement() &&
-    m_docPref.show.autoGuides() &&
-    m_customizationDelegate &&
-    int(m_customizationDelegate->getPressedKeyAction(KeyContext::MoveTool) & KeyAction::AutoSelectLayer));
+  m_showAutoCelGuides =
+    (msg && getCurrentEditorInk()->isCelMovement() &&
+     m_docPref.show.autoGuides() && m_customizationDelegate &&
+     int(m_customizationDelegate->getPressedKeyAction(KeyContext::MoveTool) &
+         KeyAction::AutoSelectLayer));
 
   // Check if the user is pressing the Ctrl or Cmd key on move
   // tool to show automatic guides.
-  if (m_showAutoCelGuides &&
-      m_state->allowLayerEdges()) {
+  if (m_showAutoCelGuides && m_state->allowLayerEdges()) {
     auto mouseMsg = dynamic_cast<ui::MouseMessage*>(msg);
 
     ColorPicker picker;
-    picker.pickColor(getSite(),
-                     screenToEditorF(mouseMsg ? mouseMsg->position():
-                                                mousePosInDisplay()),
-                     m_proj, ColorPicker::FromComposition);
-    m_showGuidesThisCel = (picker.layer() ? picker.layer()->cel(m_frame):
-                                            nullptr);
+    picker.pickColor(
+      getSite(),
+      screenToEditorF(mouseMsg ? mouseMsg->position() : mousePosInDisplay()),
+      m_proj,
+      ColorPicker::FromComposition);
+    m_showGuidesThisCel =
+      (picker.layer() ? picker.layer()->cel(m_frame) : nullptr);
   }
   else {
     m_showGuidesThisCel = nullptr;
@@ -3073,27 +3136,25 @@ int Editor::otherLayersOpacity() const
 void Editor::registerCommands()
 {
   // TODO merge with ToggleOtherLayersOpacity
-  Commands::instance()
-    ->add(
-      new QuickCommand(
-        CommandId::SwitchNonactiveLayersOpacity(),
-        []{
-          static int oldValue = -1;
-          auto& option = Preferences::instance().experimental.nonactiveLayersOpacity;
-          if (oldValue == -1) {
-            oldValue = option();
-            if (option() == 255)
-              option(128);
-            else
-              option(255);
-          }
-          else {
-            const int newValue = oldValue;
-            oldValue = option();
-            option(newValue);
-          }
-          app_refresh_screen();
-        }));
+  Commands::instance()->add(
+    new QuickCommand(CommandId::SwitchNonactiveLayersOpacity(), [] {
+      static int oldValue = -1;
+      auto& option =
+        Preferences::instance().experimental.nonactiveLayersOpacity;
+      if (oldValue == -1) {
+        oldValue = option();
+        if (option() == 255)
+          option(128);
+        else
+          option(255);
+      }
+      else {
+        const int newValue = oldValue;
+        oldValue = option();
+        option(newValue);
+      }
+      app_refresh_screen();
+    }));
 }
 
-} // namespace app
+}  // namespace app

--- a/src/app/ui/editor/editor.h
+++ b/src/app/ui/editor/editor.h
@@ -43,468 +43,477 @@
 #include <set>
 
 namespace doc {
-  class Layer;
-  class Sprite;
-}
+class Layer;
+class Sprite;
+}  // namespace doc
 namespace gfx {
-  class Region;
+class Region;
 }
 namespace ui {
-  class Cursor;
-  class Graphics;
-  class View;
-}
+class Cursor;
+class Graphics;
+class View;
+}  // namespace ui
 
 namespace app {
-  class Context;
-  class DocView;
-  class EditorCustomizationDelegate;
-  class EditorRender;
-  class PixelsMovement;
-  class Site;
-  class Transformation;
+class Context;
+class DocView;
+class EditorCustomizationDelegate;
+class EditorRender;
+class PixelsMovement;
+class Site;
+class Transformation;
 
-  namespace tools {
-    class Ink;
-    class Pointer;
-    class Tool;
+namespace tools {
+class Ink;
+class Pointer;
+class Tool;
+}  // namespace tools
+
+enum class AutoScroll {
+  MouseDir,
+  ScrollDir,
+};
+
+class Editor : public ui::Widget,
+               public app::DocObserver,
+               public IColorSource,
+               public ITileSource,
+               public tools::ActiveToolObserver {
+public:
+  enum EditorFlags {
+    kNoneFlag = 0,
+    kShowGrid = 1,
+    kShowMask = 2,
+    kShowOnionskin = 4,
+    kShowOutside = 8,
+    kShowDecorators = 16,
+    kShowSymmetryLine = 32,
+    kShowSlices = 64,
+    kDefaultEditorFlags =
+      (kShowGrid | kShowMask | kShowOnionskin | kShowOutside | kShowDecorators |
+       kShowSymmetryLine | kShowSlices)
+  };
+
+  enum class ZoomBehavior {
+    CENTER,  // Zoom from center (don't change center of the editor)
+    MOUSE,   // Zoom from cursor
+  };
+
+  static ui::WidgetType Type();
+
+  Editor(Doc* document,
+         EditorFlags flags = kDefaultEditorFlags,
+         EditorStatePtr state = nullptr);
+  ~Editor();
+
+  static Editor* activeEditor() { return m_activeEditor; }
+  static void _setActiveEditor(Editor* editor) { m_activeEditor = editor; }
+  static void destroyEditorSharedInternals();
+
+  bool isActive() const { return (m_activeEditor == this); }
+  bool isUsingNewRenderEngine() const;
+
+  DocView* getDocView() { return m_docView; }
+  void setDocView(DocView* docView) { m_docView = docView; }
+
+  // Returns the current state.
+  EditorStatePtr getState() { return m_state; }
+
+  bool isMovingPixels() const;
+  void dropMovingPixels();
+
+  // Changes the state of the editor.
+  void setState(const EditorStatePtr& newState);
+
+  // Backs to previous state.
+  void backToPreviousState();
+
+  // Gets/sets the current decorator. The decorator is not owned by
+  // the Editor, so it must be deleted by the caller.
+  EditorDecorator* decorator() { return m_decorator; }
+  void setDecorator(EditorDecorator* decorator) { m_decorator = decorator; }
+  void getInvalidDecoratoredRegion(gfx::Region& region);
+
+  EditorFlags editorFlags() const { return m_flags; }
+  void setEditorFlags(EditorFlags flags) { m_flags = flags; }
+
+  bool isExtraCelLocked() const { return m_flashing != Flashing::None; }
+
+  Doc* document() { return m_document; }
+  Sprite* sprite() { return m_sprite; }
+  Layer* layer() { return m_layer; }
+  frame_t frame() { return m_frame; }
+  DocumentPreferences& docPref() { return m_docPref; }
+
+  void getSite(Site* site) const;
+  Site getSite() const;
+
+  void setLayer(const Layer* layer);
+  void setFrame(frame_t frame);
+
+  const render::Projection& projection() const { return m_proj; }
+  const render::Zoom& zoom() const { return m_proj.zoom(); }
+  const gfx::Point& padding() const { return m_padding; }
+
+  void setZoom(const render::Zoom& zoom);
+  void setDefaultScroll();
+  void setScrollToCenter();
+  void setScrollAndZoomToFitScreen();
+  void setEditorScroll(const gfx::Point& scroll);
+  void setEditorZoom(const render::Zoom& zoom);
+
+  // Updates the Editor's view.
+  void updateEditor(const bool restoreScrollPos);
+
+  // Draws the sprite taking care of the whole clipping region.
+  void drawSpriteClipped(const gfx::Region& updateRegion);
+
+  void flashCurrentLayer();
+
+  // Convert ui::Display coordinates (pixel relative to the top-left
+  // corner of the in the display content bounds) from/to
+  // editor/sprite coordinates (pixel in the canvas).
+  //
+  // TODO we should rename these functions to displayToEditor() and editorToDisplay()
+  gfx::Point screenToEditor(const gfx::Point& pt) const;
+  gfx::Point screenToEditorCeiling(const gfx::Point& pt) const;
+  gfx::PointF screenToEditorF(const gfx::Point& pt) const;
+  gfx::Point editorToScreen(const gfx::Point& pt) const;
+  gfx::PointF editorToScreenF(const gfx::PointF& pt) const;
+  gfx::Rect screenToEditor(const gfx::Rect& rc) const;
+  gfx::Rect editorToScreen(const gfx::Rect& rc) const;
+  gfx::RectF editorToScreenF(const gfx::RectF& rc) const;
+
+  void add_observer(EditorObserver* observer);
+  void remove_observer(EditorObserver* observer);
+
+  void setCustomizationDelegate(EditorCustomizationDelegate* delegate);
+
+  EditorCustomizationDelegate* getCustomizationDelegate()
+  {
+    return m_customizationDelegate;
   }
 
-  enum class AutoScroll {
-    MouseDir,
-    ScrollDir,
-  };
-
-  class Editor : public ui::Widget,
-                 public app::DocObserver,
-                 public IColorSource,
-                 public ITileSource,
-                 public tools::ActiveToolObserver {
-  public:
-    enum EditorFlags {
-      kNoneFlag = 0,
-      kShowGrid = 1,
-      kShowMask = 2,
-      kShowOnionskin = 4,
-      kShowOutside = 8,
-      kShowDecorators = 16,
-      kShowSymmetryLine = 32,
-      kShowSlices = 64,
-      kDefaultEditorFlags = (kShowGrid |
-                             kShowMask |
-                             kShowOnionskin |
-                             kShowOutside |
-                             kShowDecorators |
-                             kShowSymmetryLine |
-                             kShowSlices)
-    };
-
-    enum class ZoomBehavior {
-      CENTER,                   // Zoom from center (don't change center of the editor)
-      MOUSE,                    // Zoom from cursor
-    };
-
-    static ui::WidgetType Type();
-
-    Editor(Doc* document,
-           EditorFlags flags = kDefaultEditorFlags,
-           EditorStatePtr state = nullptr);
-    ~Editor();
-
-    static Editor* activeEditor() { return m_activeEditor; }
-    static void _setActiveEditor(Editor* editor) { m_activeEditor = editor; }
-    static void destroyEditorSharedInternals();
-
-    bool isActive() const { return (m_activeEditor == this); }
-    bool isUsingNewRenderEngine() const;
-
-    DocView* getDocView() { return m_docView; }
-    void setDocView(DocView* docView) { m_docView = docView; }
-
-    // Returns the current state.
-    EditorStatePtr getState() { return m_state; }
-
-    bool isMovingPixels() const;
-    void dropMovingPixels();
-
-    // Changes the state of the editor.
-    void setState(const EditorStatePtr& newState);
-
-    // Backs to previous state.
-    void backToPreviousState();
-
-    // Gets/sets the current decorator. The decorator is not owned by
-    // the Editor, so it must be deleted by the caller.
-    EditorDecorator* decorator() { return m_decorator; }
-    void setDecorator(EditorDecorator* decorator) { m_decorator = decorator; }
-    void getInvalidDecoratoredRegion(gfx::Region& region);
-
-    EditorFlags editorFlags() const { return m_flags; }
-    void setEditorFlags(EditorFlags flags) { m_flags = flags; }
-
-    bool isExtraCelLocked() const {
-      return m_flashing != Flashing::None;
-    }
-
-    Doc* document() { return m_document; }
-    Sprite* sprite() { return m_sprite; }
-    Layer* layer() { return m_layer; }
-    frame_t frame() { return m_frame; }
-    DocumentPreferences& docPref() { return m_docPref; }
-
-    void getSite(Site* site) const;
-    Site getSite() const;
-
-    void setLayer(const Layer* layer);
-    void setFrame(frame_t frame);
-
-    const render::Projection& projection() const { return m_proj; }
-    const render::Zoom& zoom() const { return m_proj.zoom(); }
-    const gfx::Point& padding() const { return m_padding; }
-
-    void setZoom(const render::Zoom& zoom);
-    void setDefaultScroll();
-    void setScrollToCenter();
-    void setScrollAndZoomToFitScreen();
-    void setEditorScroll(const gfx::Point& scroll);
-    void setEditorZoom(const render::Zoom& zoom);
-
-    // Updates the Editor's view.
-    void updateEditor(const bool restoreScrollPos);
-
-    // Draws the sprite taking care of the whole clipping region.
-    void drawSpriteClipped(const gfx::Region& updateRegion);
-
-    void flashCurrentLayer();
-
-    // Convert ui::Display coordinates (pixel relative to the top-left
-    // corner of the in the display content bounds) from/to
-    // editor/sprite coordinates (pixel in the canvas).
-    //
-    // TODO we should rename these functions to displayToEditor() and editorToDisplay()
-    gfx::Point screenToEditor(const gfx::Point& pt) const;
-    gfx::Point screenToEditorCeiling(const gfx::Point& pt) const;
-    gfx::PointF screenToEditorF(const gfx::Point& pt) const;
-    gfx::Point editorToScreen(const gfx::Point& pt) const;
-    gfx::PointF editorToScreenF(const gfx::PointF& pt) const;
-    gfx::Rect screenToEditor(const gfx::Rect& rc) const;
-    gfx::Rect editorToScreen(const gfx::Rect& rc) const;
-    gfx::RectF editorToScreenF(const gfx::RectF& rc) const;
-
-    void add_observer(EditorObserver* observer);
-    void remove_observer(EditorObserver* observer);
-
-    void setCustomizationDelegate(EditorCustomizationDelegate* delegate);
-
-    EditorCustomizationDelegate* getCustomizationDelegate() {
-      return m_customizationDelegate;
-    }
-
-    // Returns the visible area of the viewport in sprite coordinates.
-    gfx::Rect getViewportBounds();
-
-    // Returns the visible area of the active sprite.
-    gfx::Rect getVisibleSpriteBounds();
-
-    gfx::Size canvasSize() const;
-    gfx::Point mainTilePosition() const;
-    void expandRegionByTiledMode(gfx::Region& rgn,
-                                 const bool withProj) const;
-    void collapseRegionByTiledMode(gfx::Region& rgn) const;
-
-    // Changes the scroll to see the given point as the center of the editor.
-    void centerInSpritePoint(const gfx::PointF& spritePos);
-    void centerInSpritePoint(const gfx::Point& spritePos);
-    gfx::PointF spritePointInCenter() const;
-
-    void updateStatusBar();
-
-    // Control scroll when cursor goes out of the editor viewport.
-    gfx::Point autoScroll(const ui::MouseMessage* msg,
-                          const AutoScroll dir);
-
-    tools::Tool* getCurrentEditorTool() const;
-    tools::Ink* getCurrentEditorInk() const;
-
-    tools::ToolLoopModifiers getToolLoopModifiers() const { return m_toolLoopModifiers; }
-    bool isAutoSelectLayer();
-
-    // Returns true if we are able to draw in the current doc/sprite/layer/cel.
-    bool canDraw();
-
-    // Returns true if the cursor is inside the active mask/selection.
-    bool isInsideSelection();
-
-    // Returns true if the cursor is inside the selection and the
-    // selection mode is the default one which prioritizes and easy
-    // way to move the selection.
-    bool canStartMovingSelectionPixels();
-
-    // Returns true if the range selected in the timeline should be
-    // kept. E.g. When we are moving/transforming pixels on multiple
-    // cels, the MovingPixelsState can handle previous/next frame
-    // commands, so it's nice to keep the timeline range intact while
-    // we are in the MovingPixelsState.
-    bool keepTimelineRange();
-
-    // Returns the element that will be modified if the mouse is used
-    // in the given position.
-    EditorHit calcHit(const gfx::Point& mouseScreenPos);
-
-    void setZoomAndCenterInMouse(const render::Zoom& zoom,
-      const gfx::Point& mousePos, ZoomBehavior zoomBehavior);
-
-    void pasteImage(const Image* image,
-                    const Mask* mask = nullptr,
-                    const gfx::Point* position = nullptr);
-
-    void startSelectionTransformation(const gfx::Point& move, double angle);
-    void startFlipTransformation(doc::algorithm::FlipType flipType);
-    void updateTransformation(const Transformation& transform);
-
-    // Used by EditorView to notify changes in the view's scroll
-    // position.
-    void notifyScrollChanged();
-    void notifyZoomChanged();
-
-    // Returns true and changes to ScrollingState when "msg" says "the
-    // user wants to scroll". Same for zoom.
-    bool checkForScroll(ui::MouseMessage* msg);
-    bool checkForZoom(ui::MouseMessage* msg);
-
-    // Start Scrolling/ZoomingState
-    void startScrollingState(ui::MouseMessage* msg);
-    void startZoomingState(ui::MouseMessage* msg);
-
-    // Animation control
-    void play(const bool playOnce,
-              const bool playAll,
-              const bool playSubtags);
-    void stop();
-    bool isPlaying() const;
-
-    // Shows a popup menu to change the editor animation speed.
-    void showAnimationSpeedMultiplierPopup();
-    double getAnimationSpeedMultiplier() const;
-    void setAnimationSpeedMultiplier(double speed);
-
-    // Functions to be used in EditorState::onSetCursor()
-    void showMouseCursor(ui::CursorType cursorType,
-                         const ui::Cursor* cursor = nullptr);
-    void showBrushPreview(const gfx::Point& pos);
-
-    // Gets the brush preview controller.
-    BrushPreview& brushPreview() { return m_brushPreview; }
-
-    static EditorRender& renderEngine() { return *m_renderEngine; }
-
-    // IColorSource
-    app::Color getColorByPosition(const gfx::Point& pos) override;
-
-    // ITileSource
-    doc::tile_t getTileByPosition(const gfx::Point& pos) override;
-
-    void setTagFocusBand(int value) { m_tagFocusBand = value; }
-    int tagFocusBand() const { return m_tagFocusBand; }
-
-    // Returns true if the Shift key to draw straight lines with a
-    // freehand tool is pressed.
-    bool startStraightLineWithFreehandTool(const tools::Pointer* pointer);
-
-    // Functions to handle the set of selected slices.
-    bool isSliceSelected(const doc::Slice* slice) const;
-    void clearSlicesSelection();
-    void selectSlice(const doc::Slice* slice);
-    bool selectSliceBox(const gfx::Rect& box);
-    void selectAllSlices();
-    bool hasSelectedSlices() const { return !m_selectedSlices.empty(); }
-
-    // Called by DocView's InputChainElement::onCancel() impl when Esc
-    // key is pressed to cancel the active selection.
-    void cancelSelections();
-
-    // Properties to show information in the status bar
-    bool showAutoCelGuides() const { return m_showAutoCelGuides; }
-
-    // Used in case an unhandled exception was caught when processing
-    // an Editor or EditorState event.
-    void showUnhandledException(const std::exception& ex,
-                                const ui::Message* msg);
-
-    static void registerCommands();
-
-  protected:
-    bool onProcessMessage(ui::Message* msg) override;
-    void onSizeHint(ui::SizeHintEvent& ev) override;
-    void onResize(ui::ResizeEvent& ev) override;
-    void onPaint(ui::PaintEvent& ev) override;
-    void onInvalidateRegion(const gfx::Region& region) override;
-    void onSamplingChange();
-    void onFgColorChange();
-    void onContextBarBrushChange();
-    void onTiledModeBeforeChange();
-    void onTiledModeChange();
-    void onShowExtrasChange();
-
-    // DocObserver impl
-    void onColorSpaceChanged(DocEvent& ev) override;
-    void onExposeSpritePixels(DocEvent& ev) override;
-    void onSpritePixelRatioChanged(DocEvent& ev) override;
-    void onBeforeRemoveLayer(DocEvent& ev) override;
-    void onBeforeRemoveCel(DocEvent& ev) override;
-    void onAddTag(DocEvent& ev) override;
-    void onRemoveTag(DocEvent& ev) override;
-    void onRemoveSlice(DocEvent& ev) override;
-    void onBeforeLayerVisibilityChange(DocEvent& ev, bool newState) override;
-
-    // ActiveToolObserver impl
-    void onActiveToolChange(tools::Tool* tool) override;
-
-  private:
-    enum class Flashing { None, WithFlashExtraCel, WaitingDeferedPaint };
-
-    void setStateInternal(const EditorStatePtr& newState);
-    void updateQuicktool();
-    void updateToolByTipProximity(ui::PointerType pointerType);
-
-    // firstFromMouseDown=true when we call this function from the
-    // first MouseDown message (instead of KeyDown).
-    void updateToolLoopModifiersIndicators(const bool firstFromMouseDown = false);
-
-    void drawBackground(ui::Graphics* g);
-    void drawSpriteUnclippedRect(ui::Graphics* g, const gfx::Rect& rc);
-    void drawMaskSafe();
-    void drawMask(ui::Graphics* g);
-    void drawGrid(ui::Graphics* g, const gfx::Rect& spriteBounds, const gfx::Rect& gridBounds,
-                  const app::Color& color, int alpha);
-    void drawSlices(ui::Graphics* g);
-    void drawTileNumbers(ui::Graphics* g, const Cel* cel);
-    void drawCelBounds(ui::Graphics* g, const Cel* cel, const gfx::Color color);
-    void drawCelGuides(ui::Graphics* g, const Cel* cel, const Cel* mouseCel);
-    void drawCelHGuide(ui::Graphics* g,
-                       const int sprX1, const int sprX2,
-                       const int scrX1, const int scrX2, const int scrY,
-                       const gfx::Rect& scrCelBounds, const gfx::Rect& scrCmpBounds,
-                       const int dottedX);
-    void drawCelVGuide(ui::Graphics* g,
-                       const int sprY1, const int sprY2,
-                       const int scrY1, const int scrY2, const int scrX,
-                       const gfx::Rect& scrCelBounds, const gfx::Rect& scrCmpBounds,
-                       const int dottedY);
-    gfx::Rect getCelScreenBounds(const Cel* cel);
-
-    void setCursor(const gfx::Point& mouseDisplayPos);
-
-    // Draws the specified portion of sprite in the editor.  Warning:
-    // You should setup the clip of the screen before calling this
-    // routine.
-    void drawOneSpriteUnclippedRect(ui::Graphics* g, const gfx::Rect& rc, int dx, int dy);
-
-    gfx::Point calcExtraPadding(const render::Projection& proj);
-
-    void invalidateCanvas();
-    void invalidateIfActive();
-    void updateAutoCelGuides(ui::Message* msg);
-
-    int otherLayersOpacity() const;
-
-    // Stack of states. The top element in the stack is the current state (m_state).
-    EditorStatesHistory m_statesHistory;
-    EditorStatesHistory m_deletedStates;
-
-    // Current editor state (it can be shared between several editors to
-    // the same document). This member cannot be NULL.
-    EditorStatePtr m_state;
-
-    // Current decorator (to draw extra UI elements).
-    EditorDecorator* m_decorator;
-
-    Doc* m_document;              // Active document in the editor
-    Sprite* m_sprite;             // Active sprite in the editor
-    Layer* m_layer;               // Active layer in the editor
-    frame_t m_frame;              // Active frame in the editor
-    render::Projection m_proj;    // Zoom/pixel ratio in the editor
-    DocumentPreferences& m_docPref;
-    // Helper functions affected by the current Tiled Mode.
-    app::TiledModeHelper m_tiledModeHelper;
-
-    // Brush preview
-    BrushPreview m_brushPreview;
-
-    tools::ToolLoopModifiers m_toolLoopModifiers;
-
-    // Extra space around the sprite.
-    gfx::Point m_padding;
-
-    // Marching ants stuff
-    ui::Timer m_antsTimer;
-    int m_antsOffset;
-
-    obs::scoped_connection m_samplingChangeConn;
-    obs::scoped_connection m_fgColorChangeConn;
-    obs::scoped_connection m_contextBarBrushChangeConn;
-    obs::scoped_connection m_showExtrasConn;
-
-    // Slots listeing document preferences.
-    obs::scoped_connection m_tiledConnBefore;
-    obs::scoped_connection m_tiledConn;
-    obs::scoped_connection m_gridConn;
-    obs::scoped_connection m_pixelGridConn;
-    obs::scoped_connection m_bgConn;
-    obs::scoped_connection m_onionskinConn;
-    obs::scoped_connection m_symmetryModeConn;
-
-    EditorObservers m_observers;
-
-    EditorCustomizationDelegate* m_customizationDelegate;
-
-    DocView* m_docView;
-
-    // Last known mouse position received by this editor when the
-    // mouse button was pressed. Used for auto-scrolling. To get the
-    // current mouse position on the editor you can use
-    // ui::Display::lastMousePos().
-    gfx::Point m_oldPos;
-
-    EditorFlags m_flags;
-
-    bool m_secondaryButton;
-    Flashing m_flashing;
-
-    // Animation speed multiplier.
-    double m_aniSpeed;
-    bool m_isPlaying;
-
-    // The Cel that is above the mouse if the Ctrl (or Cmd) key is
-    // pressed (move key).
-    Cel* m_showGuidesThisCel;
-    bool m_showAutoCelGuides;
-
-    // Focused tag band. Used by the Timeline to save/restore the
-    // focused tag band for each sprite/editor.
-    int m_tagFocusBand;
-
-    // Used to restore scroll when the tiled mode is changed.
-    // TODO could we avoid one extra field just to do this?
-    gfx::Point m_oldMainTilePos;
+  // Returns the visible area of the viewport in sprite coordinates.
+  gfx::Rect getViewportBounds();
+
+  // Returns the visible area of the active sprite.
+  gfx::Rect getVisibleSpriteBounds();
+
+  gfx::Size canvasSize() const;
+  gfx::Point mainTilePosition() const;
+  void expandRegionByTiledMode(gfx::Region& rgn, const bool withProj) const;
+  void collapseRegionByTiledMode(gfx::Region& rgn) const;
+
+  // Changes the scroll to see the given point as the center of the editor.
+  void centerInSpritePoint(const gfx::PointF& spritePos);
+  void centerInSpritePoint(const gfx::Point& spritePos);
+  gfx::PointF spritePointInCenter() const;
+
+  void updateStatusBar();
+
+  // Control scroll when cursor goes out of the editor viewport.
+  gfx::Point autoScroll(const ui::MouseMessage* msg, const AutoScroll dir);
+
+  tools::Tool* getCurrentEditorTool() const;
+  tools::Ink* getCurrentEditorInk() const;
+
+  tools::ToolLoopModifiers getToolLoopModifiers() const
+  {
+    return m_toolLoopModifiers;
+  }
+  bool isAutoSelectLayer();
+
+  // Returns true if we are able to draw in the current doc/sprite/layer/cel.
+  bool canDraw();
+
+  // Returns true if the cursor is inside the active mask/selection.
+  bool isInsideSelection();
+
+  // Returns true if the cursor is inside the selection and the
+  // selection mode is the default one which prioritizes and easy
+  // way to move the selection.
+  bool canStartMovingSelectionPixels();
+
+  // Returns true if the range selected in the timeline should be
+  // kept. E.g. When we are moving/transforming pixels on multiple
+  // cels, the MovingPixelsState can handle previous/next frame
+  // commands, so it's nice to keep the timeline range intact while
+  // we are in the MovingPixelsState.
+  bool keepTimelineRange();
+
+  // Returns the element that will be modified if the mouse is used
+  // in the given position.
+  EditorHit calcHit(const gfx::Point& mouseScreenPos);
+
+  void setZoomAndCenterInMouse(const render::Zoom& zoom,
+                               const gfx::Point& mousePos,
+                               ZoomBehavior zoomBehavior);
+
+  void pasteImage(const Image* image,
+                  const Mask* mask = nullptr,
+                  const gfx::Point* position = nullptr);
+
+  void startSelectionTransformation(const gfx::Point& move, double angle);
+  void startFlipTransformation(doc::algorithm::FlipType flipType);
+  void updateTransformation(const Transformation& transform);
+
+  // Used by EditorView to notify changes in the view's scroll
+  // position.
+  void notifyScrollChanged();
+  void notifyZoomChanged();
+
+  // Returns true and changes to ScrollingState when "msg" says "the
+  // user wants to scroll". Same for zoom.
+  bool checkForScroll(ui::MouseMessage* msg);
+  bool checkForZoom(ui::MouseMessage* msg);
+
+  // Start Scrolling/ZoomingState
+  void startScrollingState(ui::MouseMessage* msg);
+  void startZoomingState(ui::MouseMessage* msg);
+
+  // Animation control
+  void play(const bool playOnce, const bool playAll, const bool playSubtags);
+  void stop();
+  bool isPlaying() const;
+
+  // Shows a popup menu to change the editor animation speed.
+  void showAnimationSpeedMultiplierPopup();
+  double getAnimationSpeedMultiplier() const;
+  void setAnimationSpeedMultiplier(double speed);
+
+  // Functions to be used in EditorState::onSetCursor()
+  void showMouseCursor(ui::CursorType cursorType,
+                       const ui::Cursor* cursor = nullptr);
+  void showBrushPreview(const gfx::Point& pos);
+
+  // Gets the brush preview controller.
+  BrushPreview& brushPreview() { return m_brushPreview; }
+
+  static EditorRender& renderEngine() { return *m_renderEngine; }
+
+  // IColorSource
+  app::Color getColorByPosition(const gfx::Point& pos) override;
+
+  // ITileSource
+  doc::tile_t getTileByPosition(const gfx::Point& pos) override;
+
+  void setTagFocusBand(int value) { m_tagFocusBand = value; }
+  int tagFocusBand() const { return m_tagFocusBand; }
+
+  // Returns true if the Shift key to draw straight lines with a
+  // freehand tool is pressed.
+  bool startStraightLineWithFreehandTool(const tools::Pointer* pointer);
+
+  // Functions to handle the set of selected slices.
+  bool isSliceSelected(const doc::Slice* slice) const;
+  void clearSlicesSelection();
+  void selectSlice(const doc::Slice* slice);
+  bool selectSliceBox(const gfx::Rect& box);
+  void selectAllSlices();
+  bool hasSelectedSlices() const { return !m_selectedSlices.empty(); }
+
+  // Called by DocView's InputChainElement::onCancel() impl when Esc
+  // key is pressed to cancel the active selection.
+  void cancelSelections();
+
+  // Properties to show information in the status bar
+  bool showAutoCelGuides() const { return m_showAutoCelGuides; }
+
+  // Used in case an unhandled exception was caught when processing
+  // an Editor or EditorState event.
+  void showUnhandledException(const std::exception& ex, const ui::Message* msg);
+
+  static void registerCommands();
+
+protected:
+  bool onProcessMessage(ui::Message* msg) override;
+  void onSizeHint(ui::SizeHintEvent& ev) override;
+  void onResize(ui::ResizeEvent& ev) override;
+  void onPaint(ui::PaintEvent& ev) override;
+  void onInvalidateRegion(const gfx::Region& region) override;
+  void onSamplingChange();
+  void onFgColorChange();
+  void onContextBarBrushChange();
+  void onTiledModeBeforeChange();
+  void onTiledModeChange();
+  void onShowExtrasChange();
+
+  // DocObserver impl
+  void onColorSpaceChanged(DocEvent& ev) override;
+  void onExposeSpritePixels(DocEvent& ev) override;
+  void onSpritePixelRatioChanged(DocEvent& ev) override;
+  void onBeforeRemoveLayer(DocEvent& ev) override;
+  void onBeforeRemoveCel(DocEvent& ev) override;
+  void onAddTag(DocEvent& ev) override;
+  void onRemoveTag(DocEvent& ev) override;
+  void onRemoveSlice(DocEvent& ev) override;
+  void onBeforeLayerVisibilityChange(DocEvent& ev, bool newState) override;
+  void onBeforeLayerEditableChange(DocEvent& ev, bool newState) override;
+
+  // ActiveToolObserver impl
+  void onActiveToolChange(tools::Tool* tool) override;
+
+private:
+  enum class Flashing { None, WithFlashExtraCel, WaitingDeferedPaint };
+
+  void setStateInternal(const EditorStatePtr& newState);
+  void updateQuicktool();
+  void updateToolByTipProximity(ui::PointerType pointerType);
+
+  // firstFromMouseDown=true when we call this function from the
+  // first MouseDown message (instead of KeyDown).
+  void updateToolLoopModifiersIndicators(const bool firstFromMouseDown = false);
+
+  void drawBackground(ui::Graphics* g);
+  void drawSpriteUnclippedRect(ui::Graphics* g, const gfx::Rect& rc);
+  void drawMaskSafe();
+  void drawMask(ui::Graphics* g);
+  void drawGrid(ui::Graphics* g,
+                const gfx::Rect& spriteBounds,
+                const gfx::Rect& gridBounds,
+                const app::Color& color,
+                int alpha);
+  void drawSlices(ui::Graphics* g);
+  void drawTileNumbers(ui::Graphics* g, const Cel* cel);
+  void drawCelBounds(ui::Graphics* g, const Cel* cel, const gfx::Color color);
+  void drawCelGuides(ui::Graphics* g, const Cel* cel, const Cel* mouseCel);
+  void drawCelHGuide(ui::Graphics* g,
+                     const int sprX1,
+                     const int sprX2,
+                     const int scrX1,
+                     const int scrX2,
+                     const int scrY,
+                     const gfx::Rect& scrCelBounds,
+                     const gfx::Rect& scrCmpBounds,
+                     const int dottedX);
+  void drawCelVGuide(ui::Graphics* g,
+                     const int sprY1,
+                     const int sprY2,
+                     const int scrY1,
+                     const int scrY2,
+                     const int scrX,
+                     const gfx::Rect& scrCelBounds,
+                     const gfx::Rect& scrCmpBounds,
+                     const int dottedY);
+  gfx::Rect getCelScreenBounds(const Cel* cel);
+
+  void setCursor(const gfx::Point& mouseDisplayPos);
+
+  // Draws the specified portion of sprite in the editor.  Warning:
+  // You should setup the clip of the screen before calling this
+  // routine.
+  void drawOneSpriteUnclippedRect(ui::Graphics* g,
+                                  const gfx::Rect& rc,
+                                  int dx,
+                                  int dy);
+
+  gfx::Point calcExtraPadding(const render::Projection& proj);
+
+  void invalidateCanvas();
+  void invalidateIfActive();
+  void updateAutoCelGuides(ui::Message* msg);
+
+  int otherLayersOpacity() const;
+
+  // Stack of states. The top element in the stack is the current state (m_state).
+  EditorStatesHistory m_statesHistory;
+  EditorStatesHistory m_deletedStates;
+
+  // Current editor state (it can be shared between several editors to
+  // the same document). This member cannot be NULL.
+  EditorStatePtr m_state;
+
+  // Current decorator (to draw extra UI elements).
+  EditorDecorator* m_decorator;
+
+  Doc* m_document;            // Active document in the editor
+  Sprite* m_sprite;           // Active sprite in the editor
+  Layer* m_layer;             // Active layer in the editor
+  frame_t m_frame;            // Active frame in the editor
+  render::Projection m_proj;  // Zoom/pixel ratio in the editor
+  DocumentPreferences& m_docPref;
+  // Helper functions affected by the current Tiled Mode.
+  app::TiledModeHelper m_tiledModeHelper;
+
+  // Brush preview
+  BrushPreview m_brushPreview;
+
+  tools::ToolLoopModifiers m_toolLoopModifiers;
+
+  // Extra space around the sprite.
+  gfx::Point m_padding;
+
+  // Marching ants stuff
+  ui::Timer m_antsTimer;
+  int m_antsOffset;
+
+  obs::scoped_connection m_samplingChangeConn;
+  obs::scoped_connection m_fgColorChangeConn;
+  obs::scoped_connection m_contextBarBrushChangeConn;
+  obs::scoped_connection m_showExtrasConn;
+
+  // Slots listening document preferences.
+  obs::scoped_connection m_tiledConnBefore;
+  obs::scoped_connection m_tiledConn;
+  obs::scoped_connection m_gridConn;
+  obs::scoped_connection m_pixelGridConn;
+  obs::scoped_connection m_bgConn;
+  obs::scoped_connection m_onionskinConn;
+  obs::scoped_connection m_symmetryModeConn;
+
+  EditorObservers m_observers;
+
+  EditorCustomizationDelegate* m_customizationDelegate;
+
+  DocView* m_docView;
+
+  // Last known mouse position received by this editor when the
+  // mouse button was pressed. Used for auto-scrolling. To get the
+  // current mouse position on the editor you can use
+  // ui::Display::lastMousePos().
+  gfx::Point m_oldPos;
+
+  EditorFlags m_flags;
+
+  bool m_secondaryButton;
+  Flashing m_flashing;
+
+  // Animation speed multiplier.
+  double m_aniSpeed;
+  bool m_isPlaying;
+
+  // The Cel that is above the mouse if the Ctrl (or Cmd) key is
+  // pressed (move key).
+  Cel* m_showGuidesThisCel;
+  bool m_showAutoCelGuides;
+
+  // Focused tag band. Used by the Timeline to save/restore the
+  // focused tag band for each sprite/editor.
+  int m_tagFocusBand;
+
+  // Used to restore scroll when the tiled mode is changed.
+  // TODO could we avoid one extra field just to do this?
+  gfx::Point m_oldMainTilePos;
 
 #if ENABLE_DEVMODE
-    gfx::Rect m_perfInfoBounds;
+  gfx::Rect m_perfInfoBounds;
 #endif
 
-    // For slices
-    doc::SelectedObjects m_selectedSlices;
+  // For slices
+  doc::SelectedObjects m_selectedSlices;
 
-    // Active sprite editor with the keyboard focus.
-    static Editor* m_activeEditor;
+  // Active sprite editor with the keyboard focus.
+  static Editor* m_activeEditor;
 
-    // The render engine must be shared between all editors so when a
-    // DrawingState is being used in one editor, other editors for the
-    // same document can show the same preview image/stroke being drawn
-    // (search for Render::setPreviewImage()).
-    static std::unique_ptr<EditorRender> m_renderEngine;
-  };
+  // The render engine must be shared between all editors so when a
+  // DrawingState is being used in one editor, other editors for the
+  // same document can show the same preview image/stroke being drawn
+  // (search for Render::setPreviewImage()).
+  static std::unique_ptr<EditorRender> m_renderEngine;
+};
 
-} // namespace app
+}  // namespace app
 
 #endif

--- a/src/app/ui/editor/editor_state.h
+++ b/src/app/ui/editor/editor_state.h
@@ -16,147 +16,178 @@
 #include <memory>
 
 namespace gfx {
-  class Region;
+class Region;
 }
 
 namespace ui {
-  class KeyMessage;
-  class MouseMessage;
-  class TouchMessage;
-}
+class KeyMessage;
+class MouseMessage;
+class TouchMessage;
+}  // namespace ui
 
 namespace doc {
-  class Layer;
-  class Tag;
-}
+class Layer;
+class Tag;
+}  // namespace doc
 
 namespace app {
-  class Editor;
-  class EditorDecorator;
+class Editor;
+class EditorDecorator;
 
-  namespace tools {
-    class Ink;
-    class Tool;
+namespace tools {
+class Ink;
+class Tool;
+}  // namespace tools
+
+// Represents one state of the sprite's editor (Editor class).  This
+// is a base class, a dummy state that ignores all events from the
+// Editor. Subclasses overrides these methods to customize the
+// behavior of the Editor to do different tasks (e.g. scrolling,
+// drawing in the active sprite, etc.).
+class EditorState {
+public:
+  enum LeaveAction { DiscardState, KeepState };
+
+  EditorState() { }
+  virtual ~EditorState() { }
+
+  // Returns true if this state is a "temporal" state. It means that
+  // this state doesn't go to other state than the previous one.
+  virtual bool isTemporalState() const { return false; }
+
+  // Called just before this state is replaced by a new state in the
+  // Editor::setState() method.  Returns true if this state should be
+  // kept in the EditorStatesHistory.
+  virtual LeaveAction onLeaveState(Editor* editor, EditorState* newState)
+  {
+    return KeepState;
   }
 
-  // Represents one state of the sprite's editor (Editor class).  This
-  // is a base class, a dummy state that ignores all events from the
-  // Editor. Subclasses overrides these methods to customize the
-  // behavior of the Editor to do different tasks (e.g. scrolling,
-  // drawing in the active sprite, etc.).
-  class EditorState {
-  public:
-    enum LeaveAction {
-      DiscardState,
-      KeepState
-    };
+  // Called when this instance is set as the new Editor's state when
+  // Editor::setState() method is used.
+  virtual void onEnterState(Editor* editor) { }
 
-    EditorState() { }
-    virtual ~EditorState() { }
+  // Called just before the state will be removed from the
+  // EditorStatesHistory.  This event is useful to remove the
+  // decorator from the editor.
+  virtual void onBeforePopState(Editor* editor) { }
 
-    // Returns true if this state is a "temporal" state. It means that
-    // this state doesn't go to other state than the previous one.
-    virtual bool isTemporalState() const { return false; }
+  // Called when the current tool in the tool bar changes. It is
+  // useful for states which depends on the selected current tool (as
+  // MovingPixelsState which drops the pixels in case the user selects
+  // other drawing tool).
+  virtual void onActiveToolChange(Editor* editor, tools::Tool* tool) { }
 
-    // Called just before this state is replaced by a new state in the
-    // Editor::setState() method.  Returns true if this state should be
-    // kept in the EditorStatesHistory.
-    virtual LeaveAction onLeaveState(Editor* editor, EditorState* newState) {
-      return KeepState;
-    }
+  // Called when the editor gets the focus.
+  virtual void onEditorGotFocus(Editor* editor) { }
 
-    // Called when this instance is set as the new Editor's state when
-    // Editor::setState() method is used.
-    virtual void onEnterState(Editor* editor) { }
+  // Called when the user presses a mouse button over the editor.
+  virtual bool onMouseDown(Editor* editor, ui::MouseMessage* msg)
+  {
+    return false;
+  }
 
-    // Called just before the state will be removed from the
-    // EditorStatesHistory.  This event is useful to remove the
-    // decorator from the editor.
-    virtual void onBeforePopState(Editor* editor) { }
+  // Called when the user releases a mouse button.
+  virtual bool onMouseUp(Editor* editor, ui::MouseMessage* msg)
+  {
+    return false;
+  }
 
-    // Called when the current tool in the tool bar changes. It is
-    // useful for states which depends on the selected current tool (as
-    // MovingPixelsState which drops the pixels in case the user selects
-    // other drawing tool).
-    virtual void onActiveToolChange(Editor* editor, tools::Tool* tool) { }
+  // Called when the user moves the mouse over the editor.
+  virtual bool onMouseMove(Editor* editor, ui::MouseMessage* msg)
+  {
+    return false;
+  }
 
-    // Called when the editor gets the focus.
-    virtual void onEditorGotFocus(Editor* editor) { }
+  // Called when the user moves the mouse wheel over the editor.
+  virtual bool onMouseWheel(Editor* editor, ui::MouseMessage* msg)
+  {
+    return false;
+  }
 
-    // Called when the user presses a mouse button over the editor.
-    virtual bool onMouseDown(Editor* editor, ui::MouseMessage* msg) { return false; }
+  // Called when the user wants to zoom in/out using a pinch gesture in the trackpad.
+  virtual bool onTouchMagnify(Editor* editor, ui::TouchMessage* msg)
+  {
+    return false;
+  }
 
-    // Called when the user releases a mouse button.
-    virtual bool onMouseUp(Editor* editor, ui::MouseMessage* msg) { return false; }
+  // Called when the user moves the mouse wheel over the editor.
+  virtual bool onDoubleClick(Editor* editor, ui::MouseMessage* msg)
+  {
+    return false;
+  }
 
-    // Called when the user moves the mouse over the editor.
-    virtual bool onMouseMove(Editor* editor, ui::MouseMessage* msg) { return false; }
+  // Called each time the mouse changes its position so we can set an
+  // appropiated cursor depending on the new coordinates of the mouse
+  // pointer.
+  virtual bool onSetCursor(Editor* editor, const gfx::Point& mouseScreenPos)
+  {
+    return false;
+  }
 
-    // Called when the user moves the mouse wheel over the editor.
-    virtual bool onMouseWheel(Editor* editor, ui::MouseMessage* msg) { return false; }
+  // Called when a key is pressed over the current editor.
+  virtual bool onKeyDown(Editor* editor, ui::KeyMessage* msg) { return false; }
 
-    // Called when the user wants to zoom in/out using a pinch gesture in the trackpad.
-    virtual bool onTouchMagnify(Editor* editor, ui::TouchMessage* msg) { return false; }
+  // Called when a key is released.
+  virtual bool onKeyUp(Editor* editor, ui::KeyMessage* msg) { return false; }
 
-    // Called when the user moves the mouse wheel over the editor.
-    virtual bool onDoubleClick(Editor* editor, ui::MouseMessage* msg) { return false; }
+  // Called when the editor scroll is changed.
+  virtual bool onScrollChange(Editor* editor) { return false; }
 
-    // Called each time the mouse changes its position so we can set an
-    // appropiated cursor depending on the new coordinates of the mouse
-    // pointer.
-    virtual bool onSetCursor(Editor* editor, const gfx::Point& mouseScreenPos) { return false; }
+  // Called when status bar needs to be updated.
+  virtual bool onUpdateStatusBar(Editor* editor) { return false; }
 
-    // Called when a key is pressed over the current editor.
-    virtual bool onKeyDown(Editor* editor, ui::KeyMessage* msg) { return false; }
+  // When a part of the sprite will be exposed.
+  virtual void onExposeSpritePixels(const gfx::Region& rgn) { }
 
-    // Called when a key is released.
-    virtual bool onKeyUp(Editor* editor, ui::KeyMessage* msg) { return false; }
+  // Returns true if the this state requires the brush-preview as
+  // drawing cursor.
+  virtual bool requireBrushPreview() { return false; }
 
-    // Called when the editor scroll is changed.
-    virtual bool onScrollChange(Editor* editor) { return false; }
+  // Returns true if this state allow layer edges and cel guides
+  virtual bool allowLayerEdges() { return false; }
 
-    // Called when status bar needs to be updated.
-    virtual bool onUpdateStatusBar(Editor* editor) { return false; }
+  // Returns true if this state accept the given quicktool.
+  virtual bool acceptQuickTool(tools::Tool* tool) { return true; }
 
-    // When a part of the sprite will be exposed.
-    virtual void onExposeSpritePixels(const gfx::Region& rgn) { }
+  // Custom ink in this state.
+  virtual tools::Ink* getStateInk() const { return nullptr; }
 
-    // Returns true if the this state requires the brush-preview as
-    // drawing cursor.
-    virtual bool requireBrushPreview() { return false; }
+  // Called when a tag is deleted.
+  virtual void onRemoveTag(Editor* editor, doc::Tag* tag) { }
 
-    // Returns true if this state allow layer edges and cel guides
-    virtual bool allowLayerEdges() { return false; }
+  // Used to adjust the grid origin point for temporal cels created
+  // by states like DrawingState + ExpandCelCanvas.
+  virtual bool getGridBounds(Editor* editor, gfx::Rect& gridBounds)
+  {
+    return false;
+  }
 
-    // Returns true if this state accept the given quicktool.
-    virtual bool acceptQuickTool(tools::Tool* tool) { return true; }
+  // Called when a layer is going to be removed, e.g. useful in case
+  // that the state cached a layer pointer in an internal
+  // collection.
+  virtual void onBeforeRemoveLayer(Editor* editor) { }
 
-    // Custom ink in this state.
-    virtual tools::Ink* getStateInk() const { return nullptr; }
+  // Called when the visibility of a specific layer is changed.
+  virtual void onBeforeLayerVisibilityChange(Editor* editor,
+                                             doc::Layer* layer,
+                                             bool newState)
+  {
+  }
 
-    // Called when a tag is deleted.
-    virtual void onRemoveTag(Editor* editor, doc::Tag* tag) { }
+  // Called when the editable flag of a specific layer is changed.
+  virtual void onBeforeLayerEditableChange(Editor* editor,
+                                           doc::Layer* layer,
+                                           bool newState)
+  {
+  }
 
-    // Used to adjust the grid origin point for temporal cels created
-    // by states like DrawingState + ExpandCelCanvas.
-    virtual bool getGridBounds(Editor* editor, gfx::Rect& gridBounds) { return false; }
+private:
+  DISABLE_COPYING(EditorState);
+};
 
-    // Called when a layer is going to be removed, e.g. useful in case
-    // that the state cached a layer pointer in an internal
-    // collection.
-    virtual void onBeforeRemoveLayer(Editor* editor) { }
+using EditorStatePtr = std::shared_ptr<EditorState>;
 
-    // Called when the visibility of a specific layer is changed.
-    virtual void onBeforeLayerVisibilityChange(Editor* editor,
-                                               doc::Layer* layer,
-                                               bool newState) { }
-
-  private:
-    DISABLE_COPYING(EditorState);
-  };
-
-  using EditorStatePtr = std::shared_ptr<EditorState>;
-
-} // namespace app
+}  // namespace app
 
 #endif  // APP_UI_EDITOR_EDITOR_STATE_H_INCLUDED

--- a/src/app/ui/editor/moving_pixels_state.cpp
+++ b/src/app/ui/editor/moving_pixels_state.cpp
@@ -5,10 +5,10 @@
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
 
-#define MOVPIXS_TRACE(...) // TRACE(__VA_ARGS__)
+#define MOVPIXS_TRACE(...)  // TRACE(__VA_ARGS__)
 
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+  #include "config.h"
 #endif
 
 #include "app/ui/editor/moving_pixels_state.h"
@@ -87,25 +87,23 @@ MovingPixelsState::MovingPixelsState(Editor* editor,
 
   // Setup transparent mode/mask color
   if (Preferences::instance().selection.autoOpaque()) {
-    Preferences::instance().selection.opaque(
-      editor->layer()->isBackground());
+    Preferences::instance().selection.opaque(editor->layer()->isBackground());
   }
   onTransparentColorChange();
 
-  m_renderTimer.Tick.connect([this]{ onRenderTimer(); });
+  m_renderTimer.Tick.connect([this] { onRenderTimer(); });
 
   // Hook BeforeCommandExecution signal so we know if the user wants
   // to execute other command, so we can drop pixels.
-  m_ctxConn =
-    context->BeforeCommandExecution.connect(&MovingPixelsState::onBeforeCommandExecution, this);
+  m_ctxConn = context->BeforeCommandExecution.connect(
+    &MovingPixelsState::onBeforeCommandExecution, this);
 
   // Listen to any change to the transparent color from the ContextBar.
-  m_opaqueConn =
-    Preferences::instance().selection.opaque.AfterChange.connect(
-      [this]{ onTransparentColorChange(); });
+  m_opaqueConn = Preferences::instance().selection.opaque.AfterChange.connect(
+    [this] { onTransparentColorChange(); });
   m_transparentConn =
     Preferences::instance().selection.transparentColor.AfterChange.connect(
-      [this]{ onTransparentColorChange(); });
+      [this] { onTransparentColorChange(); });
 
   // Add the current editor as filter for key message of the manager
   // so we can catch the Enter key, and avoid to execute the
@@ -197,7 +195,8 @@ void MovingPixelsState::onEditorGotFocus(Editor* editor)
   contextBar->updateForMovingPixels(getTransformation(editor));
 }
 
-EditorState::LeaveAction MovingPixelsState::onLeaveState(Editor* editor, EditorState* newState)
+EditorState::LeaveAction MovingPixelsState::onLeaveState(Editor* editor,
+                                                         EditorState* newState)
 {
   MOVPIXS_TRACE("MOVPIXS: onLeaveState\n");
 
@@ -258,12 +257,10 @@ void MovingPixelsState::onActiveToolChange(Editor* editor, tools::Tool* tool)
   if (m_pixelsMovement) {
     // We don't want to drop pixels in case the user change the tool
     // for scrolling/zooming/picking colors.
-    if ((!tool->getInk(0)->isSelection() ||
-         !tool->getInk(1)->isSelection()) &&
+    if ((!tool->getInk(0)->isSelection() || !tool->getInk(1)->isSelection()) &&
         (!tool->getInk(0)->isScrollMovement() ||
          !tool->getInk(1)->isScrollMovement()) &&
-        (!tool->getInk(0)->isZoom() ||
-         !tool->getInk(1)->isZoom()) &&
+        (!tool->getInk(0)->isZoom() || !tool->getInk(1)->isZoom()) &&
         (!tool->getInk(0)->isEyedropper() ||
          !tool->getInk(1)->isEyedropper())) {
       // We have to drop pixels
@@ -272,8 +269,7 @@ void MovingPixelsState::onActiveToolChange(Editor* editor, tools::Tool* tool)
     // If we've temporarily gone to a non-selection tool and now we're
     // back, we've just to update the context bar to show the "moving
     // pixels" controls (e.g. OK/Cancel movement buttons).
-    else if (tool->getInk(0)->isSelection() ||
-             tool->getInk(1)->isSelection()) {
+    else if (tool->getInk(0)->isSelection() || tool->getInk(1)->isSelection()) {
       ContextBar* contextBar = App::instance()->contextBar();
       contextBar->updateForMovingPixels(getTransformation(editor));
     }
@@ -298,8 +294,7 @@ bool MovingPixelsState::onMouseDown(Editor* editor, MouseMessage* msg)
   contextBar->updateForMovingPixels(getTransformation(editor));
 
   // Start scroll loop
-  if (editor->checkForScroll(msg) ||
-      editor->checkForZoom(msg))
+  if (editor->checkForScroll(msg) || editor->checkForZoom(msg))
     return true;
 
   // Call the eyedropper command
@@ -313,16 +308,14 @@ bool MovingPixelsState::onMouseDown(Editor* editor, MouseMessage* msg)
   Doc* document = editor->document();
 
   // Transform selected pixels
-  if (document->isMaskVisible() &&
-      decorator->getTransformHandles(editor) &&
+  if (document->isMaskVisible() && decorator->getTransformHandles(editor) &&
       (!Preferences::instance().selection.modifiersDisableHandles() ||
        msg->modifiers() == kKeyNoneModifier)) {
     TransformHandles* transfHandles = decorator->getTransformHandles(editor);
 
     // Get the handle covered by the mouse.
-    HandleType handle = transfHandles->getHandleAtPoint(editor,
-                                                        msg->position(),
-                                                        getTransformation(editor));
+    HandleType handle = transfHandles->getHandleAtPoint(
+      editor, msg->position(), getTransformation(editor));
 
     if (handle != NoHandle) {
       if (layer_is_locked(editor))
@@ -346,7 +339,9 @@ bool MovingPixelsState::onMouseDown(Editor* editor, MouseMessage* msg)
 
     // In case that the user is pressing the copy-selection keyboard shortcut.
     if (auto customization = editor->getCustomizationDelegate()) {
-      if (int(customization->getPressedKeyAction(KeyContext::TranslatingSelection) & KeyAction::CopySelection)) {
+      if (int(customization->getPressedKeyAction(
+                KeyContext::TranslatingSelection) &
+              KeyAction::CopySelection)) {
         // Stamp the pixels to create the copy.
         m_pixelsMovement->stampImage();
       }
@@ -357,8 +352,8 @@ bool MovingPixelsState::onMouseDown(Editor* editor, MouseMessage* msg)
     }
 
     // Re-catch the image
-    m_pixelsMovement->catchImageAgain(
-      editor->screenToEditorF(msg->position()), MovePixelsHandle);
+    m_pixelsMovement->catchImageAgain(editor->screenToEditorF(msg->position()),
+                                      MovePixelsHandle);
 
     editor->captureMouse();
     return true;
@@ -461,7 +456,8 @@ void MovingPixelsState::onCommitMouseMove(Editor* editor,
   m_editor->updateStatusBar();
 }
 
-bool MovingPixelsState::onSetCursor(Editor* editor, const gfx::Point& mouseScreenPos)
+bool MovingPixelsState::onSetCursor(Editor* editor,
+                                    const gfx::Point& mouseScreenPos)
 {
   ASSERT(m_pixelsMovement);
   ASSERT(editor == m_editor);
@@ -487,13 +483,12 @@ bool MovingPixelsState::onKeyDown(Editor* editor, KeyMessage* msg)
   // FineControl now (e.g. if we pressed another modifier key).
   m_lockedKeyAction = KeyAction::None;
 
-  if (msg->scancode() == kKeyEnter || // TODO make this key customizable
-      msg->scancode() == kKeyEnterPad ||
-      msg->scancode() == kKeyEsc) {
+  if (msg->scancode() == kKeyEnter ||  // TODO make this key customizable
+      msg->scancode() == kKeyEnterPad || msg->scancode() == kKeyEsc) {
     dropPixels();
 
     // The escape key drop pixels and deselect the mask.
-    if (msg->scancode() == kKeyEsc) { // TODO make this key customizable
+    if (msg->scancode() == kKeyEsc) {  // TODO make this key customizable
       Command* cmd = Commands::instance()->byId(CommandId::DeselectMask());
       UIContext::instance()->executeCommandFromMenuOrShortcut(cmd);
     }
@@ -547,54 +542,68 @@ bool MovingPixelsState::onUpdateStatusBar(Editor* editor)
   int gcd = base::gcd(w, h);
   StatusBar::instance()->setStatusText(
     100,
-    fmt::format(
-      ":pos: {} {}"
-      " :size: {} {}"
-      " :selsize: {} {} [{:.02f}% {:.02f}%]"
-      " :angle: {:.1f}"
-      " :aspect_ratio: {}:{}",
-      int(transform.bounds().x),
-      int(transform.bounds().y),
-      imageSize.w,
-      imageSize.h,
-      w,
-      h,
-      (double)w*100.0/imageSize.w,
-      (double)h*100.0/imageSize.h,
-      180.0 * transform.angle() / PI,
-      w/gcd,
-      h/gcd));
+    fmt::format(":pos: {} {}"
+                " :size: {} {}"
+                " :selsize: {} {} [{:.02f}% {:.02f}%]"
+                " :angle: {:.1f}"
+                " :aspect_ratio: {}:{}",
+                int(transform.bounds().x),
+                int(transform.bounds().y),
+                imageSize.w,
+                imageSize.h,
+                w,
+                h,
+                (double)w * 100.0 / imageSize.w,
+                (double)h * 100.0 / imageSize.h,
+                180.0 * transform.angle() / PI,
+                w / gcd,
+                h / gcd));
 
   return true;
 }
 
 bool MovingPixelsState::acceptQuickTool(tools::Tool* tool)
 {
-  return
-    (!m_pixelsMovement ||
-     tool->getInk(0)->isSelection() ||
-     tool->getInk(0)->isEyedropper() ||
-     tool->getInk(0)->isScrollMovement() ||
-     tool->getInk(0)->isZoom());
+  return (!m_pixelsMovement || tool->getInk(0)->isSelection() ||
+          tool->getInk(0)->isEyedropper() ||
+          tool->getInk(0)->isScrollMovement() || tool->getInk(0)->isZoom());
+}
+
+void MovingPixelsState::dropPixelsIfLayerIsSelected(doc::Layer* layer)
+{
+  if (!isActiveDocument())
+    return;
+
+  if (m_pixelsMovement) {
+    const Site& site = m_pixelsMovement->site();
+    if (site.layer() == layer || site.range().contains(layer)) {
+      dropPixels();
+    }
+  }
 }
 
 void MovingPixelsState::onBeforeLayerVisibilityChange(Editor* editor,
                                                       doc::Layer* layer,
                                                       bool newState)
 {
-  if (!isActiveDocument())
-    return;
-
   // If the layer visibility of any selected layer changes, we just
   // drop the pixels (it's the easiest way to avoid modifying hidden
   // pixels).
-  if (m_pixelsMovement) {
-    const Site& site = m_pixelsMovement->site();
-    if (site.layer() == layer ||
-        site.range().contains(layer)) {
-      dropPixels();
-    }
-  }
+  dropPixelsIfLayerIsSelected(layer);
+}
+
+void MovingPixelsState::onBeforeLayerEditableChange(Editor* editor,
+                                                    doc::Layer* layer,
+                                                    bool newState)
+{
+  // If the layer 'editable' flag of any selected layer changes,
+  // we just drop the pixels (it's the easiest way to avoid modifying
+  // hidden pixels and it's the simplest treatment when
+  // locking the layer)
+  // TODO: It would be more convenient not to drop the selected
+  // image if the 'lock' then 'unlock' actions are performed without
+  // any transformation taking place.
+  dropPixelsIfLayerIsSelected(layer);
 }
 
 // Before executing any command, we drop the pixels (go back to standby).
@@ -602,17 +611,17 @@ void MovingPixelsState::onBeforeCommandExecution(CommandExecutionEvent& ev)
 {
   Command* command = ev.command();
 
-  MOVPIXS_TRACE("MOVPIXS: onBeforeCommandExecution %s\n", command->id().c_str());
+  MOVPIXS_TRACE("MOVPIXS: onBeforeCommandExecution %s\n",
+                command->id().c_str());
 
   // If the command is for other editor, we don't drop pixels.
   if (!isActiveEditor())
     return;
 
-  if (layer_is_locked(m_editor) &&
-      (command->id() == CommandId::Flip() ||
-      command->id() == CommandId::Cut() ||
-      command->id() == CommandId::Clear() ||
-      command->id() == CommandId::Rotate())) {
+  if (layer_is_locked(m_editor) && (command->id() == CommandId::Flip() ||
+                                    command->id() == CommandId::Cut() ||
+                                    command->id() == CommandId::Clear() ||
+                                    command->id() == CommandId::Rotate())) {
     ev.cancel();
     return;
   }
@@ -624,7 +633,8 @@ void MovingPixelsState::onBeforeCommandExecution(CommandExecutionEvent& ev)
         ev.cancel();
         return;
       }
-      gfx::Point delta = moveMaskCmd->getMoveThing().getDelta(UIContext::instance());
+      gfx::Point delta =
+        moveMaskCmd->getMoveThing().getDelta(UIContext::instance());
       // Verify Shift condition of the MoveMaskCommand (i.e. wrap = true)
       if (moveMaskCmd->isWrap()) {
         m_pixelsMovement->shift(delta.x, delta.y);
@@ -662,17 +672,17 @@ void MovingPixelsState::onBeforeCommandExecution(CommandExecutionEvent& ev)
       if (floatingImage->isTilemap()) {
         Site site = m_editor->getSite();
         ASSERT(site.tileset());
-        Clipboard::instance()->
-          copyTilemap(floatingImage.get(),
-                      floatingMask.get(),
-                      document->sprite()->palette(m_editor->frame()),
-                      site.tileset());
+        Clipboard::instance()->copyTilemap(
+          floatingImage.get(),
+          floatingMask.get(),
+          document->sprite()->palette(m_editor->frame()),
+          site.tileset());
       }
       else {
-        Clipboard::instance()->
-          copyImage(floatingImage.get(),
-                    floatingMask.get(),
-                    document->sprite()->palette(m_editor->frame()));
+        Clipboard::instance()->copyImage(
+          floatingImage.get(),
+          floatingMask.get(),
+          document->sprite()->palette(m_editor->frame()));
       }
     }
 
@@ -757,8 +767,7 @@ void MovingPixelsState::onBeforeFrameChanged(Editor* editor)
   if (!isActiveDocument())
     return;
 
-  if (m_pixelsMovement &&
-      !m_pixelsMovement->canHandleFrameChange()) {
+  if (m_pixelsMovement && !m_pixelsMovement->canHandleFrameChange()) {
     dropPixels();
   }
 }
@@ -786,11 +795,10 @@ void MovingPixelsState::onTransparentColorChange()
   ASSERT(m_pixelsMovement);
 
   bool opaque = Preferences::instance().selection.opaque();
-  setTransparentColor(
-    opaque,
-    opaque ?
-      app::Color::fromMask():
-      Preferences::instance().selection.transparentColor());
+  setTransparentColor(opaque,
+                      opaque ?
+                        app::Color::fromMask() :
+                        Preferences::instance().selection.transparentColor());
 }
 
 void MovingPixelsState::onRenderTimer()
@@ -805,7 +813,6 @@ void MovingPixelsState::onDropPixels(ContextBarObserver::DropAction action)
     return;
 
   switch (action) {
-
     case ContextBarObserver::DropPixels:
       dropPixels();
       break;
@@ -826,7 +833,8 @@ void MovingPixelsState::onPivotChange()
   contextBar->updateForMovingPixels(getTransformation(m_editor));
 }
 
-void MovingPixelsState::setTransparentColor(bool opaque, const app::Color& color)
+void MovingPixelsState::setTransparentColor(bool opaque,
+                                            const app::Color& color)
 {
   ASSERT(m_pixelsMovement);
 
@@ -933,4 +941,4 @@ KeyAction MovingPixelsState::getCurrentKeyAction() const
     return KeyAction::None;
 }
 
-} // namespace app
+}  // namespace app

--- a/src/app/ui/editor/moving_pixels_state.h
+++ b/src/app/ui/editor/moving_pixels_state.h
@@ -21,116 +21,123 @@
 #include "ui/timer.h"
 
 namespace doc {
-  class Layer;
+class Layer;
 }
 
 namespace app {
-  class CommandExecutionEvent;
-  class Editor;
+class CommandExecutionEvent;
+class Editor;
 
-  class MovingPixelsState
-    : public StandbyState
-    , EditorObserver
-    , TimelineObserver
-    , ContextBarObserver
-    , PixelsMovementDelegate
-    , DelayedMouseMoveDelegate {
-  public:
-    MovingPixelsState(Editor* editor,
-                      ui::MouseMessage* msg,
-                      PixelsMovementPtr pixelsMovement,
-                      HandleType handle);
-    virtual ~MovingPixelsState();
+class MovingPixelsState : public StandbyState,
+                          EditorObserver,
+                          TimelineObserver,
+                          ContextBarObserver,
+                          PixelsMovementDelegate,
+                          DelayedMouseMoveDelegate {
+public:
+  MovingPixelsState(Editor* editor,
+                    ui::MouseMessage* msg,
+                    PixelsMovementPtr pixelsMovement,
+                    HandleType handle);
+  virtual ~MovingPixelsState();
 
-    bool canHandleFrameChange() const {
-      return m_pixelsMovement->canHandleFrameChange();
-    }
+  bool canHandleFrameChange() const
+  {
+    return m_pixelsMovement->canHandleFrameChange();
+  }
 
-    void translate(const gfx::PointF& delta);
-    void rotate(double angle);
-    void flip(doc::algorithm::FlipType flipType);
-    void shift(int dx, int dy);
+  void translate(const gfx::PointF& delta);
+  void rotate(double angle);
+  void flip(doc::algorithm::FlipType flipType);
+  void shift(int dx, int dy);
 
-    void updateTransformation(const Transformation& t);
+  void updateTransformation(const Transformation& t);
 
-    // EditorState
-    void onEnterState(Editor* editor) override;
-    void onEditorGotFocus(Editor* editor) override;
-    LeaveAction onLeaveState(Editor* editor, EditorState* newState) override;
-    void onActiveToolChange(Editor* editor, tools::Tool* tool) override;
-    bool onMouseDown(Editor* editor, ui::MouseMessage* msg) override;
-    bool onMouseUp(Editor* editor, ui::MouseMessage* msg) override;
-    bool onMouseMove(Editor* editor, ui::MouseMessage* msg) override;
-    bool onSetCursor(Editor* editor, const gfx::Point& mouseScreenPos) override;
-    bool onKeyDown(Editor* editor, ui::KeyMessage* msg) override;
-    bool onKeyUp(Editor* editor, ui::KeyMessage* msg) override;
-    bool onUpdateStatusBar(Editor* editor) override;
-    bool acceptQuickTool(tools::Tool* tool) override;
-    bool requireBrushPreview() override { return false; }
-    void onBeforeLayerVisibilityChange(Editor* editor, doc::Layer* layer, bool newState) override;
+  // EditorState
+  void onEnterState(Editor* editor) override;
+  void onEditorGotFocus(Editor* editor) override;
+  LeaveAction onLeaveState(Editor* editor, EditorState* newState) override;
+  void onActiveToolChange(Editor* editor, tools::Tool* tool) override;
+  bool onMouseDown(Editor* editor, ui::MouseMessage* msg) override;
+  bool onMouseUp(Editor* editor, ui::MouseMessage* msg) override;
+  bool onMouseMove(Editor* editor, ui::MouseMessage* msg) override;
+  bool onSetCursor(Editor* editor, const gfx::Point& mouseScreenPos) override;
+  bool onKeyDown(Editor* editor, ui::KeyMessage* msg) override;
+  bool onKeyUp(Editor* editor, ui::KeyMessage* msg) override;
+  bool onUpdateStatusBar(Editor* editor) override;
+  bool acceptQuickTool(tools::Tool* tool) override;
+  bool requireBrushPreview() override { return false; }
+  void onBeforeLayerVisibilityChange(Editor* editor,
+                                     doc::Layer* layer,
+                                     bool newState) override;
+  void onBeforeLayerEditableChange(Editor* editor,
+                                   doc::Layer* layer,
+                                   bool newState) override;
 
+  // EditorObserver
+  void onDestroyEditor(Editor* editor) override;
+  void onBeforeFrameChanged(Editor* editor) override;
+  void onBeforeLayerChanged(Editor* editor) override;
 
-    // EditorObserver
-    void onDestroyEditor(Editor* editor) override;
-    void onBeforeFrameChanged(Editor* editor) override;
-    void onBeforeLayerChanged(Editor* editor) override;
+  // TimelineObserver
+  void onBeforeRangeChanged(Timeline* timeline) override;
 
-    // TimelineObserver
-    void onBeforeRangeChanged(Timeline* timeline) override;
+  // ContextBarObserver
+  void onDropPixels(ContextBarObserver::DropAction action) override;
 
-    // ContextBarObserver
-    void onDropPixels(ContextBarObserver::DropAction action) override;
+  // PixelsMovementDelegate
+  void onPivotChange() override;
 
-    // PixelsMovementDelegate
-    void onPivotChange() override;
+  Transformation getTransformation(Editor* editor) override;
 
-    Transformation getTransformation(Editor* editor) override;
+private:
+  // DelayedMouseMoveDelegate impl
+  void onCommitMouseMove(Editor* editor, const gfx::PointF& spritePos) override;
 
-  private:
-    // DelayedMouseMoveDelegate impl
-    void onCommitMouseMove(Editor* editor,
-                           const gfx::PointF& spritePos) override;
+  void onTransparentColorChange();
+  void onRenderTimer();
 
-    void onTransparentColorChange();
-    void onRenderTimer();
+  // ContextObserver
+  void onBeforeCommandExecution(CommandExecutionEvent& ev);
 
-    // ContextObserver
-    void onBeforeCommandExecution(CommandExecutionEvent& ev);
+  void setTransparentColor(bool opaque, const app::Color& color);
+  void dropPixels();
 
-    void setTransparentColor(bool opaque, const app::Color& color);
-    void dropPixels();
+  bool isActiveDocument() const;
+  bool isActiveEditor() const;
 
-    bool isActiveDocument() const;
-    bool isActiveEditor() const;
+  void removeAsEditorObserver();
+  void removePixelsMovement();
 
-    void removeAsEditorObserver();
-    void removePixelsMovement();
+  KeyAction getCurrentKeyAction() const;
 
-    KeyAction getCurrentKeyAction() const;
+  // Used on 'onBeforeLayerVisibilityChange' and
+  // 'onBeforeLayerEditableChange' functions
+  void dropPixelsIfLayerIsSelected(doc::Layer* layer);
 
-    // Helper member to move/translate selection and pixels.
-    PixelsMovementPtr m_pixelsMovement;
-    DelayedMouseMove m_delayedMouseMove;
-    Editor* m_editor;
-    bool m_observingEditor;
+  // Helper member to move/translate selection and pixels.
+  PixelsMovementPtr m_pixelsMovement;
+  DelayedMouseMove m_delayedMouseMove;
+  Editor* m_editor;
+  bool m_observingEditor;
 
-    // True if the image was discarded (e.g. when a "Cut" command was
-    // used to remove the dragged image).
-    bool m_discarded;
+  // True if the image was discarded (e.g. when a "Cut" command was
+  // used to remove the dragged image).
+  bool m_discarded;
 
-    // Variable to store the initial key action to ignore it until we
-    // re-press the key. This was done mainly to avoid activating the
-    // fine control with the Ctrl key when we copy the selection until
-    // the user release and press again the Ctrl key.
-    KeyAction m_lockedKeyAction = KeyAction::None;
+  // Variable to store the initial key action to ignore it until we
+  // re-press the key. This was done mainly to avoid activating the
+  // fine control with the Ctrl key when we copy the selection until
+  // the user release and press again the Ctrl key.
+  KeyAction m_lockedKeyAction = KeyAction::None;
 
-    ui::Timer m_renderTimer;
+  ui::Timer m_renderTimer;
 
-    obs::connection m_ctxConn;
-    obs::connection m_opaqueConn;
-    obs::connection m_transparentConn;
-  };
+  obs::connection m_ctxConn;
+  obs::connection m_opaqueConn;
+  obs::connection m_transparentConn;
+};
 
-} // namespace app
+}  // namespace app
 
 #endif  // APP_UI_EDITOR_MOVING_PIXELS_STATE_H_INCLUDED


### PR DESCRIPTION
fix #4586

Some comment about the approach:
This solution solves the problem and seems like a more intuitive behavior.

Anyway, I don't like the following case:
1. `lock` the layer while there is an active selection.
2. `unlock` the layer without any movement of the selection.
Result: The original selection mask will be a new mask containing any parts that were overlapped before step 1. See the following video to understand:
![Nov-19-2024 20-05-15](https://github.com/user-attachments/assets/5d8c787e-c2d0-40f7-8fd6-d7dbdf9eddf8)
Note: this was also happening with the layer visibility state change.
I need some feedback on the approach.
