### PR TITLE
Fix invalid tileset cache after color remap

### DIFF
--- a/src/app/cmd/remap_colors.cpp
+++ b/src/app/cmd/remap_colors.cpp
@@ -15,6 +15,7 @@
 #include "doc/image.h"
 #include "doc/remap.h"
 #include "doc/sprite.h"
+#include "doc/tilesets.h"
 
 namespace app { namespace cmd {
 
@@ -46,6 +47,14 @@ void RemapColors::incrementVersions(Sprite* spr)
 {
   for (const Cel* cel : spr->uniqueCels())
     cel->image()->incrementVersion();
+
+  if (spr->hasTilesets()) {
+    for (Tileset* tileset : *spr->tilesets()) {
+      if (!tileset)
+        continue;
+      tileset->incrementVersion();
+    }
+  }
 }
 
 }} // namespace app::cmd


### PR DESCRIPTION
Changing a color palette and then remapping it does not invalidate a tileset's cache. Immediately saving to the .aseprite format after this will use the stale cache data instead of the current sprite data, resulting in the changes not being saved.

This is because `RemapColors::incrementVersions` only increments an image's version
https://github.com/aseprite/aseprite/blob/9779470d0eb02ec937b2203e4de1e1cb06414fa2/src/app/cmd/remap_colors.cpp#L48
And `ase_file_write_tileset_chunk` only checks a tileset's version
https://github.com/aseprite/aseprite/blob/9779470d0eb02ec937b2203e4de1e1cb06414fa2/src/app/file/ase_format.cpp#L1492

This clip shows a tilemap layer and a normal layer becoming desynced from each other after re-opening a file because the tilemap data was not saved:

https://github.com/user-attachments/assets/e81266cb-220e-4b71-9142-15f9d02d213c

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the Individual Contributor License Agreement V4.0. -->
<!-- If you're a first-time contributor, please sign the CLA
     as indicated in https://github.com/igarastudio/cla#signing
     and acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing
