### PR TITLE
Show export location

### DIFF
--- a/data/pref.xml
+++ b/data/pref.xml
@@ -161,6 +161,7 @@
       <option id="keep_closed_sprite_on_memory" type="bool" default="true" />
       <option id="keep_closed_sprite_on_memory_for" type="double" default="15.0" />
       <option id="show_full_path" type="bool" default="true" />
+      <option id="edit_full_path" type="bool" default="false" />
       <option id="timeline_position" type="TimelinePosition" default="TimelinePosition::BOTTOM" />
       <option id="timeline_layer_panel_width" type="int" default="100" />
       <option id="show_menu_bar" type="bool" default="true" />

--- a/data/strings/en.ini
+++ b/data/strings/en.ini
@@ -665,9 +665,6 @@ sensors_tweaks = Sensor Threshold
 
 [export_file]
 title = Export File
-choose_file = Choose File...
-relative_path = Relative Path to "{}"
-absolute_path = Absolute Path
 output_file = Output File:
 resize = Resize:
 area = Area:
@@ -1698,6 +1695,9 @@ cancel = Cancel
 
 [select_file]
 text = Select File
+choose = Choose File...
+relative_path = Relative Path to "{}"
+absolute_path = Absolute Path
 browse = ...
 
 [selection_mode]

--- a/data/strings/en.ini
+++ b/data/strings/en.ini
@@ -665,6 +665,9 @@ sensors_tweaks = Sensor Threshold
 
 [export_file]
 title = Export File
+choose_file = Choose File...
+relative_path = Relative Path to "{}"
+absolute_path = Absolute Path
 output_file = Output File:
 resize = Resize:
 area = Area:

--- a/data/widgets/export_file.xml
+++ b/data/widgets/export_file.xml
@@ -5,9 +5,7 @@
   <window id="export_file" text="@.title" help="exporting">
     <grid columns="3">
       <label text="@.output_file" />
-      <entry id="output_filename" cell_align="horizontal" maxsize="1024" maxwidth="256" />
-      <button id="output_filename_browse" text="..." style="mini_button" />
-
+      <filename id="output_field" cell_align="horizontal" cell_hspan="2" />
       <label id="resize_label" text="@.resize" />
       <hbox cell_hspan="2" cell_align="horizontal">
         <combobox id="resize" editable="true" suffix="%" expansive="true">

--- a/data/widgets/export_sprite_sheet.xml
+++ b/data/widgets/export_sprite_sheet.xml
@@ -111,10 +111,10 @@
     </hbox>
     <grid id="section_output" columns="4" expansive="true">
       <check id="image_enabled" text="@.output_file" />
-      <button id="image_filename" cell_hspan="3" cell_align="horizontal" />
+      <filename id="image_filename" cell_hspan="3" cell_align="horizontal" />
 
       <check id="data_enabled" text="@.json_data" />
-      <button id="data_filename" cell_hspan="3" cell_align="horizontal" />
+      <filename id="data_filename" cell_hspan="3" cell_align="horizontal" />
 
       <hbox />
       <hbox id="data_meta" cell_hspan="3" cell_align="horizontal">

--- a/src/app/commands/cmd_export_sprite_sheet.cpp
+++ b/src/app/commands/cmd_export_sprite_sheet.cpp
@@ -421,8 +421,8 @@ public:
     updateDataFields();
 
     std::string base = site.document()->filename();
-    std::string basePath = (base::get_file_path(base).empty() ?
-      base::get_current_path(): base::get_file_path(base));
+    const std::string basePath = (base::get_file_path(base).empty() ? base::get_current_path() :
+                                                                      base::get_file_path(base));
     base = base::join_path(basePath, base::get_file_title(base));
 
     imageFilename()->setDocFilename(base);
@@ -856,7 +856,7 @@ private:
     generatePreview();
   }
 
-  std::string onFilenameBrowse(FilenameField* field)
+  std::string onFilenameBrowse(FilenameField* const field)
   {
     const std::string& title = (field == dataFilename() ?
                                   Strings::export_sprite_sheet_save_json_title() :
@@ -877,7 +877,7 @@ private:
     return newFilename.front();
   }
 
-  void onOutputFieldEnabledChange(FilenameField* field, bool visible)
+  void onOutputFieldEnabledChange(FilenameField* const field, bool visible)
   {
     field->setAskOverwrite(true);
     field->setVisible(visible);

--- a/src/app/commands/cmd_export_sprite_sheet.cpp
+++ b/src/app/commands/cmd_export_sprite_sheet.cpp
@@ -421,7 +421,9 @@ public:
     updateDataFields();
 
     std::string base = site.document()->filename();
-    base = base::join_path(base::get_file_path(base), base::get_file_title(base));
+    std::string basePath = (base::get_file_path(base).empty() ?
+      base::get_current_path(): base::get_file_path(base));
+    base = base::join_path(basePath, base::get_file_title(base));
 
     imageFilename()->setDocFilename(base);
     dataFilename()->setDocFilename(base);

--- a/src/app/commands/cmd_save_file.cpp
+++ b/src/app/commands/cmd_save_file.cpp
@@ -358,19 +358,20 @@ void SaveFileCopyAsCommand::onExecute(Context* context)
     ExportFileWindow win(doc);
     bool askOverwrite = true;
 
-    win.SelectOutputFile.connect([this, &win, &askOverwrite, context, doc]() -> std::string {
-      std::string result = saveAsDialog(
-        context,
-        Strings::save_file_export(),
-        win.outputFilenameValue(),
-        MarkAsSaved::Off,
-        SaveInBackground::Off,
-        (doc->isAssociatedToFile() ? doc->filename() : std::string()));
-      if (!result.empty())
-        askOverwrite = false; // Already asked in the file selector dialog
+    win.outputField()->SelectOutputFile.connect(
+      [this, &win, &askOverwrite, context, doc]() -> std::string {
+        std::string result = saveAsDialog(
+          context,
+          Strings::save_file_export(),
+          win.outputField()->fullFilename(),
+          MarkAsSaved::Off,
+          SaveInBackground::Off,
+          (doc->isAssociatedToFile() ? doc->filename() : std::string()));
+        if (!result.empty())
+          askOverwrite = false; // Already asked in the file selector dialog
 
-      return result;
-    });
+        return result;
+      });
 
     if (params().filename.isSet()) {
       std::string outputPath = base::get_file_path(outputFilename);
@@ -378,7 +379,7 @@ void SaveFileCopyAsCommand::onExecute(Context* context)
         outputPath = base::get_file_path(doc->filename());
         outputFilename = base::join_path(outputPath, outputFilename);
       }
-      win.setOutputFilename(outputFilename);
+      win.outputField()->setFilename(outputFilename);
     }
 
     if (params().scale.isSet())
@@ -401,7 +402,7 @@ void SaveFileCopyAsCommand::onExecute(Context* context)
     if (!result)
       return;
 
-    outputFilename = win.outputFilenameValue();
+    outputFilename = win.outputField()->fullFilename();
 
     if (askOverwrite && base::is_file(outputFilename)) {
       int ret = OptionalAlert::show(Preferences::instance().exportFile.showOverwriteFilesAlert,

--- a/src/app/script/dialog_class.cpp
+++ b/src/app/script/dialog_class.cpp
@@ -1098,12 +1098,12 @@ int Dialog_file(lua_State* L)
     lua_pop(L, 1);
   }
 
-  widget->SelectFile.connect([=]() -> std::string {
+  widget->SelectOutputFile.connect([=]() -> std::string {
     base::paths newfilename;
-    if (app::show_file_selector(title, widget->filename(), exts, dlgType, newfilename))
+    if (app::show_file_selector(title, widget->fullFilename(), exts, dlgType, newfilename))
       return newfilename.front();
     else
-      return widget->filename();
+      return widget->fullFilename();
   });
   return Dialog_add_widget(L, widget);
 }
@@ -1717,7 +1717,7 @@ int Dialog_get_data(lua_State* L)
           }
         }
         else if (auto filenameField = dynamic_cast<const FilenameField*>(widget)) {
-          lua_pushstring(L, filenameField->filename().c_str());
+          lua_pushstring(L, filenameField->fullFilename().c_str());
         }
         else if (auto tabs = dynamic_cast<const app::script::Tabs*>(widget)) {
           std::string tabStr = tabs->tabId(tabs->selectedTab());

--- a/src/app/ui/export_file_window.cpp
+++ b/src/app/ui/export_file_window.cpp
@@ -40,8 +40,13 @@ ExportFileWindow::ExportFileWindow(const Doc* doc)
     outputField()->setFilename(m_docPref.saveCopy.filename());
   }
   else {
-    std::string newFn = base::replace_extension(doc->filename(), defaultExtension());
-    if (newFn == doc->filename()) {
+    std::string base = doc->filename();
+    std::string basePath = (base::get_file_path(base).empty() ?
+      base::get_current_path(): base::get_file_path(base));
+    base = base::join_path(basePath, base::get_file_title(base));
+
+    std::string newFn = base::replace_extension(base, defaultExtension());
+    if (newFn == base) {
       newFn = base::join_path(
         base::get_file_path(newFn),
         base::get_file_title(newFn) + "-export." + base::get_file_extension(newFn));

--- a/src/app/ui/export_file_window.cpp
+++ b/src/app/ui/export_file_window.cpp
@@ -41,8 +41,8 @@ ExportFileWindow::ExportFileWindow(const Doc* doc)
   }
   else {
     std::string base = doc->filename();
-    std::string basePath = (base::get_file_path(base).empty() ?
-      base::get_current_path(): base::get_file_path(base));
+    const std::string basePath = (base::get_file_path(base).empty() ? base::get_current_path() :
+                                                                      base::get_file_path(base));
     base = base::join_path(basePath, base::get_file_title(base));
 
     std::string newFn = base::replace_extension(base, defaultExtension());

--- a/src/app/ui/export_file_window.h
+++ b/src/app/ui/export_file_window.h
@@ -45,6 +45,7 @@ public:
   obs::signal<std::string()> SelectOutputFile;
 
 private:
+  void onOutputFilenameBrowse();
   void updateOutputFilenameEntry();
   void onOutputFilenameEntryChange();
   void updateAniDir();
@@ -57,8 +58,10 @@ private:
   const Doc* m_doc;
   DocumentPreferences& m_docPref;
   std::string m_outputPath;
+  std::string m_outputPathBase;
   std::string m_outputFilename;
   int m_preferredResize;
+  bool m_showFullPath;
 };
 
 } // namespace app

--- a/src/app/ui/export_file_window.h
+++ b/src/app/ui/export_file_window.h
@@ -26,7 +26,6 @@ public:
   bool show();
   void savePref();
 
-  std::string outputFilenameValue() const;
   double resizeValue() const;
   std::string areaValue() const;
   std::string layersValue() const;
@@ -37,17 +36,12 @@ public:
   bool applyPixelRatio() const;
   bool isForTwitter() const;
 
-  void setOutputFilename(const std::string& pathAndFilename);
   void setResizeScale(const double scale);
   void setArea(const std::string& area);
   void setAniDir(const doc::AniDir aniDir);
 
-  obs::signal<std::string()> SelectOutputFile;
-
 private:
-  void onOutputFilenameBrowse();
-  void updateOutputFilenameEntry();
-  void onOutputFilenameEntryChange();
+  void onOutputFieldChange();
   void updateAniDir();
   void updatePlaySubtags();
   void updateAdjustResizeButton();
@@ -57,11 +51,7 @@ private:
 
   const Doc* m_doc;
   DocumentPreferences& m_docPref;
-  std::string m_outputPath;
-  std::string m_outputPathBase;
-  std::string m_outputFilename;
   int m_preferredResize;
-  bool m_showFullPath;
 };
 
 } // namespace app

--- a/src/app/ui/filename_field.cpp
+++ b/src/app/ui/filename_field.cpp
@@ -27,6 +27,7 @@ using namespace ui;
 FilenameField::FilenameField(const Type type, const std::string& pathAndFilename)
   : m_entry(type == EntryAndButton ? new ui::Entry(1024, "") : nullptr)
   , m_button(type == EntryAndButton ? Strings::select_file_browse() : Strings::select_file_text())
+  , m_askOverwrite(true)
 {
   m_showFullPath = Preferences::instance().general.showFullPath();
   setFocusStop(true);
@@ -71,10 +72,10 @@ const std::string FilenameField::updatedFilename() const
   }
 }
 
-void FilenameField::setShowFullPath(const bool fullPath)
+void FilenameField::setShowFullPath(const bool on)
 {
   const std::string& fn = updatedFilename();
-  m_showFullPath = fullPath;
+  m_showFullPath = on;
   setFilename(fn);
 }
 
@@ -96,6 +97,7 @@ void FilenameField::onBrowse()
     std::string fn = SelectOutputFile();
     if (!fn.empty()) {
       setFilename(fn);
+      m_askOverwrite = false; // Already asked in file selector
     }
   });
   relative.Click.connect([this] { setShowFullPath(false); });
@@ -152,6 +154,11 @@ void FilenameField::onInitTheme(ui::InitThemeEvent& ev)
   ui::Style* style = theme->styles.miniButton();
   if (style)
     m_button.setStyle(style);
+}
+
+void FilenameField::onUpdateText()
+{
+  setShowFullPath(m_showFullPath);
 }
 
 void FilenameField::updateWidgets()

--- a/src/app/ui/filename_field.cpp
+++ b/src/app/ui/filename_field.cpp
@@ -100,6 +100,8 @@ void FilenameField::onBrowse()
   ui::MenuItem choose(Strings::select_file_choose());
   ui::MenuItem relative(Strings::select_file_relative_path(m_pathBase));
   ui::MenuItem absolute(Strings::select_file_absolute_path());
+  relative.setSelected(!m_editFullPath);
+  absolute.setSelected(m_editFullPath);
   menu.addChild(&choose);
   menu.addChild(new ui::MenuSeparator());
   menu.addChild(&relative);

--- a/src/app/ui/filename_field.cpp
+++ b/src/app/ui/filename_field.cpp
@@ -29,6 +29,7 @@ FilenameField::FilenameField(const Type type, const std::string& pathAndFilename
   , m_button(type == EntryAndButton ? Strings::select_file_browse() : Strings::select_file_text())
   , m_askOverwrite(true)
 {
+  m_pathBase = std::string();
   m_showFullPath = Preferences::instance().general.showFullPath();
   setFocusStop(true);
   if (m_entry) {
@@ -108,7 +109,8 @@ void FilenameField::onBrowse()
 
 void FilenameField::setFilename(const std::string& pathAndFilename)
 {
-  if (m_showFullPath || base::get_file_path(m_docFilename).empty()) {
+  const std::string spritePath = base::get_file_path(m_docFilename);
+  if (m_showFullPath || spritePath.empty()) {
     m_path = base::get_file_path(pathAndFilename);
     m_file = base::get_file_name(pathAndFilename);
   }
@@ -122,11 +124,11 @@ void FilenameField::setFilename(const std::string& pathAndFilename)
       m_file = base::get_file_name(pathAndFilename);
     }
   }
+
   if (m_showFullPath)
     m_path = base::get_absolute_path(m_path);
-  if (!m_showFullPath || m_pathBase.empty())
-    m_pathBase = m_path;
 
+  m_pathBase = (spritePath.empty() ? m_path: spritePath);
   updateWidgets();
 }
 

--- a/src/app/ui/filename_field.h
+++ b/src/app/ui/filename_field.h
@@ -8,6 +8,7 @@
 #define APP_UI_FILENAME_FIELD_H_INCLUDED
 #pragma once
 
+#include "obs/connection.h"
 #include "obs/signal.h"
 #include "ui/box.h"
 #include "ui/button.h"
@@ -30,7 +31,6 @@ public:
   bool askOverwrite() const { return m_askOverwrite; };
   void setFilename(const std::string& pathAndFilename);
   void setFilenameQuiet(const std::string& fn) { m_file = fn; };
-  void setShowFullPath(const bool on);
   void setDocFilename(const std::string& fn) { m_docFilename = fn; };
   void setAskOverwrite(const bool on) { m_askOverwrite = on; };
   void onUpdateText();
@@ -41,11 +41,13 @@ public:
 protected:
   bool onProcessMessage(ui::Message* msg) override;
   void onInitTheme(ui::InitThemeEvent& ev) override;
+  void onSetEditFullPath();
 
 private:
+  void setEditFullPath(const bool on);
   void updateWidgets();
   void onBrowse();
-  const std::string updatedFilename() const;
+  std::string updatedFilename() const;
 
   std::string m_path;
   std::string m_pathBase;
@@ -53,8 +55,10 @@ private:
   std::string m_docFilename;
   ui::Entry* m_entry;
   ui::Button m_button;
-  bool m_showFullPath;
+  bool m_editFullPath;
   bool m_askOverwrite;
+
+  obs::scoped_connection m_editFullPathChangeConn;
 };
 
 } // namespace app

--- a/src/app/ui/filename_field.h
+++ b/src/app/ui/filename_field.h
@@ -23,10 +23,16 @@ public:
 
   FilenameField(const Type type, const std::string& pathAndFilename);
 
-  std::string filename() const;
-  void setFilename(const std::string& fn);
+  std::string filepath() const { return m_path; };
+  std::string filename() const { return m_file; };
+  std::string fullFilename() const;
+  std::string displayedFilename() const;
+  void setFilename(const std::string& pathAndFilename);
+  void setFilenameQuiet(const std::string& fn) { m_file = fn; };
+  void setShowFullPath(const bool fullPath);
+  void setDocFilename(const std::string& fn) { m_docFilename = fn; };
 
-  obs::signal<std::string()> SelectFile;
+  obs::signal<std::string()> SelectOutputFile;
   obs::signal<void()> Change;
 
 protected:
@@ -34,10 +40,15 @@ protected:
   void onInitTheme(ui::InitThemeEvent& ev) override;
 
 private:
+  void onBrowse();
   void updateWidgets();
+  const std::string updatedFilename() const;
 
+  bool m_showFullPath;
   std::string m_path;
+  std::string m_pathBase;
   std::string m_file;
+  std::string m_docFilename;
   ui::Entry* m_entry;
   ui::Button m_button;
 };

--- a/src/app/ui/filename_field.h
+++ b/src/app/ui/filename_field.h
@@ -27,10 +27,13 @@ public:
   std::string filename() const { return m_file; };
   std::string fullFilename() const;
   std::string displayedFilename() const;
+  bool askOverwrite() const { return m_askOverwrite; };
   void setFilename(const std::string& pathAndFilename);
   void setFilenameQuiet(const std::string& fn) { m_file = fn; };
-  void setShowFullPath(const bool fullPath);
+  void setShowFullPath(const bool on);
   void setDocFilename(const std::string& fn) { m_docFilename = fn; };
+  void setAskOverwrite(const bool on) { m_askOverwrite = on; };
+  void onUpdateText();
 
   obs::signal<std::string()> SelectOutputFile;
   obs::signal<void()> Change;
@@ -40,17 +43,18 @@ protected:
   void onInitTheme(ui::InitThemeEvent& ev) override;
 
 private:
-  void onBrowse();
   void updateWidgets();
+  void onBrowse();
   const std::string updatedFilename() const;
 
-  bool m_showFullPath;
   std::string m_path;
   std::string m_pathBase;
   std::string m_file;
   std::string m_docFilename;
   ui::Entry* m_entry;
   ui::Button m_button;
+  bool m_showFullPath;
+  bool m_askOverwrite;
 };
 
 } // namespace app

--- a/src/app/widget_loader.cpp
+++ b/src/app/widget_loader.cpp
@@ -22,6 +22,7 @@
 #include "app/ui/color_button.h"
 #include "app/ui/drop_down_button.h"
 #include "app/ui/expr_entry.h"
+#include "app/ui/filename_field.h"
 #include "app/ui/font_entry.h"
 #include "app/ui/icon_button.h"
 #include "app/ui/mini_help_button.h"
@@ -254,6 +255,15 @@ Widget* WidgetLoader::convertXmlElementToWidget(const XMLElement* elem,
 
     if (elem_name == "expr" && decimals)
       ((ExprEntry*)widget)->setDecimals(strtol(decimals, nullptr, 10));
+  }
+  if (elem_name == "filename") {
+    const char* button_only = elem->Attribute("button_only");
+    const app::FilenameField::Type type = ((button_only != nullptr &&
+                                            strtol(button_only, nullptr, 10) == 1) ?
+                                             app::FilenameField::Type::ButtonOnly :
+                                             app::FilenameField::Type::EntryAndButton);
+
+    widget = new app::FilenameField(type, "");
   }
   else if (elem_name == "grid") {
     const char* columns = elem->Attribute("columns");

--- a/src/gen/ui_class.cpp
+++ b/src/gen/ui_class.cpp
@@ -104,6 +104,8 @@ static Item convert_to_item(XMLElement* elem)
     return item.typeIncl("ui::Entry", "ui/entry.h");
   if (name == "expr")
     return item.typeIncl("app::ExprEntry", "app/ui/expr_entry.h");
+  if (name == "filename")
+    return item.typeIncl("app::FilenameField", "app/ui/filename_field.h");
   if (name == "font")
     return item.typeIncl("app::FontEntry", "app/ui/font_entry.h");
   if (name == "grid")


### PR DESCRIPTION
Repurposed the already existing `FilenameField` class for use with `ExportFileWindow` and `ExportSpriteSheetWindow`. Fix #4483.

Changes to`FilenameField`:

- Moved most of the path-related logic in `ExportFileWindow` to `FilenameField`.
- Pressing the button now shows a menu with options for choosing a file, and whether to display it as absolute or relative.
- Added the class itself to the switches on `gen/ui_class.cpp` and `app/widget_loader.cpp` so that it can be used in xml files as `<filename />`. The default type is `ButtonAndEntry`, overridden by the xml attribute `button_only`.
- Added a member variable for use with the 'ask overwrite' popup, set to true by default, and then set to false when the file selector is invoked.

Notes:
- There's a small problem with 'filename' in some places refering to the *name* of the file without path (eg: `base::get_file_name()`), while in other places it refers to the full absolute path (`app::Doc::filename`). It's a very minor thing, but leaving it like this could be confusing.
- The new menu shows when `type == ButtonOnly`. I'm not sure whether to disable this or not.
- `FilenameField` could perhaps handle other bits of logic related to file extension.
- `ExportSpriteSheetWindow` used to invoke the 'ask overwrite' popup for both files regardless of whether one of them had already been confirmed for overwrite. Now it will only ask whether to overwrite a file if the corresponding boolean is set to true.