### PR TITLE
Fix crash canceling "Apply" filter and then using "OK"

### DIFF
--- a/data/strings/en.ini
+++ b/data/strings/en.ini
@@ -1,5 +1,5 @@
 # Aseprite
-# Copyright (C) 2018-2024  Igara Studio S.A.
+# Copyright (C) 2018-2025  Igara Studio S.A.
 # Copyright (C) 2016-2018  David Capello
 #
 # This work is licensed under the Creative Commons Attribution 4.0
@@ -43,7 +43,6 @@ locked_layers = There are locked layers
 no_active_layers = There is no active layer
 layer_x_is_hidden = Layer "{}" is hidden
 unmodifiable_reference_layer = Layer "{}" is reference, cannot be modified
-filter_no_unlocked_layer = No unlocked layers to apply filter
 cannot_move_bg_layer = The background layer cannot be moved
 nothing_to_move = Nothing to move
 recovery_task_using_sprite = Sprite is used by a backup/data recovery task

--- a/src/app/commands/filters/filter_manager_impl.cpp
+++ b/src/app/commands/filters/filter_manager_impl.cpp
@@ -247,6 +247,9 @@ void FilterManagerImpl::apply()
   }
   else {
     result = CommandResult(CommandResult::kCanceled);
+
+    // Rollback transaction
+    m_tx.reset();
   }
 
   ASSERT(m_reader.context());

--- a/src/app/commands/filters/filter_worker.cpp
+++ b/src/app/commands/filters/filter_worker.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2022  Igara Studio S.A.
+// Copyright (C) 2019-2025  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -148,9 +148,6 @@ void FilterWorker::run()
   if (!m_error.empty()) {
     Console console;
     console.printf("A problem has occurred.\n\nDetails:\n%s", m_error.c_str());
-  }
-  else if (m_cancelled && !m_filterMgr->isTransaction()) {
-    StatusBar::instance()->showTip(2500, Strings::statusbar_tips_filter_no_unlocked_layer());
   }
 }
 


### PR DESCRIPTION
This fixes the `ASSERT(!m_tx)` in `FilterManagerImpl::initTransaction()` in Debug mode, and a crash in Release that happens in any filter if we cancel a filter progress in the middle, and then press the "OK" button.

The removed string was removed because it looks like it's not displayed anymore (without this patch, with this patch it's displayed but doesn't make sense). Probably it's not displayed now because something changed in the middle from its introduction from ab51f02711eb30dc6fd5e8eb5ed4902e111c3d90 to fix #1610 and the current `main`/`beta` branch.