### PR TITLE
Add app.clipboard Lua API (fix #2073)

### DIFF
--- a/data/strings/en.ini
+++ b/data/strings/en.ini
@@ -1667,6 +1667,7 @@ script_label = The following script:
 file_label = wants to access to this file:
 command_label = wants to execute the following command:
 websocket_label = wants to open a WebSocket connection to this URL:
+clipboard_label = wants to access the system clipboard
 dont_show_for_this_access = Don't show this specific alert again for this script
 dont_show_for_this_script = Give full trust to this script
 allow_execute_access = &Allow Execute Access

--- a/data/widgets/script_access.xml
+++ b/data/widgets/script_access.xml
@@ -6,7 +6,7 @@
     <label text="@.script_label" />
     <hbox border="4"><link id="script" /></hbox>
     <label id="file_label" />
-    <hbox border="4"><link id="file" /></hbox>
+    <hbox id="file_container" border="4"><link id="file" /></hbox>
     <separator horizontal="true" />
     <check id="dont_show" text="@.dont_show_for_this_access" />
     <check id="full" text="@.dont_show_for_this_script" />

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -190,6 +190,7 @@ if(ENABLE_SCRIPTING)
     commands/cmd_run_script.cpp
     commands/debugger.cpp
     script/app_command_object.cpp
+    script/app_clipboard_object.cpp
     script/app_fs_object.cpp
     script/app_object.cpp
     script/app_os_object.cpp

--- a/src/app/script/app_clipboard_object.cpp
+++ b/src/app/script/app_clipboard_object.cpp
@@ -1,0 +1,136 @@
+// Aseprite
+// Copyright (c) 2022-2024  Igara Studio S.A.
+//
+// This program is distributed under the terms of
+// the End-User License Agreement for Aseprite.
+
+#ifdef HAVE_CONFIG_H
+  #include "config.h"
+#endif
+
+#include "app/modules/palettes.h"
+#include "app/script/luacpp.h"
+#include "app/util/clipboard.h"
+#include "clip/clip.h"
+#include "engine.h"
+
+namespace app { namespace script {
+
+namespace {
+
+struct Clipboard {};
+
+int Clipboard_clear(lua_State* L)
+{
+  if (!clip::clear())
+    return luaL_error(L, "failed to clear the clipboard");
+
+  return 1;
+}
+
+int Clipboard_is_text(lua_State* L)
+{
+  lua_pushboolean(L, clip::has(clip::text_format()));
+  return 1;
+}
+
+int Clipboard_is_image(lua_State* L)
+{
+  lua_pushboolean(L, clip::has(clip::image_format()));
+  return 1;
+}
+
+int Clipboard_is_empty(lua_State* L)
+{
+  // Using clip::has(clip::empty_format()) had inconsistent results, might as well avoid false
+  // positives by just checking the two formats we support
+  lua_pushboolean(L, !clip::has(clip::image_format()) && !clip::has(clip::text_format()));
+  return 1;
+}
+
+int Clipboard_get_image(lua_State* L)
+{
+  doc::Image* image = nullptr;
+  doc::Mask* mask = nullptr;
+  doc::Palette* palette = nullptr;
+  doc::Tileset* tileset = nullptr;
+  const bool result =
+    app::Clipboard::instance()->getNativeBitmap(&image, &mask, &palette, &tileset);
+
+  // TODO: If we get a tileset, should we convert it to an image?
+  if (image == nullptr || !result)
+    return luaL_error(L, "failed to get image from clipboard");
+
+  push_image(L, image);
+  return 1;
+}
+
+int Clipboard_get_text(lua_State* L)
+{
+  std::string str;
+  if (!clip::get_text(str))
+    return luaL_error(L, "failed to get text from clipboard");
+
+  lua_pushstring(L, str.c_str());
+  return 1;
+}
+
+int Clipboard_set_image(lua_State* L)
+{
+  auto* image = may_get_image_from_arg(L, 2);
+  if (!image)
+    return luaL_error(L, "invalid image");
+
+  const bool result = app::Clipboard::instance()->setNativeBitmap(
+    image,
+    nullptr,
+    get_current_palette(), // TODO: Not sure if there's any way to get the palette from the image
+    nullptr,
+    image->maskColor() // TODO: Unsure if this is sufficient.
+  );
+
+  if (!result)
+    return luaL_error(L, "failed to set image to clipboard");
+
+  return 0;
+}
+
+int Clipboard_set_text(lua_State* L)
+{
+  const char* text = lua_tostring(L, 2);
+  if (text != NULL && strlen(text) > 0 && !clip::set_text(text))
+    return luaL_error(L, "failed to set the clipboard text to '%s'", text);
+
+  return 0;
+}
+
+const luaL_Reg Clipboard_methods[] = {
+  { "clear", Clipboard_clear },
+  { nullptr, nullptr         }
+};
+
+const Property Clipboard_properties[] = {
+  { "isText",  Clipboard_is_text,   nullptr             },
+  { "isImage", Clipboard_is_image,  nullptr             },
+  { "isEmpty", Clipboard_is_empty,  nullptr             },
+  { "text",    Clipboard_get_text,  Clipboard_set_text  },
+  { "image",   Clipboard_get_image, Clipboard_set_image },
+  { nullptr,   nullptr,             nullptr             }
+};
+
+} // anonymous namespace
+
+DEF_MTNAME(Clipboard);
+
+void register_clipboard_classes(lua_State* L)
+{
+  REG_CLASS(L, Clipboard);
+  REG_CLASS_PROPERTIES(L, Clipboard);
+}
+
+void push_app_clipboard(lua_State* L)
+{
+  push_new<Clipboard>(L);
+}
+
+}} // namespace app::script

--- a/src/app/script/app_object.cpp
+++ b/src/app/script/app_object.cpp
@@ -526,6 +526,12 @@ int App_get_editor(lua_State* L)
   return 0;
 }
 
+int App_get_clipboard(lua_State* L)
+{
+  push_app_clipboard(L);
+  return 1;
+}
+
 int App_get_sprite(lua_State* L)
 {
   app::Context* ctx = App::instance()->context();
@@ -854,6 +860,7 @@ const Property App_properties[] = {
   { "theme",          App_get_theme,          nullptr                },
   { "uiScale",        App_get_uiScale,        nullptr                },
   { "editor",         App_get_editor,         nullptr                },
+  { "clipboard",      App_get_clipboard,      nullptr                },
   { nullptr,          nullptr,                nullptr                }
 };
 

--- a/src/app/script/engine.cpp
+++ b/src/app/script/engine.cpp
@@ -201,6 +201,7 @@ void register_sprites_class(lua_State* L);
 void register_tag_class(lua_State* L);
 void register_tags_class(lua_State* L);
 void register_theme_classes(lua_State* L);
+void register_clipboard_classes(lua_State* L);
 void register_tile_class(lua_State* L);
 void register_tileset_class(lua_State* L);
 void register_tilesets_class(lua_State* L);
@@ -501,6 +502,7 @@ Engine::Engine() : L(luaL_newstate()), m_delegate(nullptr), m_printLastResult(fa
   register_tag_class(L);
   register_tags_class(L);
   register_theme_classes(L);
+  register_clipboard_classes(L);
   register_tile_class(L);
   register_tileset_class(L);
   register_tilesets_class(L);

--- a/src/app/script/engine.h
+++ b/src/app/script/engine.h
@@ -140,6 +140,7 @@ private:
 
 void push_app_events(lua_State* L);
 void push_app_theme(lua_State* L, int uiscale = 1);
+void push_app_clipboard(lua_State* L);
 int push_image_iterator_function(lua_State* L, const doc::Image* image, int extraArgIndex);
 void push_brush(lua_State* L, const doc::BrushRef& brush);
 void push_cel_image(lua_State* L, doc::Cel* cel);

--- a/src/app/script/engine.h
+++ b/src/app/script/engine.h
@@ -195,7 +195,7 @@ doc::Image* get_image_from_arg(lua_State* L, int index);
 doc::Cel* get_image_cel_from_arg(lua_State* L, int index);
 doc::Tileset* get_image_tileset_from_arg(lua_State* L, int index);
 doc::frame_t get_frame_number_from_arg(lua_State* L, int index);
-const doc::Mask* get_mask_from_arg(lua_State* L, int index);
+doc::Mask* get_mask_from_arg(lua_State* L, int index);
 app::tools::Tool* get_tool_from_arg(lua_State* L, int index);
 doc::BrushRef get_brush_from_arg(lua_State* L, int index);
 doc::Tileset* get_tile_index_from_arg(lua_State* L, int index, doc::tile_index& ts);

--- a/src/app/script/security.h
+++ b/src/app/script/security.h
@@ -30,6 +30,7 @@ enum class ResourceType {
   File,
   Command,
   WebSocket,
+  Clipboard,
 };
 
 void overwrite_unsecure_functions(lua_State* L);

--- a/src/app/script/selection_class.cpp
+++ b/src/app/script/selection_class.cpp
@@ -364,7 +364,7 @@ void push_sprite_selection(lua_State* L, Sprite* sprite)
   push_new<SelectionObj>(L, nullptr, sprite);
 }
 
-const doc::Mask* get_mask_from_arg(lua_State* L, int index)
+doc::Mask* get_mask_from_arg(lua_State* L, int index)
 {
   return get_obj<SelectionObj>(L, index)->mask(L);
 }

--- a/src/app/util/clipboard.h
+++ b/src/app/util/clipboard.h
@@ -90,6 +90,16 @@ public:
   void setClipboardText(const std::string& text) override;
   bool getClipboardText(std::string& text) override;
 
+  bool setNativeBitmap(const doc::Image* image,
+                       const doc::Mask* mask,
+                       const doc::Palette* palette,
+                       const doc::Tileset* tileset,
+                       const doc::color_t indexMaskColor);
+  bool getNativeBitmap(doc::Image** image,
+                       doc::Mask** mask,
+                       doc::Palette** palette,
+                       doc::Tileset** tileset);
+
 private:
   void setData(doc::Image* image,
                doc::Mask* mask,
@@ -103,15 +113,6 @@ private:
   void clearNativeContent();
   void registerNativeFormats();
   bool hasNativeBitmap() const;
-  bool setNativeBitmap(const doc::Image* image,
-                       const doc::Mask* mask,
-                       const doc::Palette* palette,
-                       const doc::Tileset* tileset,
-                       const doc::color_t indexMaskColor);
-  bool getNativeBitmap(doc::Image** image,
-                       doc::Mask** mask,
-                       doc::Palette** palette,
-                       doc::Tileset** tileset);
   bool getNativeBitmapSize(gfx::Size* size);
 
   bool setNativePalette(const doc::Palette* palette, const doc::PalettePicks& picks);

--- a/src/app/util/clipboard_native.cpp
+++ b/src/app/util/clipboard_native.cpp
@@ -153,12 +153,12 @@ bool Clipboard::setNativeBitmap(const doc::Image* image,
   switch (image->pixelFormat()) {
     case doc::IMAGE_RGB: {
       // We use the RGB image data directly
-      clip::image img(image->getPixelAddress(0, 0), spec);
+      const clip::image img(image->getPixelAddress(0, 0), spec);
       l.set_image(img);
       break;
     }
     case doc::IMAGE_GRAYSCALE: {
-      clip::image img(spec);
+      const clip::image img(spec);
       const doc::LockImageBits<doc::GrayscaleTraits> bits(image);
       auto it = bits.begin();
       uint32_t* dst = (uint32_t*)img.data();
@@ -175,7 +175,10 @@ bool Clipboard::setNativeBitmap(const doc::Image* image,
       break;
     }
     case doc::IMAGE_INDEXED: {
-      clip::image img(spec);
+      if (!palette)
+        return false;
+
+      const clip::image img(spec);
       const doc::LockImageBits<doc::IndexedTraits> bits(image);
       auto it = bits.begin();
       uint32_t* dst = (uint32_t*)img.data();
@@ -193,7 +196,7 @@ bool Clipboard::setNativeBitmap(const doc::Image* image,
       l.set_image(img);
       break;
     }
-    default: TRACE("Unsupported pixelFormat: %d\n", image->pixelFormat()); return false;
+    default: return false;
   }
 
   return true;
@@ -231,7 +234,7 @@ bool Clipboard::getNativeBitmap(doc::Image** image,
         if (bits & 4)
           *palette = doc::read_palette(is);
         if (bits & 8)
-          *tileset = doc::read_tileset(is, nullptr);
+          *tileset = doc::read_tileset(is, nullptr, false);
         if (image)
           return true;
       }

--- a/src/app/util/clipboard_native.cpp
+++ b/src/app/util/clipboard_native.cpp
@@ -193,6 +193,7 @@ bool Clipboard::setNativeBitmap(const doc::Image* image,
       l.set_image(img);
       break;
     }
+    default: TRACE("Unsupported pixelFormat: %d\n", image->pixelFormat()); return false;
   }
 
   return true;

--- a/src/doc/tileset_io.cpp
+++ b/src/doc/tileset_io.cpp
@@ -62,13 +62,17 @@ Tileset* read_tileset(std::istream& is,
   const ObjectId id = read32(is);
   const tileset_index ntiles = read32(is);
   const Grid grid = read_grid(is);
-  auto tileset = new Tileset(sprite, grid, ntiles);
-  if (setId)
+  auto* tileset = new Tileset(sprite, grid, sprite ? ntiles : 0);
+  if (sprite && setId)
     tileset->setId(id);
 
   for (tileset_index ti = 0; ti < ntiles; ++ti) {
-    ImageRef image(read_image(is, setId));
-    tileset->set(ti, image);
+    const ImageRef image(read_image(is, sprite ? setId : false));
+
+    if (sprite)
+      tileset->set(ti, image);
+    else
+      tileset->add(image);
   }
 
   // Read extra version byte after tiles

--- a/src/doc/tileset_io.cpp
+++ b/src/doc/tileset_io.cpp
@@ -63,11 +63,11 @@ Tileset* read_tileset(std::istream& is,
   const tileset_index ntiles = read32(is);
   const Grid grid = read_grid(is);
   auto* tileset = new Tileset(sprite, grid, sprite ? ntiles : 0);
-  if (sprite && setId)
+  if (setId)
     tileset->setId(id);
 
   for (tileset_index ti = 0; ti < ntiles; ++ti) {
-    const ImageRef image(read_image(is, sprite ? setId : false));
+    const ImageRef image(read_image(is, setId));
 
     if (sprite)
       tileset->set(ti, image);

--- a/tests/scripts/app_clipboard.lua
+++ b/tests/scripts/app_clipboard.lua
@@ -79,16 +79,20 @@ do -- Image copying and access (with .content)
     image = app.image,
     palettte = sprite.palettes[1],
     mask = sprite.spec.transparentColor,
-    tileset = nil,
-    text = nil, -- TODO: Error when this happens
+    tileset = nil
   }
 
   expect_eq(false, app.clipboard.hasText)
   expect_eq(true, app.clipboard.hasImage)
 
-  local result = app.clipboard.content
-  assert(result ~= nil)
+  local c = app.clipboard.content
+  assert(c ~= nil)
 
-  expect_eq(sprite.image.bytes, c.image.bytes)
-  -- TODO: the rest
+  expect_eq(app.image.bytes, c.image.bytes)
+
+  --TODO: Failing for some reason
+  --expect_eq(sprite.palettes[1]:getColor(1).rgbaPixel, c.palette:getColor(1).rgbaPixel)
+
+  --TODO: Mask returning nil ATM
+  --expect_eq(sprite.spec.transparentColor, c.mask)
 end

--- a/tests/scripts/app_clipboard.lua
+++ b/tests/scripts/app_clipboard.lua
@@ -67,7 +67,16 @@ do -- Image copying and access
 end
 
 do -- Image copying and access (with .content)
-  local sprite = Sprite{ fromFile="sprites/abcd.aseprite" }
+  -- TODO: Using the previous image for now to avoid the IMAGE_TILEMAP format not being supported.
+  local beforeSprite = Sprite{ fromFile="sprites/abcd.aseprite" }
+  local imageBefore = app.image:clone()
+
+  local sprite = Sprite{ fromFile="sprites/2x2tilemap2x2tile.aseprite" }
+  assert(app.image ~= nil)
+
+  if imageBefore ~= nil then
+    expect_eq(false, imageBefore:isEqual(app.image))
+  end
 
   app.clipboard.clear()
 
@@ -76,10 +85,10 @@ do -- Image copying and access (with .content)
   assert(app.image ~= nil)
 
   app.clipboard.content = {
-    image = app.image,
+    image = imageBefore,
     palettte = sprite.palettes[1],
-    mask = sprite.spec.transparentColor,
-    tileset = nil
+    mask = sprite.selection,
+    tileset = app.layer.tileset
   }
 
   expect_eq(false, app.clipboard.hasText)
@@ -88,11 +97,8 @@ do -- Image copying and access (with .content)
   local c = app.clipboard.content
   assert(c ~= nil)
 
-  expect_eq(app.image.bytes, c.image.bytes)
-
-  --TODO: Failing for some reason
-  --expect_eq(sprite.palettes[1]:getColor(1).rgbaPixel, c.palette:getColor(1).rgbaPixel)
-
-  --TODO: Mask returning nil ATM
-  --expect_eq(sprite.spec.transparentColor, c.mask)
+  assert(imageBefore:isEqual(c.image))
+  expect_eq(sprite.palettes[1]:getColor(1).rgbaPixel, c.palette:getColor(1).rgbaPixel)
+  assert(app.layer.tileset:tile(0).image:isEqual(c.tileset:tile(0).image))
+  expect_eq(sprite.selection, c.mask)
 end

--- a/tests/scripts/app_clipboard.lua
+++ b/tests/scripts/app_clipboard.lua
@@ -1,0 +1,50 @@
+-- Copyright (C) 2024  Igara Studio S.A.
+--
+-- This file is released under the terms of the MIT license.
+-- Read LICENSE.txt for more information.
+
+dofile('./test_utils.lua')
+
+do -- Clipboard clearing
+  app.clipboard.text = "hello world"
+  expect_eq(false, app.clipboard.isEmpty)
+  app.clipboard.clear()
+  expect_eq(true, app.clipboard.isEmpty)
+end
+
+do -- Text copying and access
+  app.clipboard.clear()
+
+  expect_eq(false, app.clipboard.isText)
+  expect_eq(false, app.clipboard.isImage)
+  expect_eq(true, app.clipboard.isEmpty)
+
+  app.clipboard.text = "hello world"
+
+  expect_eq(true, app.clipboard.isText)
+  expect_eq(false, app.clipboard.isImage)
+  expect_eq(false, app.clipboard.isEmpty)
+
+  expect_eq("hello world", app.clipboard.text)
+end
+
+do -- Image copying and access
+  local sprite = Sprite{ fromFile="sprites/abcd.aseprite" }
+
+  app.clipboard.clear()
+
+  expect_eq(false, app.clipboard.isText)
+  expect_eq(false, app.clipboard.isImage)
+  expect_eq(true, app.clipboard.isEmpty)
+
+  assert(app.image ~= nil)
+  app.clipboard.image = app.image
+
+  expect_eq(false, app.clipboard.isText)
+  expect_eq(true, app.clipboard.isImage)
+  expect_eq(false, app.clipboard.isEmpty)
+
+  expect_eq(app.image.width, app.clipboard.image.width)
+  expect_eq(app.image.height, app.clipboard.image.height)
+  expect_eq(app.image.bytes, app.clipboard.image.bytes)
+end

--- a/tests/scripts/app_clipboard.lua
+++ b/tests/scripts/app_clipboard.lua
@@ -5,27 +5,46 @@
 
 dofile('./test_utils.lua')
 
-do -- Clipboard clearing
-  app.clipboard.text = "hello world"
-  expect_eq(false, app.clipboard.isEmpty)
+do -- Text clearing
+  app.clipboard.text = "clear me"
+  expect_eq(true, app.clipboard.hasText)
   app.clipboard.clear()
-  expect_eq(true, app.clipboard.isEmpty)
+  expect_eq(false, app.clipboard.hasText)
+end
+
+do -- Text clearing (with content)
+  app.clipboard.content = { text = "clear me 2" }
+  expect_eq(true, app.clipboard.hasText)
+  app.clipboard.clear()
+  expect_eq(false, app.clipboard.hasText)
 end
 
 do -- Text copying and access
   app.clipboard.clear()
 
-  expect_eq(false, app.clipboard.isText)
-  expect_eq(false, app.clipboard.isImage)
-  expect_eq(true, app.clipboard.isEmpty)
+  expect_eq(false, app.clipboard.hasText)
+  expect_eq(false, app.clipboard.hasImage)
 
   app.clipboard.text = "hello world"
 
-  expect_eq(true, app.clipboard.isText)
-  expect_eq(false, app.clipboard.isImage)
-  expect_eq(false, app.clipboard.isEmpty)
+  expect_eq(true, app.clipboard.hasText)
+  expect_eq(false, app.clipboard.hasImage)
 
   expect_eq("hello world", app.clipboard.text)
+end
+
+do -- Text copying and access (with .content)
+  app.clipboard.clear()
+
+  expect_eq(false, app.clipboard.hasText)
+  expect_eq(false, app.clipboard.hasImage)
+
+  app.clipboard.content = { text = "hello world 2"}
+
+  expect_eq(true, app.clipboard.hasText)
+  expect_eq(false, app.clipboard.hasImage)
+
+  expect_eq("hello world 2", app.clipboard.content.text)
 end
 
 do -- Image copying and access
@@ -33,18 +52,43 @@ do -- Image copying and access
 
   app.clipboard.clear()
 
-  expect_eq(false, app.clipboard.isText)
-  expect_eq(false, app.clipboard.isImage)
-  expect_eq(true, app.clipboard.isEmpty)
+  expect_eq(false, app.clipboard.hasText)
+  expect_eq(false, app.clipboard.hasImage)
 
   assert(app.image ~= nil)
   app.clipboard.image = app.image
 
-  expect_eq(false, app.clipboard.isText)
-  expect_eq(true, app.clipboard.isImage)
-  expect_eq(false, app.clipboard.isEmpty)
+  expect_eq(false, app.clipboard.hasText)
+  expect_eq(true, app.clipboard.hasImage)
 
   expect_eq(app.image.width, app.clipboard.image.width)
   expect_eq(app.image.height, app.clipboard.image.height)
   expect_eq(app.image.bytes, app.clipboard.image.bytes)
+end
+
+do -- Image copying and access (with .content)
+  local sprite = Sprite{ fromFile="sprites/abcd.aseprite" }
+
+  app.clipboard.clear()
+
+  expect_eq(false, app.clipboard.hasText)
+  expect_eq(false, app.clipboard.hasImage)
+  assert(app.image ~= nil)
+
+  app.clipboard.content = {
+    image = app.image,
+    palettte = sprite.palettes[1],
+    mask = sprite.spec.transparentColor,
+    tileset = nil,
+    text = nil, -- TODO: Error when this happens
+  }
+
+  expect_eq(false, app.clipboard.hasText)
+  expect_eq(true, app.clipboard.hasImage)
+
+  local result = app.clipboard.content
+  assert(result ~= nil)
+
+  expect_eq(sprite.image.bytes, c.image.bytes)
+  -- TODO: the rest
 end

--- a/tests/scripts/app_clipboard.lua
+++ b/tests/scripts/app_clipboard.lua
@@ -67,7 +67,7 @@ do -- Image copying and access
 end
 
 do -- Image copying and access (with .content)
-  -- TODO: Using the previous image for now to avoid the IMAGE_TILEMAP format not being supported.
+  -- Using another image to avoid the IMAGE_TILEMAP format not being supported.
   local beforeSprite = Sprite{ fromFile="sprites/abcd.aseprite" }
   local imageBefore = app.image:clone()
 
@@ -87,7 +87,7 @@ do -- Image copying and access (with .content)
   app.clipboard.content = {
     image = imageBefore,
     palettte = sprite.palettes[1],
-    mask = sprite.selection,
+    selection = sprite.selection,
     tileset = app.layer.tileset
   }
 
@@ -100,5 +100,5 @@ do -- Image copying and access (with .content)
   assert(imageBefore:isEqual(c.image))
   expect_eq(sprite.palettes[1]:getColor(1).rgbaPixel, c.palette:getColor(1).rgbaPixel)
   assert(app.layer.tileset:tile(0).image:isEqual(c.tileset:tile(0).image))
-  expect_eq(sprite.selection, c.mask)
+  expect_eq(sprite.selection, c.selection)
 end


### PR DESCRIPTION
Implements a native clipboard interface API for Lua, fixes #2073

```lua
-- Empties the clipboard
app.clipboard.clear()

-- Content check
app.clipboard.hasText
app.clipboard.hasImage

-- Quick access
app.clipboard.text
app.clipboard.image

-- Full table
app.clipboard.content = {
 image,
 selection,
 palette,
 tileset,
 text
}
```