### PR TITLE
Regression: Edit > Keyboard Shortcuts > Action Modifiers is empty (fix #4893)

### DIFF
--- a/src/app/commands/cmd_keyboard_shortcuts.cpp
+++ b/src/app/commands/cmd_keyboard_shortcuts.cpp
@@ -582,10 +582,11 @@ private:
     fillWheelActionsList();
     fillDragActionsList();
 
+    // Fill the 'Commands' and 'Action Modifier' lists
     for (const KeyPtr& key : m_keys) {
       if (key->type() == KeyType::Tool || key->type() == KeyType::Quicktool ||
           key->type() == KeyType::WheelAction || key->type() == KeyType::DragAction ||
-          key->isListed()) {
+          !key->isListed()) {
         continue;
       }
 

--- a/src/app/ui/keyboard_shortcuts.cpp
+++ b/src/app/ui/keyboard_shortcuts.cpp
@@ -538,7 +538,7 @@ bool Key::isLooselyPressed() const
 
 bool Key::isListed() const
 {
-  return type() != KeyType::Command || !command()->isListed(params());
+  return type() == KeyType::Action || (type() == KeyType::Command && command()->isListed(params()));
 }
 
 bool Key::hasAccel(const ui::Accelerator& accel) const


### PR DESCRIPTION
It fixes the regression inserted in https://github.com/aseprite/aseprite/issues/4387.
Before this fix 'Action' keys were not taken into account in the "Key::isListed()" function.
It was changed the name of 'Key::isListed()' x 'Key::skipListing()' to avoid confussion.
It was also changed the name of 'Command::isListed()'  x  'Command::isOnList()'.

fix #4893 