### PR TITLE
Add fitCriteria parameter to ChangePixelFormat command

### DIFF
--- a/src/app/commands/cmd_change_pixel_format.cpp
+++ b/src/app/commands/cmd_change_pixel_format.cpp
@@ -667,8 +667,7 @@ render::DitheringMatrix ChangePixelFormatCommand::getDitheringMatrix(
   }
 
   // Default dithering matrix is BayerMatrix(8)
-  // TODO object slicing here (from BayerMatrix -> DitheringMatrix)
-  return render::BayerMatrix(8);
+  return render::BayerMatrix::make(8);
 }
 
 Command* CommandFactory::createChangePixelFormatCommand()

--- a/src/app/commands/cmd_change_pixel_format.cpp
+++ b/src/app/commands/cmd_change_pixel_format.cpp
@@ -601,8 +601,8 @@ void ChangePixelFormatCommand::onExecute(Context* ctx)
                                  render::Dithering(params().dithering(), matrix, params().factor()),
                                  params().rgbmap(),
                                  get_gray_func(params().toGray()),
-                                 &job,
-                                 params().fitCriteria())); // SpriteJob is a render::TaskDelegate
+                                 &job, // SpriteJob is a render::TaskDelegate
+                                 params().fitCriteria()));
     });
     job.waitJob();
   }

--- a/src/app/commands/new_params.cpp
+++ b/src/app/commands/new_params.cpp
@@ -25,7 +25,6 @@
 #include "doc/anidir.h"
 #include "doc/color_mode.h"
 #include "doc/fit_criteria.h"
-#include "doc/pixel_format.h"
 #include "doc/rgbmap_algorithm.h"
 #include "filters/color_curve.h"
 #include "filters/hue_saturation_filter.h"
@@ -274,19 +273,6 @@ void Param<doc::FitCriteria>::fromString(const std::string& value)
 }
 
 template<>
-void Param<doc::PixelFormat>::fromString(const std::string& value)
-{
-  if (base::utf8_icmp(value, "rgb") == 0)
-    setValue(doc::PixelFormat::IMAGE_RGB);
-  else if (base::utf8_icmp(value, "grayscale") == 0 || base::utf8_icmp(value, "gray") == 0)
-    setValue(doc::PixelFormat::IMAGE_GRAYSCALE);
-  else if (base::utf8_icmp(value, "indexed") == 0)
-    setValue(doc::PixelFormat::IMAGE_INDEXED);
-  else
-    setValue(doc::PixelFormat::IMAGE_RGB);
-}
-
-template<>
 void Param<render::DitheringAlgorithm>::fromString(const std::string& value)
 {
   if (base::utf8_icmp(value, "ordered") == 0)
@@ -492,15 +478,6 @@ void Param<doc::FitCriteria>::fromLua(lua_State* L, int index)
     fromString(lua_tostring(L, index));
   else
     setValue((doc::FitCriteria)lua_tointeger(L, index));
-}
-
-template<>
-void Param<doc::PixelFormat>::fromLua(lua_State* L, int index)
-{
-  if (lua_type(L, index) == LUA_TSTRING)
-    fromString(lua_tostring(L, index));
-  else
-    setValue((doc::PixelFormat)lua_tointeger(L, index));
 }
 
 template<>

--- a/src/app/commands/new_params.cpp
+++ b/src/app/commands/new_params.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2022  Igara Studio S.A.
+// Copyright (C) 2019-2025  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -10,8 +10,11 @@
 
 #include "app/commands/new_params.h"
 
+#include "app/app.h"
 #include "app/color.h"
+#include "app/console.h"
 #include "app/doc_exporter.h"
+#include "app/load_matrix.h"
 #include "app/pref/preferences.h"
 #include "app/sprite_sheet_type.h"
 #include "app/tools/ink_type.h"
@@ -21,6 +24,8 @@
 #include "doc/algorithm/resize_image.h"
 #include "doc/anidir.h"
 #include "doc/color_mode.h"
+#include "doc/fit_criteria.h"
+#include "doc/pixel_format.h"
 #include "doc/rgbmap_algorithm.h"
 #include "filters/color_curve.h"
 #include "filters/hue_saturation_filter.h"
@@ -28,6 +33,7 @@
 #include "filters/tiled_mode.h"
 #include "gfx/rect.h"
 #include "gfx/size.h"
+#include "render/dithering_algorithm.h"
 
 #ifdef ENABLE_SCRIPTING
   #include "app/script/engine.h"
@@ -252,6 +258,60 @@ void Param<gen::SelectionMode>::fromString(const std::string& value)
     setValue(gen::SelectionMode::DEFAULT);
 }
 
+template<>
+void Param<doc::FitCriteria>::fromString(const std::string& value)
+{
+  if (base::utf8_icmp(value, "rgb") == 0)
+    setValue(doc::FitCriteria::RGB);
+  else if (base::utf8_icmp(value, "linearizedRGB") == 0)
+    setValue(doc::FitCriteria::linearizedRGB);
+  else if (base::utf8_icmp(value, "ciexyz") == 0)
+    setValue(doc::FitCriteria::CIEXYZ);
+  else if (base::utf8_icmp(value, "cielab") == 0)
+    setValue(doc::FitCriteria::CIELAB);
+  else
+    setValue(doc::FitCriteria::DEFAULT);
+}
+
+template<>
+void Param<doc::PixelFormat>::fromString(const std::string& value)
+{
+  if (base::utf8_icmp(value, "rgb") == 0)
+    setValue(doc::PixelFormat::IMAGE_RGB);
+  else if (base::utf8_icmp(value, "grayscale") == 0 || base::utf8_icmp(value, "gray") == 0)
+    setValue(doc::PixelFormat::IMAGE_GRAYSCALE);
+  else if (base::utf8_icmp(value, "indexed") == 0)
+    setValue(doc::PixelFormat::IMAGE_INDEXED);
+  else
+    setValue(doc::PixelFormat::IMAGE_RGB);
+}
+
+template<>
+void Param<render::DitheringAlgorithm>::fromString(const std::string& value)
+{
+  if (base::utf8_icmp(value, "ordered") == 0)
+    setValue(render::DitheringAlgorithm::Ordered);
+  else if (base::utf8_icmp(value, "old") == 0)
+    setValue(render::DitheringAlgorithm::Old);
+  else if (base::utf8_icmp(value, "error-diffusion") == 0)
+    setValue(render::DitheringAlgorithm::ErrorDiffusion);
+  else
+    setValue(render::DitheringAlgorithm::None);
+}
+
+template<>
+void Param<app::gen::ToGrayAlgorithm>::fromString(const std::string& value)
+{
+  if (base::utf8_icmp(value, "luma") == 0)
+    setValue(gen::ToGrayAlgorithm::LUMA);
+  else if (base::utf8_icmp(value, "hsv") == 0)
+    setValue(gen::ToGrayAlgorithm::HSV);
+  else if (base::utf8_icmp(value, "hsl") == 0)
+    setValue(gen::ToGrayAlgorithm::HSL);
+  else
+    setValue(gen::ToGrayAlgorithm::DEFAULT);
+}
+
 //////////////////////////////////////////////////////////////////////
 // Convert values from Lua
 //////////////////////////////////////////////////////////////////////
@@ -423,6 +483,42 @@ void Param<gen::SelectionMode>::fromLua(lua_State* L, int index)
     fromString(lua_tostring(L, index));
   else
     setValue((gen::SelectionMode)lua_tointeger(L, index));
+}
+
+template<>
+void Param<doc::FitCriteria>::fromLua(lua_State* L, int index)
+{
+  if (lua_type(L, index) == LUA_TSTRING)
+    fromString(lua_tostring(L, index));
+  else
+    setValue((doc::FitCriteria)lua_tointeger(L, index));
+}
+
+template<>
+void Param<doc::PixelFormat>::fromLua(lua_State* L, int index)
+{
+  if (lua_type(L, index) == LUA_TSTRING)
+    fromString(lua_tostring(L, index));
+  else
+    setValue((doc::PixelFormat)lua_tointeger(L, index));
+}
+
+template<>
+void Param<render::DitheringAlgorithm>::fromLua(lua_State* L, int index)
+{
+  if (lua_type(L, index) == LUA_TSTRING)
+    fromString(lua_tostring(L, index));
+  else
+    setValue((render::DitheringAlgorithm)lua_tointeger(L, index));
+}
+
+template<>
+void Param<app::gen::ToGrayAlgorithm>::fromLua(lua_State* L, int index)
+{
+  if (lua_type(L, index) == LUA_TSTRING)
+    fromString(lua_tostring(L, index));
+  else
+    setValue((app::gen::ToGrayAlgorithm)lua_tointeger(L, index));
 }
 
 void CommandWithNewParamsBase::loadParamsFromLuaTable(lua_State* L, int index)

--- a/src/doc/pixel_format.h
+++ b/src/doc/pixel_format.h
@@ -1,5 +1,5 @@
 // Aseprite Document Library
-// Copyright (c) 2019 Igara Studio S.A.
+// Copyright (c) 2019-2025 Igara Studio S.A.
 // Copyright (c) 2001-2014 David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -11,6 +11,8 @@
 
 namespace doc {
 
+// This enum might be replaced/deprecated/removed in the future, please use
+// doc::ColorMode instead.
 enum PixelFormat {
   IMAGE_RGB,       // 32bpp see doc::rgba()
   IMAGE_GRAYSCALE, // 16bpp see doc::graya()

--- a/src/render/dithering_matrix.h
+++ b/src/render/dithering_matrix.h
@@ -47,21 +47,24 @@ private:
 };
 
 // Creates a Bayer dither matrix.
-class BayerMatrix : public DitheringMatrix {
+struct BayerMatrix {
   static int D2[4];
 
 public:
-  BayerMatrix(int n) : DitheringMatrix(n, n)
+  static DitheringMatrix make(int n)
   {
+    DitheringMatrix matrix(n, n);
+
     for (int i = 0; i < n; ++i)
       for (int j = 0; j < n; ++j)
-        operator()(i, j) = Dn(i, j, n);
+        matrix(i, j) = Dn(i, j, n);
 
-    calcMaxValue();
+    matrix.calcMaxValue();
+    return matrix;
   }
 
 private:
-  int Dn(int i, int j, int n) const
+  static int Dn(int i, int j, int n)
   {
     ASSERT(i >= 0 && i < n);
     ASSERT(j >= 0 && j < n);

--- a/src/render/ordered_dither_tests.cpp
+++ b/src/render/ordered_dither_tests.cpp
@@ -19,7 +19,7 @@ using namespace render;
 
 TEST(BayerMatrix, CheckD2)
 {
-  BayerMatrix matrix(2);
+  DitheringMatrix matrix = BayerMatrix::make(2);
   int expected[2 * 2] = { 0, 2, 3, 1 };
   int c = 0;
   for (int i = 0; i < 2; ++i)
@@ -29,7 +29,7 @@ TEST(BayerMatrix, CheckD2)
 
 TEST(BayerMatrix, CheckD4)
 {
-  BayerMatrix matrix(4);
+  DitheringMatrix matrix = BayerMatrix::make(4);
   int expected[4 * 4] = { 0, 8, 2, 10, 12, 4, 14, 6, 3, 11, 1, 9, 15, 7, 13, 5 };
   int c = 0;
   for (int i = 0; i < 4; ++i)
@@ -39,7 +39,7 @@ TEST(BayerMatrix, CheckD4)
 
 TEST(BayerMatrix, CheckD8)
 {
-  BayerMatrix matrix(8);
+  DitheringMatrix matrix = BayerMatrix::make(8);
   int expected[8 * 8] = { 0,  32, 8,  40, 2,  34, 10, 42, 48, 16, 56, 24, 50, 18, 58, 26,
                           12, 44, 4,  36, 14, 46, 6,  38, 60, 28, 52, 20, 62, 30, 54, 22,
 

--- a/tests/scripts/color_quantization.lua
+++ b/tests/scripts/color_quantization.lua
@@ -144,6 +144,26 @@ do
   expect_img(bg, { 0, 1,
                    2, 0 })
 
+  -- Test fitCriteria param
+  s = Sprite(6, 2, ColorMode.RGB)
+  p = Palette(4)
+  p:setColor(0, Color(0, 0, 0))
+  p:setColor(1, Color(255, 0, 0))
+  p:setColor(2, Color(199, 0, 0))
+  p:setColor(3, Color(155, 0, 0))
+  s:setPalette(p)
+
+  local img = s.cels[1].image
+
+  array_to_pixels({
+    rgba(72, 0, 0), rgba(109, 0, 0), rgba(145, 0, 0), rgba(182, 0, 0), rgba(218, 0, 0), rgba(255, 0, 0),
+    rgba(72, 0, 0), rgba(109, 0, 0), rgba(145, 0, 0), rgba(182, 0, 0), rgba(218, 0, 0), rgba(255, 0, 0)}, img)
+
+  app.command.ChangePixelFormat{ format="indexed",  fitCriteria="linearizedRGB" }
+
+  img = s.cels[1].image
+  expect_img(img, { 3, 3, 3, 2, 2, 1,
+                   3, 3, 3, 2, 2, 1 })
 end
 
 ----------------------------------------------------------------------


### PR DESCRIPTION
Fix #4781 

This PR also includes:
- A refactor of ChangePixelFormatCommand to make it inherit from CommandWithNewParams.
- A new "dithering-factor" parameter to being able to specify this for the "error-diffusion" dithering algorithm.
- A commit to avoid the BayerMatrix object slicing, not actually needed.