### PR TITLE
Add UUIDs to layers

### DIFF
--- a/data/strings/en.ini
+++ b/data/strings/en.ini
@@ -1775,8 +1775,8 @@ change_sprite_props = Change Sprite Properties
 tilesets = Tilesets
 delete_tileset = Delete
 duplicate_tileset = Duplicate
-use_uuid_for_layers = Use Universally Unique Identifiers for layers
-use_uuid_for_layers_tooltip = By checking this a UUID will be automatically assigned to each layer
+use_uuid_for_layers = Create UUID for layers
+use_uuid_for_layers_tooltip = By checking this an UUID (Universally Unique Identifiers)\nwill be automatically assigned to each layer\nand saved in .aseprite files
 
 [sprite_size]
 title = Sprite Size

--- a/data/strings/en.ini
+++ b/data/strings/en.ini
@@ -983,6 +983,7 @@ visible_layers = Visible layers
 [layer_properties]
 title = Layer Properties
 name = Name:
+uuid = UUID:
 mode = Mode:
 opacity = Opacity:
 tileset_tooltip = Tileset
@@ -1774,6 +1775,8 @@ change_sprite_props = Change Sprite Properties
 tilesets = Tilesets
 delete_tileset = Delete
 duplicate_tileset = Duplicate
+use_uuid_for_layers = Use Universally Unique Identifiers for layers
+use_uuid_for_layers_tooltip = By checking this a UUID will be automatically assigned to each layer
 
 [sprite_size]
 title = Sprite Size

--- a/data/widgets/layer_properties.xml
+++ b/data/widgets/layer_properties.xml
@@ -15,6 +15,9 @@
 
       <label text="@.opacity" />
       <opacityslider id="opacity" width="128" cell_align="horizontal" cell_hspan="2" />
+
+      <label id="uuid_label" text="@.uuid" visible="false" />
+      <label id="uuid" cell_hspan="2" visible="false"/>
     </grid>
   </vbox>
 </window>

--- a/data/widgets/layer_properties.xml
+++ b/data/widgets/layer_properties.xml
@@ -17,7 +17,7 @@
       <opacityslider id="opacity" width="128" cell_align="horizontal" cell_hspan="2" />
 
       <label id="uuid_label" text="@.uuid" visible="false" />
-      <label id="uuid" cell_hspan="2" visible="false"/>
+      <entry id="uuid" readonly="true" maxsize="36" cell_hspan="2" visible="false"/>
     </grid>
   </vbox>
 </window>

--- a/data/widgets/sprite_properties.xml
+++ b/data/widgets/sprite_properties.xml
@@ -42,6 +42,8 @@
           <button id="convert_color_profile" text="@.convert" />
         </hbox>
       </hbox>
+
+      <check text="@.use_uuid_for_layers" id="use_uuid_for_layers" tooltip="@.use_uuid_for_layers_tooltip" cell_hspan="2" />
     </grid>
 
     <vbox expansive="true" id="tilesets_placeholder">

--- a/docs/ase-file-specs.md
+++ b/docs/ase-file-specs.md
@@ -79,7 +79,7 @@ A 128-byte header (same as FLC/FLI header, but with other magic number):
                   1 = Layer opacity has valid value
                   2 = Layer blend mode/opacity is valid for groups
                       (composite groups separately first when rendering)
-                  4 = Layers are using UUIDs
+                  4 = Layers have an UUID
     WORD        Speed (milliseconds between frame, like in FLC files)
                 DEPRECATED: You should use the frame duration field
                 from each frame header
@@ -203,8 +203,8 @@ entire layers layout:
     STRING      Layer name
     + If layer type = 2
       DWORD     Tileset index
-    UUID        Layer's universally unique identifier (present only if the
-                [main header](#header) "Flags" field has the bit 3 enabled)
+    + If file header flags have bit 4:
+    UUID        Layer's universally unique identifier
 
 ### Cel Chunk (0x2005)
 

--- a/docs/ase-file-specs.md
+++ b/docs/ase-file-specs.md
@@ -79,6 +79,7 @@ A 128-byte header (same as FLC/FLI header, but with other magic number):
                   1 = Layer opacity has valid value
                   2 = Layer blend mode/opacity is valid for groups
                       (composite groups separately first when rendering)
+                  4 = Layers are using UUIDs
     WORD        Speed (milliseconds between frame, like in FLC files)
                 DEPRECATED: You should use the frame duration field
                 from each frame header
@@ -202,6 +203,8 @@ entire layers layout:
     STRING      Layer name
     + If layer type = 2
       DWORD     Tileset index
+    UUID        Layer's universally unique identifier (present only if the
+                [main header](#header) "Flags" field has the bit 3 enabled)
 
 ### Cel Chunk (0x2005)
 

--- a/src/app/commands/cmd_layer_properties.cpp
+++ b/src/app/commands/cmd_layer_properties.cpp
@@ -464,8 +464,7 @@ private:
       m_userDataView.setVisible(false, false);
     }
 
-    bool uuidVisible = m_document && m_document->sprite() &&
-                       m_document->sprite()->useUuidsForLayers();
+    bool uuidVisible = m_document && m_document->sprite() && m_document->sprite()->uuidsForLayers();
     uuidLabel()->setVisible(uuidVisible);
     uuid()->setVisible(uuidVisible);
 

--- a/src/app/commands/cmd_layer_properties.cpp
+++ b/src/app/commands/cmd_layer_properties.cpp
@@ -32,6 +32,7 @@
 #include "app/ui/timeline/timeline.h"
 #include "app/ui/user_data_view.h"
 #include "app/ui_context.h"
+#include "base/convert_to.h"
 #include "base/scoped_value.h"
 #include "doc/image.h"
 #include "doc/layer.h"
@@ -462,6 +463,14 @@ private:
       opacity()->setEnabled(false);
       m_userDataView.setVisible(false, false);
     }
+
+    bool uuidVisible = m_document && m_document->sprite() &&
+                       m_document->sprite()->useUuidsForLayers();
+    uuidLabel()->setVisible(uuidVisible);
+    uuid()->setVisible(uuidVisible);
+
+    if (uuidVisible)
+      uuid()->setText(m_layer ? base::convert_to<std::string>(m_layer->uuid()) : "");
 
     if (tileset()->isVisible() != tilemapVisibility) {
       tileset()->setVisible(tilemapVisibility);

--- a/src/app/commands/cmd_layer_properties.cpp
+++ b/src/app/commands/cmd_layer_properties.cpp
@@ -470,7 +470,7 @@ private:
     uuid()->setVisible(uuidVisible);
 
     if (uuidVisible)
-      uuid()->setText(m_layer ? base::convert_to<std::string>(m_layer->uuid()) : "");
+      uuid()->setText(m_layer ? base::convert_to<std::string>(m_layer->uuid()) : std::string());
 
     if (tileset()->isVisible() != tilemapVisibility) {
       tileset()->setVisible(tilemapVisibility);

--- a/src/app/commands/cmd_sprite_properties.cpp
+++ b/src/app/commands/cmd_sprite_properties.cpp
@@ -142,6 +142,8 @@ public:
   {
     userData()->Click.connect([this] { onToggleUserData(); });
 
+    useUuidForLayers()->setSelected(sprite->useUuidsForLayers());
+
     m_userDataView.configureAndSet(m_sprite->userData(), propertiesGrid());
 
     if (sprite->tilesets()->size() == 0) {
@@ -396,6 +398,8 @@ void SpritePropertiesCommand::onExecute(Context* context)
     PixelRatio pixelRatio = base::convert_to<PixelRatio>(window.pixelRatio()->getValue());
 
     const UserData newUserData = window.getUserData();
+
+    sprite->setUseUuidsForLayers(window.useUuidForLayers()->isSelected());
 
     if (index != sprite->transparentColor() || pixelRatio != sprite->pixelRatio() ||
         newUserData != sprite->userData()) {

--- a/src/app/commands/cmd_sprite_properties.cpp
+++ b/src/app/commands/cmd_sprite_properties.cpp
@@ -142,7 +142,7 @@ public:
   {
     userData()->Click.connect([this] { onToggleUserData(); });
 
-    useUuidForLayers()->setSelected(sprite->useUuidsForLayers());
+    useUuidForLayers()->setSelected(sprite->uuidsForLayers());
 
     m_userDataView.configureAndSet(m_sprite->userData(), propertiesGrid());
 
@@ -399,7 +399,7 @@ void SpritePropertiesCommand::onExecute(Context* context)
 
     const UserData newUserData = window.getUserData();
 
-    sprite->setUseUuidsForLayers(window.useUuidForLayers()->isSelected());
+    sprite->setUuidsForLayers(window.useUuidForLayers()->isSelected());
 
     if (index != sprite->transparentColor() || pixelRatio != sprite->pixelRatio() ||
         newUserData != sprite->userData()) {

--- a/src/app/crash/read_document.cpp
+++ b/src/app/crash/read_document.cpp
@@ -451,9 +451,6 @@ private:
            type == ObjectType::LayerTilemap);
 
     std::string name = read_string(s);
-    base::Uuid uuid;
-    if (m_serial >= SerialFormat::Ver3)
-      uuid = read_uuid(s);
 
     std::unique_ptr<Layer> lay;
 
@@ -503,11 +500,15 @@ private:
     if (!lay)
       return nullptr;
 
-    if (m_serial >= SerialFormat::Ver3)
-      lay->setUuid(uuid);
-
     UserData userData = read_user_data(s, m_serial);
     lay->setUserData(userData);
+
+    base::Uuid uuid;
+    if (m_serial >= SerialFormat::Ver3) {
+      uuid = read_uuid(s);
+      lay->setUuid(uuid);
+    }
+
     return lay.release();
   }
 

--- a/src/app/crash/write_document.cpp
+++ b/src/app/crash/write_document.cpp
@@ -251,7 +251,6 @@ private:
     write32(s, static_cast<int>(lay->flags())); // Flags
     write16(s, static_cast<int>(lay->type()));  // Type
     write_string(s, lay->name());
-    write_uuid(s, lay->uuid());
 
     switch (lay->type()) {
       case ObjectType::LayerImage:
@@ -284,6 +283,8 @@ private:
 
     // Save user data
     write_user_data(s, lay->userData());
+
+    write_uuid(s, lay->uuid());
     return true;
   }
 

--- a/src/app/crash/write_document.cpp
+++ b/src/app/crash/write_document.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2024  Igara Studio S.A.
+// Copyright (C) 2018-2025  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -41,6 +41,7 @@
 #include "doc/tileset_io.h"
 #include "doc/tilesets.h"
 #include "doc/user_data_io.h"
+#include "doc/uuid_io.h"
 #include "fixmath/fixmath.h"
 
 #include <fstream>
@@ -250,6 +251,7 @@ private:
     write32(s, static_cast<int>(lay->flags())); // Flags
     write16(s, static_cast<int>(lay->type()));  // Type
     write_string(s, lay->name());
+    write_uuid(s, lay->uuid());
 
     switch (lay->type()) {
       case ObjectType::LayerImage:

--- a/src/app/file/ase_format.cpp
+++ b/src/app/file/ase_format.cpp
@@ -544,7 +544,7 @@ static void ase_file_prepare_header(FILE* f,
                                                               0);
   header->flags = (ASE_FILE_FLAG_LAYER_WITH_OPACITY |
                    (composeGroups ? ASE_FILE_FLAG_COMPOSITE_GROUPS : 0) |
-                   (sprite->useUuidsForLayers() ? ASE_FILE_FLAG_LAYER_WITH_UUID : 0));
+                   (sprite->uuidsForLayers() ? ASE_FILE_FLAG_LAYER_WITH_UUID : 0));
   header->speed = sprite->frameDuration(firstFrame);
   header->next = 0;
   header->frit = 0;

--- a/src/dio/aseprite_common.h
+++ b/src/dio/aseprite_common.h
@@ -1,5 +1,5 @@
 // Aseprite Document IO Library
-// Copyright (c) 2018-2023 Igara Studio S.A.
+// Copyright (c) 2018-2025 Igara Studio S.A.
 // Copyright (c) 2001-2018 David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -19,6 +19,7 @@
 
 #define ASE_FILE_FLAG_LAYER_WITH_OPACITY 1
 #define ASE_FILE_FLAG_COMPOSITE_GROUPS   2
+#define ASE_FILE_FLAG_LAYER_WITH_UUID    4
 
 #define ASE_FILE_CHUNK_FLI_COLOR2        4
 #define ASE_FILE_CHUNK_FLI_COLOR         11

--- a/src/dio/aseprite_decoder.cpp
+++ b/src/dio/aseprite_decoder.cpp
@@ -75,8 +75,8 @@ bool AsepriteDecoder::decode()
   sprite->setGridBounds(
     gfx::Rect(header.grid_x, header.grid_y, header.grid_width, header.grid_height));
 
-  sprite->setUseUuidsForLayers((header.flags & ASE_FILE_FLAG_LAYER_WITH_UUID) ==
-                               ASE_FILE_FLAG_LAYER_WITH_UUID);
+  sprite->setUuidsForLayers((header.flags & ASE_FILE_FLAG_LAYER_WITH_UUID) ==
+                            ASE_FILE_FLAG_LAYER_WITH_UUID);
 
   // Prepare variables for layer chunks
   doc::Layer* last_layer = sprite->root();
@@ -584,7 +584,7 @@ doc::Layer* AsepriteDecoder::readLayerChunk(AsepriteHeader* header,
     return nullptr;
 
   // Read UUID if usage is enabled
-  if (sprite->useUuidsForLayers())
+  if (sprite->uuidsForLayers())
     layer->setUuid(readUuid());
 
   const bool composeGroups = (header->flags & ASE_FILE_FLAG_COMPOSITE_GROUPS);

--- a/src/dio/aseprite_decoder.h
+++ b/src/dio/aseprite_decoder.h
@@ -9,6 +9,7 @@
 #define DIO_ASEPRITE_DECODER_H_INCLUDED
 #pragma once
 
+#include "base/uuid.h"
 #include "dio/aseprite_common.h"
 #include "dio/decoder.h"
 #include "doc/frame.h"
@@ -77,6 +78,7 @@ private:
                           const AsepriteExternalFiles& extFiles);
   const doc::UserData::Variant readPropertyValue(uint16_t type);
   void readTilesData(doc::Tileset* tileset, const AsepriteExternalFiles& extFiles);
+  base::Uuid readUuid();
 
   doc::LayerList m_allLayers;
   std::vector<uint32_t> m_tilesetFlags;

--- a/src/doc/CMakeLists.txt
+++ b/src/doc/CMakeLists.txt
@@ -82,7 +82,8 @@ add_library(doc-lib
   tilesets.cpp
   user_data.cpp
   user_data_io.cpp
-  util.cpp)
+  util.cpp
+  uuid_io.cpp)
 
 target_link_libraries(doc-lib
   laf-gfx

--- a/src/doc/layer.cpp
+++ b/src/doc/layer.cpp
@@ -36,9 +36,6 @@ Layer::Layer(ObjectType type, Sprite* sprite)
          type == ObjectType::LayerTilemap);
 
   setName("Layer");
-  // Always generate a UUID for this layer, but take into account that it could
-  // be replaced. For instance, when loading a layer that already had a UUID.
-  m_uuid = base::Uuid::Generate();
 }
 
 Layer::~Layer()

--- a/src/doc/layer.cpp
+++ b/src/doc/layer.cpp
@@ -1,5 +1,5 @@
 // Aseprite Document Library
-// Copyright (C) 2019-2021  Igara Studio S.A.
+// Copyright (C) 2019-2025  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -36,6 +36,9 @@ Layer::Layer(ObjectType type, Sprite* sprite)
          type == ObjectType::LayerTilemap);
 
   setName("Layer");
+  // Always generate a UUID for this layer, but take into account that it could
+  // be replaced. For instance, when loading a layer that already had a UUID.
+  m_uuid = base::Uuid::Generate();
 }
 
 Layer::~Layer()

--- a/src/doc/layer.h
+++ b/src/doc/layer.h
@@ -147,9 +147,7 @@ private:
   Sprite* m_sprite;          // owner of the layer
   LayerGroup* m_parent;      // parent layer
   LayerFlags m_flags;        // stack order cannot be changed
-  mutable base::Uuid m_uuid; // The UUID is generated the first time the "HasUUID" flag
-                             // is activated when it is a null UUID. If this field had
-                             // a valid UUID already, it won't be replaced by a new one.
+  mutable base::Uuid m_uuid; // lazily generated layer's UUID
 
   BlendMode m_blendmode;
   int m_opacity;

--- a/src/doc/layer.h
+++ b/src/doc/layer.h
@@ -129,7 +129,12 @@ public:
   int opacity() const { return m_opacity; }
   void setOpacity(int opacity) { m_opacity = opacity; }
 
-  const base::Uuid& uuid() const { return m_uuid; }
+  const base::Uuid& uuid() const
+  {
+    if (m_uuid == base::Uuid())
+      m_uuid = base::Uuid::Generate();
+    return m_uuid;
+  }
   void setUuid(const base::Uuid& uuid) { m_uuid = uuid; }
 
   virtual Grid grid() const;
@@ -138,13 +143,13 @@ public:
   virtual void displaceFrames(frame_t fromThis, frame_t delta) = 0;
 
 private:
-  std::string m_name;   // layer name
-  Sprite* m_sprite;     // owner of the layer
-  LayerGroup* m_parent; // parent layer
-  LayerFlags m_flags;   // stack order cannot be changed
-  base::Uuid m_uuid;    // The UUID is generated the first time the "HasUUID" flag
-                        // is activated when it is a null UUID. If this field had
-                        // a valid UUID already, it won't be replaced by a new one.
+  std::string m_name;        // layer name
+  Sprite* m_sprite;          // owner of the layer
+  LayerGroup* m_parent;      // parent layer
+  LayerFlags m_flags;        // stack order cannot be changed
+  mutable base::Uuid m_uuid; // The UUID is generated the first time the "HasUUID" flag
+                             // is activated when it is a null UUID. If this field had
+                             // a valid UUID already, it won't be replaced by a new one.
 
   BlendMode m_blendmode;
   int m_opacity;

--- a/src/doc/layer.h
+++ b/src/doc/layer.h
@@ -9,6 +9,7 @@
 #define DOC_LAYER_H_INCLUDED
 #pragma once
 
+#include "base/debug.h"
 #include "base/uuid.h"
 #include "doc/blend_mode.h"
 #include "doc/cel_list.h"
@@ -135,7 +136,11 @@ public:
       m_uuid = base::Uuid::Generate();
     return m_uuid;
   }
-  void setUuid(const base::Uuid& uuid) { m_uuid = uuid; }
+  void setUuid(const base::Uuid& uuid)
+  {
+    ASSERT(m_uuid == base::Uuid());
+    m_uuid = uuid;
+  }
 
   virtual Grid grid() const;
   virtual Cel* cel(frame_t frame) const;

--- a/src/doc/layer.h
+++ b/src/doc/layer.h
@@ -1,5 +1,5 @@
 // Aseprite Document Library
-// Copyright (C) 2019-2024  Igara Studio S.A.
+// Copyright (C) 2019-2025  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -9,6 +9,7 @@
 #define DOC_LAYER_H_INCLUDED
 #pragma once
 
+#include "base/uuid.h"
 #include "doc/blend_mode.h"
 #include "doc/cel_list.h"
 #include "doc/frame.h"
@@ -128,6 +129,9 @@ public:
   int opacity() const { return m_opacity; }
   void setOpacity(int opacity) { m_opacity = opacity; }
 
+  const base::Uuid& uuid() const { return m_uuid; }
+  void setUuid(const base::Uuid& uuid) { m_uuid = uuid; }
+
   virtual Grid grid() const;
   virtual Cel* cel(frame_t frame) const;
   virtual void getCels(CelList& cels) const = 0;
@@ -138,6 +142,9 @@ private:
   Sprite* m_sprite;     // owner of the layer
   LayerGroup* m_parent; // parent layer
   LayerFlags m_flags;   // stack order cannot be changed
+  base::Uuid m_uuid;    // The UUID is generated the first time the "HasUUID" flag
+                        // is activated when it is a null UUID. If this field had
+                        // a valid UUID already, it won't be replaced by a new one.
 
   BlendMode m_blendmode;
   int m_opacity;

--- a/src/doc/layer_io.cpp
+++ b/src/doc/layer_io.cpp
@@ -41,8 +41,6 @@ void write_layer(std::ostream& os, const Layer* layer)
 {
   write32(os, layer->id());
   write_string(os, layer->name());
-  write_uuid(os, layer->uuid());
-
   write32(os, static_cast<int>(layer->flags())); // Flags
   write16(os, static_cast<int>(layer->type()));  // Type
 
@@ -108,16 +106,13 @@ void write_layer(std::ostream& os, const Layer* layer)
   }
 
   write_user_data(os, layer->userData());
+  write_uuid(os, layer->uuid());
 }
 
 Layer* read_layer(std::istream& is, SubObjectsFromSprite* subObjects, const SerialFormat serial)
 {
   ObjectId id = read32(is);
   std::string name = read_string(is);
-  base::Uuid uuid;
-  if (serial >= SerialFormat::Ver3)
-    uuid = read_uuid(is);
-
   uint32_t flags = read32(is);      // Flags
   uint16_t layer_type = read16(is); // Type
   std::unique_ptr<Layer> layer;
@@ -193,16 +188,19 @@ Layer* read_layer(std::istream& is, SubObjectsFromSprite* subObjects, const Seri
 
   const UserData userData = read_user_data(is, serial);
 
+  base::Uuid uuid;
+  if (serial >= SerialFormat::Ver3)
+    uuid = read_uuid(is);
+
   if (!layer)
     return nullptr;
-
-  if (serial >= SerialFormat::Ver3)
-    layer->setUuid(uuid);
 
   layer->setName(name);
   layer->setFlags(static_cast<LayerFlags>(flags));
   layer->setId(id);
   layer->setUserData(userData);
+  if (serial >= SerialFormat::Ver3)
+    layer->setUuid(uuid);
 
   return layer.release();
 }

--- a/src/doc/layer_io.cpp
+++ b/src/doc/layer_io.cpp
@@ -5,7 +5,6 @@
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
 
-#include "doc/uuid_io.h"
 #ifdef HAVE_CONFIG_H
   #include "config.h"
 #endif
@@ -25,6 +24,7 @@
 #include "doc/string_io.h"
 #include "doc/subobjects_io.h"
 #include "doc/user_data_io.h"
+#include "doc/uuid_io.h"
 
 #include <iostream>
 #include <memory>

--- a/src/doc/serial_format.h
+++ b/src/doc/serial_format.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (c) 2020-2024  Igara Studio S.A.
+// Copyright (c) 2020-2025  Igara Studio S.A.
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -19,7 +19,8 @@ enum class SerialFormat : uint16_t {
   Ver0 = 0, // Old version
   Ver1 = 1, // New version with tilesets
   Ver2 = 2, // Version 2 adds custom properties to user data
-  LastVer = Ver2
+  Ver3 = 3, // Version 3 adds UUIDs to layers
+  LastVer = Ver3
 };
 
 } // namespace doc

--- a/src/doc/sprite.h
+++ b/src/doc/sprite.h
@@ -1,5 +1,5 @@
 // Aseprite Document Library
-// Copyright (C) 2018-2024  Igara Studio S.A.
+// Copyright (C) 2018-2025  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -244,6 +244,9 @@ public:
 
   void setTileManagementPlugin(const std::string& plugin) { m_tileManagementPlugin = plugin; }
 
+  void setUseUuidsForLayers(bool value) { m_useUuidsForLayers = value; }
+  bool useUuidsForLayers() const { return m_useUuidsForLayers; }
+
 private:
   Document* m_document;
   ImageSpec m_spec;
@@ -271,6 +274,9 @@ private:
   // (e.g. drag & drop tiles, or TilesetMode::Auto mode, etc.),
   // giving the possibility to handle tiles exclusively to a plugin.
   std::string m_tileManagementPlugin;
+
+  // This setting indicates if the layers of this sprite are using UUIDs.
+  bool m_useUuidsForLayers = false;
 
   // Disable default constructor and copying
   Sprite();

--- a/src/doc/sprite.h
+++ b/src/doc/sprite.h
@@ -244,8 +244,8 @@ public:
 
   void setTileManagementPlugin(const std::string& plugin) { m_tileManagementPlugin = plugin; }
 
-  void setUseUuidsForLayers(bool value) { m_useUuidsForLayers = value; }
-  bool useUuidsForLayers() const { return m_useUuidsForLayers; }
+  void setUuidsForLayers(bool value) { m_uuidsForLayers = value; }
+  bool uuidsForLayers() const { return m_uuidsForLayers; }
 
 private:
   Document* m_document;
@@ -276,7 +276,7 @@ private:
   std::string m_tileManagementPlugin;
 
   // This setting indicates if the layers of this sprite are using UUIDs.
-  bool m_useUuidsForLayers = false;
+  bool m_uuidsForLayers = false;
 
   // Disable default constructor and copying
   Sprite();

--- a/src/doc/user_data_io.cpp
+++ b/src/doc/user_data_io.cpp
@@ -1,5 +1,5 @@
 // Aseprite Document Library
-// Copyright (c) 2023 Igara Studio S.A.
+// Copyright (c) 2023-2025 Igara Studio S.A.
 // Copyright (c) 2001-2015 David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -14,6 +14,7 @@
 #include "base/serialization.h"
 #include "doc/string_io.h"
 #include "doc/user_data.h"
+#include "doc/uuid_io.h"
 
 #include <iostream>
 
@@ -86,9 +87,7 @@ static void write_property_value(std::ostream& os, const UserData::Variant& vari
     }
     case USER_DATA_PROPERTY_TYPE_UUID: {
       auto uuid = get_value<base::Uuid>(variant);
-      for (int i = 0; i < 16; ++i) {
-        write8(os, uuid[i]);
-      }
+      write_uuid(os, uuid);
       break;
     }
   }
@@ -207,12 +206,7 @@ static UserData::Variant read_property_value(std::istream& is, uint16_t type)
       return value;
     }
     case USER_DATA_PROPERTY_TYPE_UUID: {
-      base::Uuid value;
-      uint8_t* bytes = value.bytes();
-      for (int i = 0; i < 16; ++i) {
-        bytes[i] = read8(is);
-      }
-      return value;
+      return read_uuid(is);
     }
   }
 

--- a/src/doc/uuid_io.cpp
+++ b/src/doc/uuid_io.cpp
@@ -1,0 +1,33 @@
+// Aseprite Document Library
+// Copyright (c) 2025 Igara Studio S.A.
+//
+// This file is released under the terms of the MIT license.
+// Read LICENSE.txt for more information.
+
+#include "doc/uuid_io.h"
+
+#include "base/serialization.h"
+#include "base/uuid.h"
+
+namespace doc {
+
+using namespace base::serialization;
+
+base::Uuid read_uuid(std::istream& is)
+{
+  base::Uuid value;
+  uint8_t* bytes = value.bytes();
+  for (int i = 0; i < 16; ++i) {
+    bytes[i] = read8(is);
+  }
+  return value;
+}
+
+void write_uuid(std::ostream& os, const base::Uuid& uuid)
+{
+  for (int i = 0; i < 16; ++i) {
+    write8(os, uuid[i]);
+  }
+}
+
+} // namespace doc

--- a/src/doc/uuid_io.h
+++ b/src/doc/uuid_io.h
@@ -1,0 +1,23 @@
+// Aseprite Document Library
+// Copyright (c) 2025 Igara Studio S.A.
+//
+// This file is released under the terms of the MIT license.
+// Read LICENSE.txt for more information.
+
+#ifndef DOC_UUID_IO_H_INCLUDED
+#define DOC_UUID_IO_H_INCLUDED
+#pragma once
+
+#include "base/uuid.h"
+
+#include <iostream>
+
+namespace doc {
+
+base::Uuid read_uuid(std::istream& is);
+
+void write_uuid(std::ostream& os, const base::Uuid& uuid);
+
+} // namespace doc
+
+#endif

--- a/src/doc/uuid_io.h
+++ b/src/doc/uuid_io.h
@@ -10,7 +10,7 @@
 
 #include "base/uuid.h"
 
-#include <iostream>
+#include <iosfwd>
 
 namespace doc {
 


### PR DESCRIPTION
Fix #3683

This PR adds a new checkbox to the "Sprite properties" window to enable/disable to usage of UUIDs in layers. Also adds a field in the "Layer properties" window that shows the current UUID, only if the aforementioned checkbox is checked.