### PR TITLE
Handle null target in DragEvent 

### DIFF
--- a/src/ui/drag_event.h
+++ b/src/ui/drag_event.h
@@ -20,7 +20,8 @@ namespace ui {
   public:
     DragEvent(Component* source, ui::Widget* target, os::DragEvent& ev)
       : Event(source)
-      , m_position(ev.position() - target->bounds().origin())
+      , m_position((target ? ev.position() - target->bounds().origin()
+                           : ev.position()))
       , m_ev(ev) {}
 
     bool handled() const { return m_handled; }


### PR DESCRIPTION
When creating a DragEvent there is the possibility that the target parameter received by its constructor be null, this PR just takes into account that possibility, thus avoiding a crash. Fix #4824
