### PR TITLE
Fix crash applying filters (fix #4928)

### DIFF
--- a/src/app/commands/filters/filter_manager_impl.cpp
+++ b/src/app/commands/filters/filter_manager_impl.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2023  Igara Studio S.A.
+// Copyright (C) 2019-2025  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -251,7 +251,8 @@ void FilterManagerImpl::apply()
 
   ASSERT(m_reader.context());
   m_reader.context()->setCommandResult(result);
-  init(m_site.cel());
+  if (m_site.cel())
+    init(m_site.cel());
 }
 
 void FilterManagerImpl::applyToTarget()

--- a/src/app/commands/filters/filter_manager_impl.h
+++ b/src/app/commands/filters/filter_manager_impl.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2023  Igara Studio S.A.
+// Copyright (C) 2019-2025  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -100,6 +100,7 @@ public:
   doc::Sprite* sprite() { return m_site.sprite(); }
   doc::Layer* layer() { return m_site.layer(); }
   doc::frame_t frame() { return m_site.frame(); }
+  doc::Cel* cel() { return m_site.cel(); }
   doc::Image* destinationImage() const { return m_dst.get(); }
   gfx::Point position() const { return gfx::Point(0, 0); }
 

--- a/src/app/commands/filters/filter_window.cpp
+++ b/src/app/commands/filters/filter_window.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2020-2023  Igara Studio S.A.
+// Copyright (C) 2020-2025  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -166,6 +166,13 @@ void FilterWindow::onApply()
   update_screen_for_document(m_filterMgr->document());
 
   restartPreview();
+
+  // If there is no cel after applying the filter, then close the window because we cannot
+  // continue applying it over an empty cel.
+  if (!m_filterMgr->cel()) {
+    onCancel();
+    return;
+  }
 }
 
 void FilterWindow::onOk()

--- a/src/app/ui/timeline/timeline.cpp
+++ b/src/app/ui/timeline/timeline.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2024  Igara Studio S.A.
+// Copyright (C) 2018-2025  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -1958,7 +1958,7 @@ void Timeline::onAddCel(DocEvent& ev)
 
 void Timeline::onAfterRemoveCel(DocEvent& ev)
 {
-  invalidateLayer(ev.layer());
+  ui::execute_now_or_enqueue([this, ev] { invalidateLayer(ev.layer()); });
 }
 
 void Timeline::onLayerNameChange(DocEvent& ev)

--- a/src/ui/system.cpp
+++ b/src/ui/system.cpp
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2018-2024  Igara Studio S.A.
+// Copyright (C) 2018-2025  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -278,6 +278,14 @@ void execute_from_ui_thread(std::function<void()>&& func)
   ev.setType(os::Event::Callback);
   ev.setCallback(std::move(func));
   os::queue_event(ev);
+}
+
+void execute_now_or_enqueue(std::function<void()>&& func)
+{
+  if (is_ui_thread())
+    func();
+  else
+    execute_from_ui_thread(std::move(func));
 }
 
 bool is_ui_thread()

--- a/src/ui/system.h
+++ b/src/ui/system.h
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2019-2024  Igara Studio S.A.
+// Copyright (C) 2019-2025  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -62,6 +62,9 @@ gfx::Point get_mouse_position();
 void set_mouse_position(const gfx::Point& newPos, Display* display);
 
 void execute_from_ui_thread(std::function<void()>&& func);
+// If it is called from the UI thread just executes the function, if it is
+// called from a different thread, then call execute_from_ui_thread.
+void execute_now_or_enqueue(std::function<void()>&& func);
 bool is_ui_thread();
 #ifdef _DEBUG
 void assert_ui_thread();


### PR DESCRIPTION
Prevents the program from crashing when applying a filter that as a result removes the current cel. Fix #4928 
Also, this PR introduces the `ui::execute_now_or_enqueue` function that is used in `Timeline::onAfterRemoveCel` to avoid this assert:
https://github.com/aseprite/aseprite/blob/5e6927ed4e362c42ce8a3aecb62e6f64a3c8a5a5/src/app/pref/preferences.cpp#L31-L36

That is reached by the following call stack of the filter worker thread (hence it is called from outside the main thread):

```
ui::assert_ui_thread() (src/ui/system.cpp:299)
app::Preferences::instance() (src/app/pref/preferences.cpp:35)
app::Timeline::docPref() const (src/app/ui/timeline/timeline.cpp:4278)
app::Timeline::zoom() const (src/app/ui/timeline/timeline.cpp:4318)
app::Timeline::layerBoxHeight() const (src/app/ui/timeline/timeline.cpp:4298)
app::Timeline::getPartBounds(app::Timeline::Hit const&) const (src/app/ui/timeline/timeline.cpp:3029)
app::Timeline::invalidateLayer(doc::Layer const*) (src/app/ui/timeline/timeline.cpp:3257)
app::Timeline::onAfterRemoveCel(app::DocEvent&) (src/app/ui/timeline/timeline.cpp:1962)
void obs::observers<app::DocObserver>::notify_observers<app::DocEvent&>(void (app::DocObserver::*)(app::DocEvent&), app::DocEvent&) (src/observable/obs/observers.h:37)
void obs::observable<app::DocObserver>::notify_observers<app::DocEvent&>(void (app::DocObserver::*)(app::DocEvent&), app::DocEvent&) (src/observable/obs/observable.h:33)
app::cmd::AddCel::removeCel(doc::Layer*, doc::Cel*) (src/app/cmd/add_cel.cpp:113)
app::cmd::AddCel::onUndo() (src/app/cmd/add_cel.cpp:61)
app::cmd::RemoveCel::onExecute() (src/app/cmd/remove_cel.cpp:26)
app::Cmd::execute(app::Context*) (src/app/cmd.cpp:39)
app::CmdSequence::onExecute() (src/app/cmd_sequence.cpp:58)
app::Cmd::execute(app::Context*) (src/app/cmd.cpp:39)
```

It should also avoid crashed by avoiding the access of the Preferences std::map<> from outside the main thread, as the comment says.
