### PR TITLE
Enable and improve beforesitechange event (fix #4785)

### DIFF
--- a/src/app/context.cpp
+++ b/src/app/context.cpp
@@ -266,7 +266,8 @@ void Context::onAddDocument(Doc* doc)
   if (m_activeSiteHandler)
     m_activeSiteHandler->addDoc(doc);
 
-  notifyActiveSiteChanged();
+  if (m_activeSiteHandler || !isUIAvailable())
+    notifyActiveSiteChanged();
 }
 
 void Context::onBeforeRemoveDocument(Doc* doc)

--- a/src/app/context.cpp
+++ b/src/app/context.cpp
@@ -266,6 +266,9 @@ void Context::onAddDocument(Doc* doc)
   if (m_activeSiteHandler)
     m_activeSiteHandler->addDoc(doc);
 
+  // Checking for an active site handler of UI not available avoids a consistency issue
+  // when opening a sprite from the first time, from the home screen, which would notify of an empty
+  // active site twice.
   if (m_activeSiteHandler || !isUIAvailable())
     notifyActiveSiteChanged();
 }

--- a/src/app/script/events_class.cpp
+++ b/src/app/script/events_class.cpp
@@ -269,9 +269,12 @@ void onAfterCommand(CommandExecutionEvent& ev)
 // ContextObserver impl
 void onActiveSiteChange(const Site& site) override
 {
-  if (m_lastActiveSite.has_value() && *m_lastActiveSite == site)
-    return; // Avoid multiple events that can happen when closing since we're changing views at the
-            // same time we're removing documents
+  if (m_lastActiveSite.has_value() && *m_lastActiveSite == site) {
+    // Avoid multiple events that can happen when closing since
+    // we're changing views at the same time we're removing
+    // documents
+    return;
+  }
 
   const bool fromUndo = (site.document() && site.document()->isUndoing());
   call(SiteChange,

--- a/src/app/site.h
+++ b/src/app/site.h
@@ -115,6 +115,20 @@ public:
   // Same as uniqueCels() with cels from non-locked/editable layers.
   doc::CelList selectedUniqueCelsToEditPixels() const;
 
+  inline bool operator==(const Site& other) const
+  {
+    if (document() != other.document())
+      return false;
+
+    if (frame() != other.frame())
+      return false;
+
+    if (cel() != other.cel())
+      return false;
+
+    return true;
+  }
+
 private:
   Focus m_focus;
   Doc* m_document;

--- a/src/app/site.h
+++ b/src/app/site.h
@@ -117,16 +117,8 @@ public:
 
   inline bool operator==(const Site& other) const
   {
-    if (document() != other.document())
-      return false;
-
-    if (frame() != other.frame())
-      return false;
-
-    if (cel() != other.cel())
-      return false;
-
-    return true;
+    return (document() == other.document() && sprite() == other.sprite() &&
+            layer() == other.layer() && frame() == other.frame() && cel() == other.cel());
   }
 
 private:

--- a/src/app/ui/main_window.cpp
+++ b/src/app/ui/main_window.cpp
@@ -413,7 +413,8 @@ void MainWindow::onResize(ui::ResizeEvent& ev)
 
 void MainWindow::onBeforeViewChange()
 {
-  UIContext::instance()->notifyBeforeActiveSiteChanged();
+  if (!getDocView())
+    UIContext::instance()->notifyBeforeActiveSiteChanged();
 }
 
 // When the active view is changed from methods like

--- a/src/app/ui/main_window.cpp
+++ b/src/app/ui/main_window.cpp
@@ -413,8 +413,7 @@ void MainWindow::onResize(ui::ResizeEvent& ev)
 
 void MainWindow::onBeforeViewChange()
 {
-  if (!getDocView())
-    UIContext::instance()->notifyBeforeActiveSiteChanged();
+  UIContext::instance()->notifyBeforeActiveSiteChanged();
 }
 
 // When the active view is changed from methods like

--- a/src/app/ui/workspace.cpp
+++ b/src/app/ui/workspace.cpp
@@ -99,7 +99,9 @@ void Workspace::setActiveView(WorkspaceView* view)
   if (!m_activePanel)
     return;
 
-  BeforeViewChanged();
+  // Avoid duplicating the BeforeViewChanged event when we open for the first time
+  if (m_activePanel->activeView() != view)
+    BeforeViewChanged();
 
   m_activePanel->setActiveView(view);
 

--- a/src/app/ui/workspace.cpp
+++ b/src/app/ui/workspace.cpp
@@ -110,8 +110,6 @@ void Workspace::setActiveView(WorkspaceView* view)
 
 void Workspace::setMainPanelAsActive()
 {
-  BeforeViewChanged();
-
   m_activePanel = &m_mainPanel;
 
   removeDropViewPreview();

--- a/src/app/ui_context.cpp
+++ b/src/app/ui_context.cpp
@@ -313,7 +313,6 @@ void UIContext::onAddDocument(Doc* doc)
   // Add a tab with the new view for the document
   App::instance()->workspace()->addView(view);
 
-  setActiveView(view);
   view->editor()->setDefaultScroll();
 }
 

--- a/tests/scripts/events.lua
+++ b/tests/scripts/events.lua
@@ -7,49 +7,70 @@ dofile('./test_utils.lua')
 
 -- Test app.events
 do
+  local bc = 0
   local c = 0
+  local beforeListener = app.events:on('beforesitechange',
+                                 function() bc = bc + 1 end)
   local listener = app.events:on('sitechange',
                                  function() c = c + 1 end)
 
-  assert(c == 0)
+  expect_eq(0, bc)
+  expect_eq(0, c)
+  expect_eq(nil, app.activeSprite)
+
   local a = Sprite(32, 32)
   expect_eq(a, app.activeSprite)
+  expect_eq(1, bc)
   expect_eq(1, c)
 
   local b = Sprite(32, 32)
   expect_eq(b, app.activeSprite)
+  expect_eq(2, bc)
   expect_eq(2, c)
 
   app.activeSprite = a
+  expect_eq(3, bc)
   expect_eq(3, c)
 
   app.events:off(listener)
+  app.events:off(beforeListener)
 
   app.activeSprite = b
+  expect_eq(3, bc)
   expect_eq(3, c)
 end
 
 -- Alternate version of the events test to ensure proper observer disconnection
 do
+  local bc = 0
   local c = 0
+  local beforeListener = app.events:on('beforesitechange',
+                                 function() bc = bc + 1 end)
   local listener = app.events:on('sitechange',
                                  function() c = c + 1 end)
 
+  assert(bc == 0)
   assert(c == 0)
   local a = Sprite(32, 32)
   expect_eq(a, app.activeSprite)
+  expect_eq(1, bc)
   expect_eq(1, c)
+
+  app.events:off(beforeListener)
 
   local b = Sprite(32, 32)
   expect_eq(b, app.activeSprite)
+  expect_eq(1, bc)
   expect_eq(2, c)
 
   app.activeSprite = a
+  expect_eq(1, bc)
   expect_eq(3, c)
 
   app.events:off(listener)
 
   app.activeSprite = b
+  expect_eq(1, bc)
   expect_eq(3, c)
 end
 


### PR DESCRIPTION
Fixes #4785, should cover the buggy cases. I also confirmed it works with normal closing of the program.

Demonstration with @dacap's test script (Which btw had a typo, `app.image` was working properly, it was the Lua code with an extra capital letter 😅)




https://github.com/user-attachments/assets/212c2aa2-d479-4dd0-a7b6-eca3d8968754

