### PR TITLE
[win] Use WinTab/tablet pressure only for certain windows (#3358)

### DIFF
--- a/src/app/script/dialog_class.cpp
+++ b/src/app/script/dialog_class.cpp
@@ -66,6 +66,8 @@ public:
     : WindowWithHand(type, text)
     , m_handTool(false)
   {
+    // As scripts can receive the "pressure" information.
+    setNeedsTabletPressure(true);
   }
 
   // Enables the Hand tool in the active editor.

--- a/src/app/ui/dynamics_popup.cpp
+++ b/src/app/ui/dynamics_popup.cpp
@@ -222,6 +222,8 @@ DynamicsPopup::DynamicsPopup(Delegate* delegate)
   , m_ditheringSel(new DitheringSelector(DitheringSelector::SelectMatrix))
   , m_fromTo(tools::ColorFromTo::BgToFg)
 {
+  setNeedsTabletPressure(true);
+
   m_dynamics->stabilizer()->Click.connect(
     [this](){
       if (m_dynamics->stabilizer()->isSelected()) {

--- a/src/app/ui/main_window.cpp
+++ b/src/app/ui/main_window.cpp
@@ -95,6 +95,7 @@ MainWindow::MainWindow()
 #endif
 {
   enableFlags(ALLOW_DROP);
+  setNeedsTabletPressure(true);
 }
 
 // This 'initialize' function is a way to split the creation of the

--- a/src/ui/manager.cpp
+++ b/src/ui/manager.cpp
@@ -1394,6 +1394,11 @@ void Manager::_openWindow(Window* window, bool center)
         spec.parent(parentDisplay->nativeWindow());
       }
 
+#if LAF_WINDOWS
+      // Just in case we'll try to avoid using WinTab at all costs.
+      spec.useTabletOptions(window->needsTabletPressure());
+#endif
+
       os::WindowRef newNativeWindow = os::System::instance()->makeWindow(spec);
       ui::Display* newDisplay = new ui::Display(parentDisplay, newNativeWindow, window);
 

--- a/src/ui/window.cpp
+++ b/src/ui/window.cpp
@@ -122,6 +122,8 @@ Window::Window(Type type, const std::string& text)
   , m_isWantFocus(true)
   , m_isForeground(false)
   , m_isAutoRemap(true)
+  , m_isResizing(false)
+  , m_needsTabletPressure(false)
 {
   setVisible(false);
   setAlign(LEFT | MIDDLE);

--- a/src/ui/window.h
+++ b/src/ui/window.h
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2019-2023  Igara Studio S.A.
+// Copyright (C) 2019-2024  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -65,6 +65,13 @@ namespace ui {
     bool isWantFocus() const { return m_isWantFocus; }
     bool isSizeable() const { return m_isSizeable; }
     bool isMoveable() const { return m_isMoveable; }
+
+    // Use to inhibit buggy WinTab implementations that might crash
+    // the whole program just calling WTOpen(). This must be called
+    // before creating the native window (before
+    // Manager::_openWindow()).
+    void setNeedsTabletPressure(const bool s) { m_needsTabletPressure = s; }
+    bool needsTabletPressure() const { return m_needsTabletPressure; }
 
     // Returns true only inside onWindowResize() when the window size
     // changed.
@@ -136,6 +143,7 @@ namespace ui {
     bool m_isForeground : 1;
     bool m_isAutoRemap : 1;
     bool m_isResizing : 1;
+    bool m_needsTabletPressure : 1;
     int m_hitTest;
     gfx::Rect m_lastFrame;
   };


### PR DESCRIPTION
Doesn't fully fix the issue #3358, but in some way avoid as much as possible crashes with tooltips (which are the most common). So WTOpen() for wintab will be only used for the MainWindow, DynamicsPopup, and scripts Dialog.