### PR TITLE
Fix crash applying a filter repeated times quickly

### DIFF
--- a/src/app/commands/filters/filter_preview.cpp
+++ b/src/app/commands/filters/filter_preview.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2023  Igara Studio S.A.
+// Copyright (C) 2019-2025  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -74,6 +74,7 @@ void FilterPreview::stop()
       m_filterMgr->end();
     }
     m_timer.stop();
+    m_restartPreviewTimer.stop();
   }
 
   // Wait the filter task to end.

--- a/src/ui/button.cpp
+++ b/src/ui/button.cpp
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2019-2023  Igara Studio S.A.
+// Copyright (C) 2019-2025  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -9,6 +9,7 @@
   #include "config.h"
 #endif
 
+#include "base/scoped_value.h"
 #include "ui/button.h"
 #include "ui/manager.h"
 #include "ui/message.h"
@@ -27,8 +28,8 @@ ButtonBase::ButtonBase(const std::string& text,
                        const WidgetType behaviorType,
                        const WidgetType drawType)
   : Widget(type)
-  , m_pressedStatus(false)
   , m_behaviorType(behaviorType)
+  , m_pressedStatus(false)
   , m_handleSelect(true)
 {
   setAlign(CENTER | MIDDLE);
@@ -52,6 +53,10 @@ WidgetType ButtonBase::behaviorType() const
 
 void ButtonBase::onClick()
 {
+  if (m_clicking)
+    return;
+
+  base::ScopedValue sv(m_clicking, true);
   // Fire Click() signal
   Click();
 }

--- a/src/ui/button.h
+++ b/src/ui/button.h
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2021-2023  Igara Studio S.A.
+// Copyright (C) 2021-2025  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -49,8 +49,16 @@ protected:
 private:
   void generateButtonSelectSignal();
 
-  bool m_pressedStatus;
   WidgetType m_behaviorType;
+  bool m_pressedStatus;
+  // Flag used to prevent nested calls of the onClik handler.
+  // This situation can happen, for example, when a button in a window
+  // opens a modal window. If the user presses the button as fast as possible
+  // it may happen that the button's onClick handler is called in the window's
+  // event loop, then the handler opens the modal and, finally a second onClick handler
+  // is called due to queued system events that now are processed by the modal's event
+  // loop that was started by the previously in course onClick handler.
+  bool m_clicking = false;
 
 protected:
   bool m_handleSelect;


### PR DESCRIPTION
This PR fixes two problems:
- First it fixes #4963 by introducing a new flag to the UI's ButtonBase click to prevent calling an onClick() handler inside of a previously called onClick() handler. There is a comment describing a situation where this can happen, which is the one happening in the resolved issue.

- Second, once fixed the above, there was a chance that the FilterPreview::onDelayedStartPreview() be called after a FilterPreview::stop() call, because the m_restarPreviewTimer was not being stopped when the preview was being stopped.

