### PR TITLE
Fix windows on visible and dialog on open

### DIFF
--- a/src/app/script/dialog_class.cpp
+++ b/src/app/script/dialog_class.cpp
@@ -78,6 +78,7 @@ protected:
     if (m_handTool && Editor::activeEditor()) {
       enableHandTool(true);
     }
+    WindowWithHand::onOpen(ev);
   }
 
   void onBeforeClose(CloseEvent& ev) override {

--- a/src/ui/window.cpp
+++ b/src/ui/window.cpp
@@ -717,8 +717,11 @@ void Window::onSetText()
 void Window::onVisible(bool visible)
 {
   Widget::onVisible(visible);
-  if (get_multiple_displays() && m_display) {
-    display()->nativeWindow()->setVisible(visible);
+  Display* display = this->display();
+  if (ownDisplay() &&
+      display &&
+      display->nativeWindow()) {
+    display->nativeWindow()->setVisible(visible);
   }
 }
 


### PR DESCRIPTION
Fix #4805 (`Window::onVisible()` not taking into account if the display was owned)
and https://community.aseprite.org/t/dialog-show-bounds-rectangle-is-broken-in-1-3-10/23917 (`DialogWindow::onOpen()` not calling `Window::onOpen()`)

