### PR TITLE
This is just a test PR, ignore it

### DIFF
--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -128,6 +128,7 @@ int app_main(int argc, char* argv[])
     os::SystemRef system(os::make_system());
     doc::Palette::initBestfit();
     app::App app;
+    bool nothing = false;
 
 #if ENABLE_SENTRY
     sentry.init();


### PR DESCRIPTION
It looks like the clang-tidy-review action is failing, we'll try to fix it updating to the latest version.