### PR TITLE
Revamp and fix DropOnTimeline command

### DIFF
--- a/src/app/cmd/drop_on_timeline.cpp
+++ b/src/app/cmd/drop_on_timeline.cpp
@@ -21,10 +21,15 @@
 #include "app/util/layer_utils.h"
 #include "app/util/open_file_job.h"
 #include "app/tx.h"
+#include "base/serialization.h"
 #include "doc/layer_list.h"
+#include "doc/layer_io.h"
+#include "doc/subobjects_io.h"
 #include "render/dithering.h"
 
 #include <algorithm>
+
+using namespace base::serialization::little_endian;
 
 namespace app {
 namespace cmd {
@@ -45,6 +50,10 @@ DropOnTimeline::DropOnTimeline(app::Doc* doc,
   ASSERT(m_layerIndex >= 0);
   for(const auto& path : m_paths)
     m_size += path.size();
+
+  // Zero layers stored.
+  write32(m_stream, 0);
+  m_size += sizeof(uint32_t);
 }
 
 DropOnTimeline::DropOnTimeline(app::Doc* doc,
@@ -61,6 +70,127 @@ DropOnTimeline::DropOnTimeline(app::Doc* doc,
                                                          , m_droppedOn(droppedOn)
 {
   ASSERT(m_layerIndex >= 0);
+
+  // Zero layers stored.
+  write32(m_stream, 0);
+  m_size += sizeof(uint32_t);
+}
+
+void DropOnTimeline::onExecute()
+{
+  Doc* destDoc = document();
+  m_previousTotalFrames = destDoc->sprite()->totalFrames();
+
+  int docsProcessed = 0;
+  while(hasPendingWork()) {
+    Doc* srcDoc;
+    if (!getNextDoc(srcDoc))
+      return;
+
+    if (srcDoc) {
+      docsProcessed++;
+      // If source document doesn't match the destination document's color
+      // mode, change it.
+      if (srcDoc->colorMode() != destDoc->colorMode()) {
+        // Execute in a source doc transaction because we don't need undo/redo
+        // this.
+        Tx tx(srcDoc);
+        tx(new cmd::SetPixelFormat(
+          srcDoc->sprite(), destDoc->sprite()->pixelFormat(),
+          render::Dithering(),
+          Preferences::instance().quantization.rgbmapAlgorithm(),
+          nullptr,
+          nullptr,
+          FitCriteria::DEFAULT));
+        tx.commit();
+      }
+
+      // If there is only one source document to process and it has a cel that
+      // can be moved, then move the cel from the source doc into the
+      // destination doc's selected frame.
+      const bool isJustOneDoc = (docsProcessed == 1 && !hasPendingWork());
+      if (isJustOneDoc && canMoveCelFrom(srcDoc)) {
+        auto* srcLayer = static_cast<LayerImage*>(srcDoc->sprite()->firstLayer());
+        auto* destLayer = static_cast<LayerImage*>(destDoc->sprite()->allLayers()[m_layerIndex]);
+        executeAndAdd(new MoveCel(srcLayer, 0, destLayer, m_frame, false));
+        break;
+      }
+
+      // If there is no room for the source frames, add frames to the
+      // destination sprite.
+      if (m_frame+srcDoc->sprite()->totalFrames() > destDoc->sprite()->totalFrames()) {
+        destDoc->sprite()->setTotalFrames(m_frame+srcDoc->sprite()->totalFrames());
+      }
+
+      // Save dropped layers from source document.
+      saveDroppedLayers(srcDoc->sprite()->root()->layers(), destDoc->sprite());
+
+      // Source doc is not needed anymore.
+      delete srcDoc;
+    }
+  }
+
+  if (m_droppedLayersIds.empty())
+    return;
+
+  destDoc->sprite()->incrementVersion();
+  destDoc->incrementVersion();
+
+  insertDroppedLayers();
+}
+
+void DropOnTimeline::onUndo()
+{
+  CmdSequence::onUndo();
+
+  if (m_droppedLayersIds.empty()) {
+    notifyGeneralUpdate();
+    return;
+  }
+
+  Doc* doc = document();
+  frame_t currentTotalFrames = doc->sprite()->totalFrames();
+
+  for (auto id : m_droppedLayersIds) {
+    auto* layer = doc::get<Layer>(id);
+    ASSERT(layer);
+    if (layer) {
+      DocEvent ev(doc);
+      ev.sprite(layer->sprite());
+      ev.layer(layer);
+      doc->notify_observers<DocEvent&>(&DocObserver::onBeforeRemoveLayer, ev);
+
+      LayerGroup* group = layer->parent();
+      group->removeLayer(layer);
+      group->incrementVersion();
+      group->sprite()->incrementVersion();
+
+      doc->notify_observers<DocEvent&>(&DocObserver::onAfterRemoveLayer, ev);
+
+      delete layer;
+    }
+  }
+  doc->sprite()->setTotalFrames(m_previousTotalFrames);
+  doc->sprite()->incrementVersion();
+  m_previousTotalFrames = currentTotalFrames;
+}
+
+void DropOnTimeline::onRedo()
+{
+  CmdSequence::onRedo();
+
+  if (m_droppedLayersIds.empty()) {
+    notifyGeneralUpdate();
+    return;
+  }
+
+  Doc* doc = document();
+  frame_t currentTotalFrames = doc->sprite()->totalFrames();
+  doc->sprite()->setTotalFrames(m_previousTotalFrames);
+  doc->sprite()->incrementVersion();
+  m_previousTotalFrames = currentTotalFrames;
+
+  insertDroppedLayers();
 }
 
 void DropOnTimeline::setupInsertionLayer(Layer*& layer, LayerGroup*& group)
@@ -153,117 +283,51 @@ bool DropOnTimeline::getNextDoc(Doc*& srcDoc)
   return getNextDocFromImage(srcDoc);
 }
 
-void DropOnTimeline::onExecute()
+void DropOnTimeline::storeDroppedLayerIds(const Layer* layer)
 {
-  Doc* destDoc = document();
-  m_previousTotalFrames = destDoc->sprite()->totalFrames();
+  if (layer->isGroup()) {
+    const auto* group = static_cast<const LayerGroup*>(layer);
+    for (auto* child : group->layers())
+      storeDroppedLayerIds(child);
 
-  int docsProcessed = 0;
-  while(hasPendingWork()) {
-    Doc* srcDoc;
-    if (!getNextDoc(srcDoc))
-      return;
-
-    if (srcDoc) {
-      docsProcessed++;
-      // If source document doesn't match the destination document's color
-      // mode, change it.
-      if (srcDoc->colorMode() != destDoc->colorMode()) {
-        // Execute in a source doc transaction because we don't need undo/redo
-        // this.
-        Tx tx(srcDoc);
-        tx(new cmd::SetPixelFormat(
-          srcDoc->sprite(), destDoc->sprite()->pixelFormat(),
-          render::Dithering(),
-          Preferences::instance().quantization.rgbmapAlgorithm(),
-          nullptr,
-          nullptr,
-          FitCriteria::DEFAULT));
-        tx.commit();
-      }
-
-      // If there is only one source document to process and it has a cel that
-      // can be moved, then move the cel from the source doc into the
-      // destination doc's selected frame.
-      const bool isJustOneDoc = (docsProcessed == 1 && !hasPendingWork());
-      if (isJustOneDoc && canMoveCelFrom(srcDoc)) {
-        auto* srcLayer = static_cast<LayerImage*>(srcDoc->sprite()->firstLayer());
-        auto* destLayer = static_cast<LayerImage*>(destDoc->sprite()->allLayers()[m_layerIndex]);
-        executeAndAdd(new MoveCel(srcLayer, 0, destLayer, m_frame, false));
-        break;
-      }
-
-      // If there is no room for the source frames, add frames to the
-      // destination sprite.
-      if (m_frame+srcDoc->sprite()->totalFrames() > destDoc->sprite()->totalFrames()) {
-        destDoc->sprite()->setTotalFrames(m_frame+srcDoc->sprite()->totalFrames());
-      }
-
-      // Save dropped layers from source document.
-      auto allLayers = srcDoc->sprite()->allLayers();
-      for (auto it = allLayers.cbegin(); it != allLayers.cend(); ++it) {
-        auto* layer = *it;
-        // TODO: If we could "relocate" a layer from the source document to the
-        // destination document we could avoid making a copy here.
-        auto* layerCopy = copy_layer_with_sprite(layer, destDoc->sprite());
-        layerCopy->displaceFrames(0, m_frame);
-        m_droppedLayers.push_back(layerCopy);
-        m_size += layerCopy->getMemSize();
-      }
-
-      // Source doc is not needed anymore.
-      delete srcDoc;
-    }
+    m_droppedLayersIds.push_back(group->id());
   }
-  destDoc->sprite()->incrementVersion();
-  destDoc->incrementVersion();
-
-  insertDroppedLayers(true);
+  else {
+    m_droppedLayersIds.push_back(layer->id());
+  }
 }
 
-void DropOnTimeline::onUndo()
+void DropOnTimeline::saveDroppedLayers(const LayerList& layers, Sprite* sprite)
 {
-  CmdSequence::onUndo();
+  size_t start = m_stream.tellp();
 
-  if (m_droppedLayers.empty()) {
-    notifyDocObservers(nullptr);
-    return;
+  // Calculate the new number of layers.
+  m_stream.seekg(0);
+  uint32_t nLayers = read32(m_stream) + layers.size();
+
+  // Flat list of all the dropped layers.
+  LayerList allDroppedLayers;
+  // Write number of layers (at the beginning of the stream).
+  m_stream.seekp(0);
+  write32(m_stream, nLayers);
+  // Move to where we must start writing.
+  m_stream.seekp(start);
+  for (auto it = layers.cbegin(); it != layers.cend(); ++it) {
+    auto* layer = *it;
+    // TODO: If we could "relocate" a layer from the source document to the
+    // destination document we could avoid making a copy here.
+    std::unique_ptr<Layer> layerCopy(copy_layer_with_sprite(layer, sprite));
+    layerCopy->displaceFrames(0, m_frame);
+
+    write_layer(m_stream, layerCopy.get());
+
+    storeDroppedLayerIds(layerCopy.get());
   }
-
-  Doc* doc = document();
-  frame_t currentTotalFrames = doc->sprite()->totalFrames();
-  Layer* layerBefore = nullptr;
-  for (auto* layer : m_droppedLayers) {
-    layerBefore = layer->getPrevious();
-    layer->parent()->removeLayer(layer);
-  }
-  doc->sprite()->setTotalFrames(m_previousTotalFrames);
-  m_previousTotalFrames = currentTotalFrames;
-
-  if (!layerBefore)
-    layerBefore = doc->sprite()->firstLayer();
-
-  notifyDocObservers(layerBefore);
+  size_t end = m_stream.tellp();
+  m_size += end - start;
 }
 
-void DropOnTimeline::onRedo()
-{
-  CmdSequence::onRedo();
-
-  if (m_droppedLayers.empty()) {
-    notifyDocObservers(nullptr);
-    return;
-  }
-
-  Doc* doc = document();
-  frame_t currentTotalFrames = doc->sprite()->totalFrames();
-  doc->sprite()->setTotalFrames(m_previousTotalFrames);
-  m_previousTotalFrames = currentTotalFrames;
-
-  insertDroppedLayers(false);
-}
-
-void DropOnTimeline::insertDroppedLayers(bool incGroupVersion)
+void DropOnTimeline::insertDroppedLayers()
 {
   // Layer used as a reference to determine if the dropped layers will be
   // inserted after or before it.
@@ -275,8 +339,11 @@ void DropOnTimeline::insertDroppedLayers(bool incGroupVersion)
 
   setupInsertionLayer(refLayer, group);
 
-  for (auto it = m_droppedLayers.cbegin(); it != m_droppedLayers.cend(); ++it) {
-    auto* layer = *it;
+  SubObjectsFromSprite io(group->sprite());
+  m_stream.seekg(0);
+  auto nLayers = read32(m_stream);
+  for (int i=0; i<nLayers; ++i) {
+    auto* layer = read_layer(m_stream, &io);
 
     if (!refLayer) {
       group->addLayer(layer);
@@ -292,12 +359,16 @@ void DropOnTimeline::insertDroppedLayers(bool incGroupVersion)
       refLayer = layer;
       insert = InsertionPoint::AfterLayer;
     }
-  }
 
-  if (incGroupVersion)
     group->incrementVersion();
+    group->sprite()->incrementVersion();
 
-  notifyDocObservers(refLayer);
+    Doc* doc = static_cast<Doc*>(group->sprite()->document());
+    DocEvent ev(doc);
+    ev.sprite(group->sprite());
+    ev.layer(layer);
+    doc->notify_observers<DocEvent&>(&DocObserver::onAddLayer, ev);
+  }
 }
 
 // Returns true if the document srcDoc has a cel that can be moved.
@@ -319,24 +390,13 @@ bool DropOnTimeline::canMoveCelFrom(app::Doc* srcDoc)
          destLayer->isImage();
 }
 
-void DropOnTimeline::notifyDocObservers(Layer* layer)
+void DropOnTimeline::notifyGeneralUpdate()
 {
   Doc* doc = document();
   if (!doc)
     return;
 
-  if (!layer) {
-    doc->notifyGeneralUpdate();
-    return;
-  }
-
-  DocEvent ev(doc);
-  ev.sprite(doc->sprite());
-  ev.layer(layer);
-  // TODO: This is a hack, we send this notification because the timeline
-  // has the code we need to execute after this command. We tried using
-  // DocObserver::onAddLayer but it makes the redo crash.
-  doc->notify_observers<DocEvent&>(&DocObserver::onAfterRemoveLayer, ev);
+  doc->notifyGeneralUpdate();
 }
 
 } // namespace cmd

--- a/src/app/cmd/drop_on_timeline.cpp
+++ b/src/app/cmd/drop_on_timeline.cpp
@@ -83,7 +83,7 @@ void DropOnTimeline::onExecute()
 
   int docsProcessed = 0;
   while(hasPendingWork()) {
-    Doc* srcDoc;
+    std::unique_ptr<Doc> srcDoc;
     if (!getNextDoc(srcDoc))
       return;
 
@@ -94,7 +94,7 @@ void DropOnTimeline::onExecute()
       if (srcDoc->colorMode() != destDoc->colorMode()) {
         // Execute in a source doc transaction because we don't need undo/redo
         // this.
-        Tx tx(srcDoc);
+        Tx tx(srcDoc.get());
         tx(new cmd::SetPixelFormat(
           srcDoc->sprite(), destDoc->sprite()->pixelFormat(),
           render::Dithering(),
@@ -109,7 +109,7 @@ void DropOnTimeline::onExecute()
       // can be moved, then move the cel from the source doc into the
       // destination doc's selected frame.
       const bool isJustOneDoc = (docsProcessed == 1 && !hasPendingWork());
-      if (isJustOneDoc && canMoveCelFrom(srcDoc)) {
+      if (isJustOneDoc && canMoveCelFrom(srcDoc.get())) {
         auto* srcLayer = static_cast<LayerImage*>(srcDoc->sprite()->firstLayer());
         auto* destLayer = static_cast<LayerImage*>(destDoc->sprite()->allLayers()[m_layerIndex]);
         executeAndAdd(new MoveCel(srcLayer, 0, destLayer, m_frame, false));
@@ -124,9 +124,6 @@ void DropOnTimeline::onExecute()
 
       // Save dropped layers from source document.
       saveDroppedLayers(srcDoc->sprite()->root()->layers(), destDoc->sprite());
-
-      // Source doc is not needed anymore.
-      delete srcDoc;
     }
   }
 
@@ -217,7 +214,7 @@ bool DropOnTimeline::hasPendingWork()
   return m_image || !m_paths.empty();
 }
 
-bool DropOnTimeline::getNextDocFromImage(Doc*& srcDoc)
+bool DropOnTimeline::getNextDocFromImage(std::unique_ptr<Doc>& srcDoc)
 {
   if (!m_image)
     return true;
@@ -227,12 +224,12 @@ bool DropOnTimeline::getNextDocFromImage(Doc*& srcDoc)
   sprite->root()->addLayer(layer);
   Cel* cel = new Cel(0, m_image);
   layer->addCel(cel);
-  srcDoc = new Doc(sprite);
+  srcDoc = std::make_unique<Doc>(sprite);
   m_image = nullptr;
   return true;
 }
 
-bool DropOnTimeline::getNextDocFromPaths(Doc*& srcDoc)
+bool DropOnTimeline::getNextDocFromPaths(std::unique_ptr<Doc>& srcDoc)
 {
   Console console;
   Context* context = document()->context();
@@ -270,13 +267,12 @@ bool DropOnTimeline::getNextDocFromPaths(Doc*& srcDoc)
   if (fop->hasError() && !fop->isStop())
     console.printf(fop->error().c_str());
 
-  srcDoc = fop->releaseDocument();
+  srcDoc.reset(fop->releaseDocument());
   return true;
 }
 
-bool DropOnTimeline::getNextDoc(Doc*& srcDoc)
+bool DropOnTimeline::getNextDoc(std::unique_ptr<Doc>& srcDoc)
 {
-  srcDoc = nullptr;
   if (m_image == nullptr && !m_paths.empty())
     return getNextDocFromPaths(srcDoc);
 

--- a/src/app/cmd/drop_on_timeline.cpp
+++ b/src/app/cmd/drop_on_timeline.cpp
@@ -63,23 +63,23 @@ DropOnTimeline::DropOnTimeline(app::Doc* doc,
   ASSERT(m_layerIndex >= 0);
 }
 
-void DropOnTimeline::setupInsertionLayer(Layer** layer, LayerGroup** group)
+void DropOnTimeline::setupInsertionLayer(Layer*& layer, LayerGroup*& group)
 {
   const LayerList& allLayers = document()->sprite()->allLayers();
-  *layer  = allLayers[m_layerIndex];
-  if (m_insert == InsertionPoint::BeforeLayer && (*layer)->isGroup()) {
-    *group = static_cast<LayerGroup*>(*layer);
+  layer = allLayers[m_layerIndex];
+  if (m_insert == InsertionPoint::BeforeLayer && layer->isGroup()) {
+    group = static_cast<LayerGroup*>(layer);
     // The user is trying to drop layers into an empty group, so there is no after
     // nor before layer...
-    if ((*group)->layersCount() == 0) {
-      *layer = nullptr;
+    if (group->layersCount() == 0) {
+      layer = nullptr;
       return;
     }
-    *layer = (*group)->lastLayer();
+    layer = group->lastLayer();
     m_insert = InsertionPoint::AfterLayer;
   }
 
-  *group  = (*layer)->parent();
+  group = layer->parent();
 }
 
 bool DropOnTimeline::hasPendingWork()
@@ -87,7 +87,7 @@ bool DropOnTimeline::hasPendingWork()
   return m_image || !m_paths.empty();
 }
 
-bool DropOnTimeline::getNextDocFromImage(Doc** srcDoc)
+bool DropOnTimeline::getNextDocFromImage(Doc*& srcDoc)
 {
   if (!m_image)
     return true;
@@ -97,12 +97,12 @@ bool DropOnTimeline::getNextDocFromImage(Doc** srcDoc)
   sprite->root()->addLayer(layer);
   Cel* cel = new Cel(0, m_image);
   layer->addCel(cel);
-  *srcDoc = new Doc(sprite);
+  srcDoc = new Doc(sprite);
   m_image = nullptr;
   return true;
 }
 
-bool DropOnTimeline::getNextDocFromPaths(Doc** srcDoc)
+bool DropOnTimeline::getNextDocFromPaths(Doc*& srcDoc)
 {
   Console console;
   Context* context = document()->context();
@@ -140,13 +140,13 @@ bool DropOnTimeline::getNextDocFromPaths(Doc** srcDoc)
   if (fop->hasError() && !fop->isStop())
     console.printf(fop->error().c_str());
 
-  *srcDoc = fop->releaseDocument();
+  srcDoc = fop->releaseDocument();
   return true;
 }
 
-bool DropOnTimeline::getNextDoc(Doc** srcDoc)
+bool DropOnTimeline::getNextDoc(Doc*& srcDoc)
 {
-  *srcDoc = nullptr;
+  srcDoc = nullptr;
   if (m_image == nullptr && !m_paths.empty())
     return getNextDocFromPaths(srcDoc);
 
@@ -161,7 +161,7 @@ void DropOnTimeline::onExecute()
   int docsProcessed = 0;
   while(hasPendingWork()) {
     Doc* srcDoc;
-    if (!getNextDoc(&srcDoc))
+    if (!getNextDoc(srcDoc))
       return;
 
     if (srcDoc) {
@@ -273,7 +273,7 @@ void DropOnTimeline::insertDroppedLayers(bool incGroupVersion)
   // Keep track of the current insertion point.
   InsertionPoint insert = m_insert;
 
-  setupInsertionLayer(&refLayer, &group);
+  setupInsertionLayer(refLayer, group);
 
   for (auto it = m_droppedLayers.cbegin(); it != m_droppedLayers.cend(); ++it) {
     auto* layer = *it;

--- a/src/app/cmd/drop_on_timeline.h
+++ b/src/app/cmd/drop_on_timeline.h
@@ -59,12 +59,12 @@ namespace cmd {
     bool canMoveCelFrom(app::Doc* srcDoc);
     void notifyGeneralUpdate();
     bool hasPendingWork();
-    // Sets srcDoc's Doc* reference to the next document to be processed.
+    // Returns the next document to be processed.
     // Returns false when the user cancelled the process, or true when the
     // process must go on.
-    bool getNextDoc(Doc*& srcDoc);
-    bool getNextDocFromImage(Doc*& srcDoc);
-    bool getNextDocFromPaths(Doc*& srcDoc);
+    bool getNextDoc(std::unique_ptr<Doc>& srcDoc);
+    bool getNextDocFromImage(std::unique_ptr<Doc>& srcDoc);
+    bool getNextDocFromPaths(std::unique_ptr<Doc>& srcDoc);
 
     void storeDroppedLayerIds(const doc::Layer* layer);
     void saveDroppedLayers(const doc::LayerList& layers, doc::Sprite* sprite);

--- a/src/app/cmd/drop_on_timeline.h
+++ b/src/app/cmd/drop_on_timeline.h
@@ -55,10 +55,9 @@ namespace cmd {
 
   private:
     void setupInsertionLayer(doc::Layer*& layer, doc::LayerGroup*& group);
-    void insertDroppedLayers(bool incGroupVersion);
+    void insertDroppedLayers();
     bool canMoveCelFrom(app::Doc* srcDoc);
-    void notifyAddLayer(doc::Layer* layer);
-    void notifyDocObservers(doc::Layer* layer);
+    void notifyGeneralUpdate();
     bool hasPendingWork();
     // Sets srcDoc's Doc* reference to the next document to be processed.
     // Returns false when the user cancelled the process, or true when the
@@ -67,6 +66,9 @@ namespace cmd {
     bool getNextDocFromImage(Doc*& srcDoc);
     bool getNextDocFromPaths(Doc*& srcDoc);
 
+    void storeDroppedLayerIds(const doc::Layer* layer);
+    void saveDroppedLayers(const doc::LayerList& layers, doc::Sprite* sprite);
+
     size_t m_size;
     base::paths m_paths;
     doc::ImageRef m_image = nullptr;
@@ -74,9 +76,11 @@ namespace cmd {
     doc::layer_t m_layerIndex;
     InsertionPoint m_insert;
     DroppedOn m_droppedOn;
-    // Holds the list of layers dropped into the document. Used to support
-    // undo/redo without having to read all the files again.
-    doc::LayerList m_droppedLayers;
+    // Serialized dropped layers' data. Used for redo operation.
+    std::stringstream m_stream;
+    // Holds the Object IDs of the dropped layers. Used when determining which
+    // layers should be removed in an undo operation.
+    std::vector<doc::ObjectId> m_droppedLayersIds;
     // Number of frames the doc had before dropping.
     doc::frame_t m_previousTotalFrames;
   };

--- a/src/app/cmd/drop_on_timeline.h
+++ b/src/app/cmd/drop_on_timeline.h
@@ -54,18 +54,18 @@ namespace cmd {
     }
 
   private:
-    void setupInsertionLayer(doc::Layer** layer, doc::LayerGroup** group);
+    void setupInsertionLayer(doc::Layer*& layer, doc::LayerGroup*& group);
     void insertDroppedLayers(bool incGroupVersion);
     bool canMoveCelFrom(app::Doc* srcDoc);
     void notifyAddLayer(doc::Layer* layer);
     void notifyDocObservers(doc::Layer* layer);
     bool hasPendingWork();
-    // Sets srcDoc's Doc* pointer to the next document to be processed.
+    // Sets srcDoc's Doc* reference to the next document to be processed.
     // Returns false when the user cancelled the process, or true when the
     // process must go on.
-    bool getNextDoc(Doc** srcDoc);
-    bool getNextDocFromImage(Doc** srcDoc);
-    bool getNextDocFromPaths(Doc** srcDoc);
+    bool getNextDoc(Doc*& srcDoc);
+    bool getNextDocFromImage(Doc*& srcDoc);
+    bool getNextDocFromPaths(Doc*& srcDoc);
 
     size_t m_size;
     base::paths m_paths;


### PR DESCRIPTION
This PR essentially fixes #4858, but it does so by revamping the `DropOnTimeline` command after I realized that it is actually not practical to store the dropped layers in a vector of pointers to layers because of how the `ObjectId`s impact on the logic needed to keep them in sync. So I used the same approach as in other commands: use a `stringstream` object to store the data (dropped layers) that needs the redo operation.

As a side effect, I believe that there is a high chance that the following crashes are fixed as well:
[ASEPRITE-2QF](https://igara-studio.sentry.io/issues/6085369687/events/ff0e50ded22d4bcbc4330aa777f531b9/)
[ASEPRITE-2QB](https://igara-studio.sentry.io/issues/6084029246/events/c3edf8fd1b1449a010abf680ebd561c5/)