### PR TITLE
Fix timeline drawing issues

### DIFF
--- a/src/app/ui/timeline/timeline.cpp
+++ b/src/app/ui/timeline/timeline.cpp
@@ -235,7 +235,7 @@ Timeline::Timeline(TooltipManager* tooltipManager)
   , m_tagBands(0)
   , m_tagFocusBand(-1)
   , m_separator_x(Preferences::instance().general.timelineLayerPanelWidth())
-  , m_separator_w(1)
+  , m_separator_w(guiscale())
   , m_confPopup(nullptr)
   , m_clipboard_timer(100, this)
   , m_offset_count(0)
@@ -1600,6 +1600,8 @@ void Timeline::onInitTheme(ui::InitThemeEvent& ev)
 
   if (m_confPopup)
     m_confPopup->initTheme();
+
+  m_separator_w = guiscale();
 }
 
 void Timeline::onInvalidateRegion(const gfx::Region& region)
@@ -2057,6 +2059,9 @@ void Timeline::getDrawableFrames(frame_t* firstFrame, frame_t* lastFrame)
 {
   *firstFrame = frame_t(viewScroll().x / frameBoxWidth());
   *lastFrame = frame_t((viewScroll().x + getCelsBounds().w) / frameBoxWidth());
+  // Last drawable frame cannot be greater than the sprite's last frame.
+  if (m_sprite && m_sprite->lastFrame() < *lastFrame)
+    *lastFrame = m_sprite->lastFrame();
 }
 
 void Timeline::drawPart(ui::Graphics* g,
@@ -2930,7 +2935,7 @@ gfx::Rect Timeline::getPartBounds(const Hit& hit) const
                        headerBoxHeight());
 
     case PART_HEADER_FRAME:
-      return gfx::Rect(bounds.x + separatorX() + m_separator_w - 1 +
+      return gfx::Rect(bounds.x + separatorX() + m_separator_w - guiscale() +
                          frameBoxWidth() * std::max(firstFrame(), hit.frame) - viewScroll().x,
                        bounds.y + y,
                        frameBoxWidth(),
@@ -2989,8 +2994,8 @@ gfx::Rect Timeline::getPartBounds(const Hit& hit) const
 
     case PART_CEL:
       if (validLayer(hit.layer) && hit.frame >= frame_t(0)) {
-        return gfx::Rect(bounds.x + separatorX() + m_separator_w - 1 + frameBoxWidth() * hit.frame -
-                           viewScroll().x,
+        return gfx::Rect(bounds.x + separatorX() + m_separator_w - guiscale() +
+                           frameBoxWidth() * hit.frame - viewScroll().x,
                          bounds.y + y + headerBoxHeight() +
                            layerBoxHeight() * (lastLayer() - hit.layer) - viewScroll().y,
                          frameBoxWidth(),
@@ -3001,7 +3006,7 @@ gfx::Rect Timeline::getPartBounds(const Hit& hit) const
     case PART_RANGE_OUTLINE: {
       gfx::Rect rc = getRangeBounds(m_range);
       int s = outlineWidth();
-      rc.enlarge(gfx::Border(s - 1, s - 1, s, s));
+      rc.enlarge(gfx::Border(s - guiscale(), s - guiscale(), s, s));
       if (rc.x < bounds.x)
         rc.offset(s, 0).inflate(-s, 0);
       if (rc.y < bounds.y)
@@ -3044,15 +3049,15 @@ gfx::Rect Timeline::getPartBounds(const Hit& hit) const
     }
 
     case PART_TAGS:
-      return gfx::Rect(bounds.x + separatorX() + m_separator_w - 1,
+      return gfx::Rect(bounds.x + separatorX() + m_separator_w - guiscale(),
                        bounds.y,
-                       bounds.w - separatorX() - m_separator_w + 1,
+                       bounds.w - separatorX() - m_separator_w + guiscale(),
                        y);
 
     case PART_TAG_BAND:
-      return gfx::Rect(bounds.x + separatorX() + m_separator_w - 1,
+      return gfx::Rect(bounds.x + separatorX() + m_separator_w - guiscale(),
                        bounds.y + (m_tagFocusBand < 0 ? oneTagHeight() * std::max(0, hit.band) : 0),
-                       bounds.w - separatorX() - m_separator_w + 1,
+                       bounds.w - separatorX() - m_separator_w + guiscale(),
                        oneTagHeight());
 
     case PART_TAG_SWITCH_BUTTONS: {


### PR DESCRIPTION
This PR fixes some glitches in the selected range position when the screen scaling is set to 100% and UI scaling to 200% (Fix #3678)
It also optimizes a bit the drawing of the timeline's frames by limiting the last frame to draw to the last frame of the sprite.