### PR TITLE
Avoid capturing the mouse from widgets in background windows

### DIFF
--- a/src/app/ui/font_entry.cpp
+++ b/src/app/ui/font_entry.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (c) 2024  Igara Studio S.A.
+// Copyright (c) 2024-2025  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -51,18 +51,12 @@ bool FontEntry::FontFace::onProcessMessage(Message* msg)
         MouseMessage* mouseMsg = static_cast<MouseMessage*>(msg);
         const gfx::Point screenPos = mouseMsg->display()->nativeWindow()->pointToScreen(
           mouseMsg->position());
-        Widget* pick = manager()->pickFromScreenPos(screenPos);
+        Manager* mgr = manager();
+        Widget* pick = mgr->pickFromScreenPos(screenPos);
         Widget* target = m_popup->getListBox();
 
         if (pick && (pick == target || pick->hasAncestor(target))) {
-          releaseMouse();
-
-          MouseMessage mouseMsg2(kMouseDownMessage,
-                                 *mouseMsg,
-                                 mouseMsg->positionForDisplay(pick->display()));
-          mouseMsg2.setRecipient(pick);
-          mouseMsg2.setDisplay(pick->display());
-          pick->sendMessage(&mouseMsg2);
+          mgr->transferAsMouseDownMessage(this, pick, mouseMsg);
           return true;
         }
       }

--- a/src/app/ui/toolbar.cpp
+++ b/src/app/ui/toolbar.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2024  Igara Studio S.A.
+// Copyright (C) 2018-2025  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -266,17 +266,10 @@ bool ToolBar::onProcessMessage(Message* msg)
       // mouse over the ToolBar.
       if (hasCapture()) {
         MouseMessage* mouseMsg = static_cast<MouseMessage*>(msg);
-        Widget* pick = manager()->pickFromScreenPos(mouseMsg->screenPosition());
+        Manager* mgr = manager();
+        Widget* pick = mgr->pickFromScreenPos(mouseMsg->screenPosition());
         if (ToolStrip* strip = dynamic_cast<ToolStrip*>(pick)) {
-          releaseMouse();
-
-          MouseMessage* mouseMsg2 = new MouseMessage(
-            kMouseDownMessage,
-            *mouseMsg,
-            mouseMsg->positionForDisplay(strip->display()));
-          mouseMsg2->setRecipient(strip);
-          mouseMsg2->setDisplay(strip->display());
-          manager()->enqueueMessage(mouseMsg2);
+          mgr->transferAsMouseDownMessage(this, strip, mouseMsg);
         }
       }
       break;
@@ -755,16 +748,10 @@ bool ToolBar::ToolStrip::onProcessMessage(Message* msg)
         if (m_hotTool)
           m_toolbar->selectTool(m_hotTool);
 
-        Widget* pick = manager()->pickFromScreenPos(mouseMsg->screenPosition());
+        Manager* mgr = manager();
+        Widget* pick = mgr->pickFromScreenPos(mouseMsg->screenPosition());
         if (ToolBar* bar = dynamic_cast<ToolBar*>(pick)) {
-          releaseMouse();
-
-          MouseMessage* mouseMsg2 = new MouseMessage(kMouseDownMessage,
-                                                     *mouseMsg,
-                                                     mouseMsg->positionForDisplay(pick->display()));
-          mouseMsg2->setRecipient(bar);
-          mouseMsg2->setDisplay(pick->display());
-          manager()->enqueueMessage(mouseMsg2);
+          mgr->transferAsMouseDownMessage(this, bar, mouseMsg);
         }
       }
       break;

--- a/src/ui/combobox.cpp
+++ b/src/ui/combobox.cpp
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2018-2023  Igara Studio S.A.
+// Copyright (C) 2018-2025  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -503,18 +503,17 @@ bool ComboBoxEntry::onProcessMessage(Message* msg)
         MouseMessage* mouseMsg = static_cast<MouseMessage*>(msg);
         gfx::Point screenPos = mouseMsg->display()->nativeWindow()->pointToScreen(
           mouseMsg->position());
-        Widget* pick = manager()->pickFromScreenPos(screenPos);
+        Manager* mgr = manager();
+        Widget* pick = mgr->pickFromScreenPos(screenPos);
         Widget* listbox = m_comboBox->m_listbox;
 
         if (pick != nullptr && (pick == listbox || pick->hasAncestor(listbox))) {
-          releaseMouse();
-
-          MouseMessage mouseMsg2(kMouseDownMessage,
-                                 *mouseMsg,
-                                 mouseMsg->positionForDisplay(pick->display()));
-          mouseMsg2.setRecipient(pick);
-          mouseMsg2.setDisplay(pick->display());
-          pick->sendMessage(&mouseMsg2);
+          mgr->transferAsMouseDownMessage(this,
+                                          pick,
+                                          mouseMsg,
+                                          // Send the message right now, if we enqueue
+                                          // the message the popup window is closed.
+                                          true);
           return true;
         }
       }

--- a/src/ui/int_entry.cpp
+++ b/src/ui/int_entry.cpp
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2019-2022  Igara Studio S.A.
+// Copyright (C) 2019-2025  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -89,17 +89,11 @@ bool IntEntry::onProcessMessage(Message* msg)
     case kMouseMoveMessage:
       if (hasCapture()) {
         MouseMessage* mouseMsg = static_cast<MouseMessage*>(msg);
-        Widget* pick = manager()->pickFromScreenPos(
+        Manager* mgr = manager();
+        Widget* pick = mgr->pickFromScreenPos(
           display()->nativeWindow()->pointToScreen(mouseMsg->position()));
         if (pick == m_slider.get()) {
-          releaseMouse();
-
-          MouseMessage mouseMsg2(kMouseDownMessage,
-                                 *mouseMsg,
-                                 mouseMsg->positionForDisplay(pick->display()));
-          mouseMsg2.setRecipient(pick);
-          mouseMsg2.setDisplay(pick->display());
-          pick->sendMessage(&mouseMsg2);
+          mgr->transferAsMouseDownMessage(this, pick, mouseMsg);
         }
       }
       break;

--- a/src/ui/manager.h
+++ b/src/ui/manager.h
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2018-2024  Igara Studio S.A.
+// Copyright (C) 2018-2025  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -72,9 +72,9 @@ public:
   void addToGarbage(Widget* widget);
   void collectGarbage();
 
-  Window* getTopWindow();
-  Window* getDesktopWindow();
-  Window* getForegroundWindow();
+  Window* getTopWindow() const;
+  Window* getDesktopWindow() const;
+  Window* getForegroundWindow() const;
   Display* getForegroundDisplay();
 
   Widget* getFocus();
@@ -83,7 +83,7 @@ public:
 
   void setFocus(Widget* widget);
   void setMouse(Widget* widget);
-  void setCapture(Widget* widget);
+  void setCapture(Widget* widget, bool force = false);
   void attractFocus(Widget* widget);
   void focusFirstChild(Widget* widget);
   void freeFocus();
@@ -106,6 +106,30 @@ public:
   bool processFocusMovementMessage(Message* msg);
 
   Widget* pickFromScreenPos(const gfx::Point& screenPos) const override;
+
+  // Transfers the given MouseMessage received "from" (generally a
+  // kMouseMoveMessage) to the given "to" widget, sending a copy of
+  // the message but changing its type to kMouseDownMessage. By
+  // default it enqueues the message.
+  //
+  // If "from" has the mouse capture, it will be released as it is
+  // highly probable that the "to" widget will recapture the mouse
+  // again.
+  //
+  // This is used in cases were the user presses the mouse button on
+  // one widget, and then drags the mouse to another widget. With this
+  // we can transfer the mouse capture between widgets (from -> to)
+  // simulating a kMouseDownMessage for the new widget "to".
+  void transferAsMouseDownMessage(Widget* from,
+                                  Widget* to,
+                                  const MouseMessage* mouseMsg,
+                                  bool sendNow = false);
+
+  // Returns true if the widget is accessible with the mouse, i.e. the
+  // widget is in the current foreground window (or a top window above
+  // the foreground, e.g. a combobox popup), or there is no foreground
+  // window and the widget is in the desktop window.
+  bool isWidgetClickable(const Widget* widget) const;
 
   void _openWindow(Window* window, bool center);
   void _closeWindow(Window* window, bool redraw_background);
@@ -164,6 +188,7 @@ private:
                           const double magnification);
   bool handleWindowZOrder();
   void updateMouseWidgets(const gfx::Point& mousePos, Display* display);
+  void allowCapture(Widget* widget);
 
   int pumpQueue();
   bool sendMessageToWidget(Message* msg, Widget* widget);

--- a/src/ui/view.cpp
+++ b/src/ui/view.cpp
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2018-2024  Igara Studio S.A.
+// Copyright (C) 2018-2025  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -186,7 +186,7 @@ void View::updateView(const bool restoreScrollPos)
   // Restore the mouse capture if it changed, which means that a
   // scroll bar (when it was temporarily removed) lost the capture.
   if (man && man->getCapture() != mouseCapture && mouseCapture->isVisible())
-    man->setCapture(mouseCapture);
+    man->setCapture(mouseCapture, true); // Force the capture
 }
 
 Viewport* View::viewport()

--- a/src/ui/widget.cpp
+++ b/src/ui/widget.cpp
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2018-2024  Igara Studio S.A.
+// Copyright (C) 2018-2025  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -1507,22 +1507,15 @@ void Widget::releaseMouse()
   }
 }
 
-bool Widget::offerCapture(ui::MouseMessage* mouseMsg, int widget_type)
+bool Widget::offerCapture(ui::MouseMessage* mouseMsg, const WidgetType widgetType)
 {
   if (hasCapture()) {
     const gfx::Point screenPos = mouseMsg->display()->nativeWindow()->pointToScreen(
       mouseMsg->position());
-    auto man = manager();
-    Widget* pick = (man ? man->pickFromScreenPos(screenPos) : nullptr);
-    if (pick && pick != this && pick->type() == widget_type) {
-      releaseMouse();
-
-      MouseMessage* mouseMsg2 = new MouseMessage(kMouseDownMessage,
-                                                 *mouseMsg,
-                                                 mouseMsg->positionForDisplay(pick->display()));
-      mouseMsg2->setDisplay(pick->display());
-      mouseMsg2->setRecipient(pick);
-      man->enqueueMessage(mouseMsg2);
+    Manager* mgr = manager();
+    Widget* pick = (mgr ? mgr->pickFromScreenPos(screenPos) : nullptr);
+    if (pick && pick != this && pick->type() == widgetType) {
+      mgr->transferAsMouseDownMessage(this, pick, mouseMsg);
       return true;
     }
   }

--- a/src/ui/widget.h
+++ b/src/ui/widget.h
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2018-2024  Igara Studio S.A.
+// Copyright (C) 2018-2025  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -336,6 +336,11 @@ public:
 
   void requestFocus();
   void releaseFocus();
+
+  // Captures the mouse to continue receiving its messages until we
+  // release the capture. Useful for widgets with painting-like
+  // capabilities, where we want to keep track of the mouse until the
+  // user releases the mouse button, or drag-and-drop behaviors.
   void captureMouse();
   void releaseMouse();
 
@@ -371,9 +376,9 @@ public:
   // the widget bounds.
   gfx::Point mousePosInClientBounds() const { return toClient(mousePosInDisplay()); }
 
-  // Offer the capture to widgets of the given type. Returns true if
+  // Offers the capture to widgets of the given type. Returns true if
   // the capture was passed to other widget.
-  bool offerCapture(MouseMessage* mouseMsg, int widget_type);
+  bool offerCapture(MouseMessage* mouseMsg, WidgetType widgetType);
 
   // Returns lower-case letter that represet the mnemonic of the widget
   // (the underscored character, i.e. the letter after & symbol).


### PR DESCRIPTION
This avoids clicking buttons that are not in the foreground/modal window. Related to #4963 and #4973
