### PR TITLE
Fix crash with custom pixel ratios (e.g. Size(4, 3)) (fix #4632)

### DIFF
--- a/src/app/script/sprite_class.cpp
+++ b/src/app/script/sprite_class.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2023  Igara Studio S.A.
+// Copyright (C) 2018-2025  Igara Studio S.A.
 // Copyright (C) 2015-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -54,6 +54,7 @@
 #include "app/ui/doc_view.h"
 #include "base/convert_to.h"
 #include "base/fs.h"
+#include "base/gcd.h"
 #include "doc/layer.h"
 #include "doc/layer_tilemap.h"
 #include "doc/mask.h"
@@ -973,7 +974,10 @@ int Sprite_get_pixelRatio(lua_State* L)
 int Sprite_set_pixelRatio(lua_State* L)
 {
   auto sprite = get_docobj<Sprite>(L, 1);
-  const gfx::Size pixelRatio = convert_args_into_size(L, 2);
+  gfx::Size pixelRatio = convert_args_into_size(L, 2);
+  double gcd = base::gcd(double(pixelRatio.w), double(pixelRatio.h));
+  pixelRatio.w = int(double(pixelRatio.w) / gcd);
+  pixelRatio.h = int(double(pixelRatio.h) / gcd);
   Tx tx(sprite);
   tx(new cmd::SetPixelRatio(sprite, pixelRatio));
   tx.commit();

--- a/src/render/projection.h
+++ b/src/render/projection.h
@@ -1,5 +1,5 @@
 // Aseprite Render Library
-// Copyright (c) 2020 Igara Studio S.A.
+// Copyright (c) 2020-2025 Igara Studio S.A.
 // Copyright (c) 2016 David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -30,6 +30,20 @@ public:
 
   void setPixelRatio(const doc::PixelRatio& pixelRatio) { m_pixelRatio = pixelRatio; }
   void setZoom(const Zoom& zoom) { m_zoom = zoom; }
+
+  // To identify simplest composite scale up cases'
+  bool isSimpleScaleUpCase() const
+  {
+    return scaleX() >= 1.0 && scaleY() >= 1.0 && (m_pixelRatio.w == 1 || m_pixelRatio.w % 2 == 0) &&
+           (m_pixelRatio.h == 1 || m_pixelRatio.h % 2 == 0);
+  }
+
+  // To identify simplest composite scale down cases
+  bool isSimpleScaleDownCase() const
+  {
+    return scaleX() <= 1.0 && scaleY() <= 1.0 && std::fmod(1.0 / scaleX(), 1.0) == 0.0 &&
+           std::fmod(1.0 / scaleY(), 1.0) == 0.0;
+  }
 
   double scaleX() const { return m_zoom.scale() * m_pixelRatio.w; }
   double scaleY() const { return m_zoom.scale() * m_pixelRatio.h; }


### PR DESCRIPTION
It would be nice to update the ComboBox corresponding to the pixel ratio in the `Sprite > Properties` dialog after:
```lua
app.sprite.pixelRatio = Size(4, 3) -- for example
```

fix #4632 