### PR TITLE
Use the environment bash to avoid errors on macOS

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 #
 # This is a script to help users and developers to build Aseprite.
 # Usage:


### PR DESCRIPTION
Using `/bin/bash` for the `build.sh` shebang means that it'll use the default bash shell on macOS which, annoyingly, is still Bash 3 which doesn't have support for a few of the `read` arguments the script is using.

This change makes it so that it grabs the bash shell from the environment, so a user can install their own updated bash version through Homebrew, etc.
