### PR TITLE
Add a helper to View to standardize scrolling behavior

### DIFF
--- a/src/app/commands/cmd_undo_history.cpp
+++ b/src/app/commands/cmd_undo_history.cpp
@@ -172,18 +172,7 @@ public:
           break;
 
         case ui::kMouseWheelMessage: {
-          auto view = ui::View::getView(this);
-          if (view) {
-            auto mouseMsg = static_cast<ui::MouseMessage*>(msg);
-            gfx::Point scroll = view->viewScroll();
-
-            if (mouseMsg->preciseWheel())
-              scroll += mouseMsg->wheelDelta();
-            else
-              scroll += mouseMsg->wheelDelta() * 3*(m_itemHeight+4*ui::guiscale());
-
-            view->setViewScroll(scroll);
-          }
+          ui::View::scrollByMessage(this, msg, 3 * m_itemHeight + 4 * ui::guiscale());
           break;
         }
 

--- a/src/app/commands/debugger.cpp
+++ b/src/app/commands/debugger.cpp
@@ -170,24 +170,12 @@ public:
 protected:
   bool onProcessMessage(Message* msg) override {
     switch (msg->type()) {
-
       case kMouseWheelMessage: {
-        View* view = View::getView(this);
-        if (view) {
-          auto mouseMsg = static_cast<MouseMessage*>(msg);
-          gfx::Point scroll = view->viewScroll();
-
-          if (mouseMsg->preciseWheel())
-            scroll += mouseMsg->wheelDelta();
-          else
-            scroll += mouseMsg->wheelDelta() * textHeight()*3;
-
-          view->setViewScroll(scroll);
-        }
+        View::scrollByMessage(this, msg);
         break;
       }
-
     }
+
     return Widget::onProcessMessage(msg);
   }
 

--- a/src/app/ui/browser_view.cpp
+++ b/src/app/ui/browser_view.cpp
@@ -249,20 +249,8 @@ private:
     }
 
     switch (msg->type()) {
-
       case kMouseWheelMessage: {
-        View* view = View::getView(this);
-        if (view) {
-          auto mouseMsg = static_cast<MouseMessage*>(msg);
-          gfx::Point scroll = view->viewScroll();
-
-          if (mouseMsg->preciseWheel())
-            scroll += mouseMsg->wheelDelta();
-          else
-            scroll += mouseMsg->wheelDelta() * textHeight()*3;
-
-          view->setViewScroll(scroll);
-        }
+        View::scrollByMessage(this, msg);
         break;
       }
     }

--- a/src/app/ui/file_list.cpp
+++ b/src/app/ui/file_list.cpp
@@ -384,14 +384,7 @@ bool FileList::onProcessMessage(Message* msg)
           break;
         }
         else {
-          gfx::Point scroll = view->viewScroll();
-
-          if (static_cast<MouseMessage*>(msg)->preciseWheel())
-            scroll += static_cast<MouseMessage*>(msg)->wheelDelta();
-          else
-            scroll += static_cast<MouseMessage*>(msg)->wheelDelta() * 3*(textHeight()+4*guiscale());
-
-          view->setViewScroll(scroll);
+          View::scrollByMessage(this, msg, 3 * (textHeight() + 4 * guiscale()));
         }
       }
       break;

--- a/src/ui/listbox.cpp
+++ b/src/ui/listbox.cpp
@@ -267,18 +267,7 @@ bool ListBox::onProcessMessage(Message* msg)
       return true;
 
     case kMouseWheelMessage: {
-      View* view = View::getView(this);
-      if (view) {
-        auto mouseMsg = static_cast<MouseMessage*>(msg);
-        gfx::Point scroll = view->viewScroll();
-
-        if (mouseMsg->preciseWheel())
-          scroll += mouseMsg->wheelDelta();
-        else
-          scroll += mouseMsg->wheelDelta() * textHeight()*3;
-
-        view->setViewScroll(scroll);
-      }
+      View::scrollByMessage(this, msg);
       break;
     }
 

--- a/src/ui/menu.cpp
+++ b/src/ui/menu.cpp
@@ -817,18 +817,7 @@ bool MenuBox::onProcessMessage(Message* msg)
       break;
 
     case kMouseWheelMessage: {
-      View* view = View::getView(this);
-      if (view) {
-        auto mouseMsg = static_cast<MouseMessage*>(msg);
-        gfx::Point scroll = view->viewScroll();
-
-        if (mouseMsg->preciseWheel())
-          scroll += mouseMsg->wheelDelta();
-        else
-          scroll += mouseMsg->wheelDelta() * textHeight()*3;
-
-        view->setViewScroll(scroll);
-      }
+      View::scrollByMessage(this, msg);
       break;
     }
 

--- a/src/ui/textbox.cpp
+++ b/src/ui/textbox.cpp
@@ -132,18 +132,7 @@ bool TextBox::onProcessMessage(Message* msg)
     }
 
     case kMouseWheelMessage: {
-      View* view = View::getView(this);
-      if (view) {
-        auto mouseMsg = static_cast<MouseMessage*>(msg);
-        gfx::Point scroll = view->viewScroll();
-
-        if (mouseMsg->preciseWheel())
-          scroll += mouseMsg->wheelDelta();
-        else
-          scroll += mouseMsg->wheelDelta() * textHeight()*3;
-
-        view->setViewScroll(scroll);
-      }
+      View::scrollByMessage(this, msg);
       break;
     }
   }

--- a/src/ui/view.cpp
+++ b/src/ui/view.cpp
@@ -225,6 +225,27 @@ View* View::getView(const Widget* widget)
     return 0;
 }
 
+void View::scrollByMessage(const Widget* widget, Message* message, std::optional<int> multiplier)
+{
+  View* view = View::getView(widget);
+  if (!view)
+    return;
+
+  auto mouseMsg = static_cast<MouseMessage*>(message);
+
+  if (!multiplier.has_value())
+    multiplier = widget->textHeight() * 3;
+
+  gfx::Point scroll = view->viewScroll();
+
+  if (mouseMsg->preciseWheel())
+    scroll += mouseMsg->wheelDelta();
+  else
+    scroll += mouseMsg->wheelDelta() * (*multiplier);
+
+  view->setViewScroll(scroll);
+}
+
 bool View::onProcessMessage(Message* msg)
 {
   switch (msg->type()) {

--- a/src/ui/view.h
+++ b/src/ui/view.h
@@ -11,9 +11,12 @@
 
 #include "gfx/point.h"
 #include "gfx/size.h"
+#include "ui/message.h"
 #include "ui/scroll_bar.h"
 #include "ui/viewport.h"
 #include "ui/widget.h"
+
+#include <optional>
 
 namespace ui {
   class ScrollRegionEvent;
@@ -58,6 +61,10 @@ namespace ui {
 
     // For viewable widgets
     static View* getView(const Widget* viewableWidget);
+
+    // Scroll the given widget's view with the mouse wheel event.
+    // The default multiplier is 3 * textHeight()
+    static void scrollByMessage(const Widget* viewableWidget, Message* message, std::optional<int> multiplier = std::nullopt);
 
   protected:
     // Events


### PR DESCRIPTION
While working on the multiline entry box I noticed that we have the same duplicated code in most view-operated widgets, so I figured I'd abstract it into a static method similar to `View::getView` so if we ever want to make changes to scrolling behavior or defaults, we can do it from one place.
