### PR TITLE
Use local deps directory in build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@
 tests/_test*
 build
 .build
+.deps
 CMakeSettings.json

--- a/build.sh
+++ b/build.sh
@@ -74,7 +74,7 @@ elif [[ "$(uname)" == "Linux" ]] ; then
     cpu=x64
 elif [[ "$(uname)" =~ "Darwin" ]] ; then
     is_macos=1
-    if [[ $(uname -m) == "arm64" ]]; then
+    if [[ $(uname -m) == "arm64" ]] ; then
         cpu=arm64
     else
         cpu=x64

--- a/build.sh
+++ b/build.sh
@@ -378,7 +378,13 @@ fi
 
 # Check Skia dependency.
 if [ ! -f "$pwd/.build/$file_skia_dir" ] ; then
-    skia_dir="$pwd/.deps/$possible_skia_dir_name"
+    # Try "C:/deps/skia" or "$HOME/deps/skia"
+    if [[ $is_win ]] ; then
+        skia_dir="C:/deps/$possible_skia_dir_name"
+        if [ ! -d "$skia_dir" ] ;
+    else
+        skia_dir="$HOME/deps/$possible_skia_dir_name"
+    fi
 
     if [ ! -d "$skia_dir" ] ; then
         echo ""

--- a/build.sh
+++ b/build.sh
@@ -74,7 +74,7 @@ elif [[ "$(uname)" == "Linux" ]] ; then
     cpu=x64
 elif [[ "$(uname)" =~ "Darwin" ]] ; then
     is_macos=1
-    if [[ $(uname -m) == "arm64" ]] ; then
+    if [[ "$(uname -m)" == "arm64" ]] ; then
         cpu=arm64
     else
         cpu=x64

--- a/build.sh
+++ b/build.sh
@@ -378,12 +378,7 @@ fi
 
 # Check Skia dependency.
 if [ ! -f "$pwd/.build/$file_skia_dir" ] ; then
-    # Try "C:/deps/skia" or "$HOME/deps/skia"
-    if [[ $is_win ]] ; then
-        skia_dir="C:/deps/$possible_skia_dir_name"
-    else
-        skia_dir="$HOME/deps/$possible_skia_dir_name"
-    fi
+    skia_dir="$pwd/.deps/$possible_skia_dir_name"
 
     if [ ! -d "$skia_dir" ] ; then
         echo ""

--- a/build.sh
+++ b/build.sh
@@ -381,7 +381,6 @@ if [ ! -f "$pwd/.build/$file_skia_dir" ] ; then
     # Try "C:/deps/skia" or "$HOME/deps/skia"
     if [[ $is_win ]] ; then
         skia_dir="C:/deps/$possible_skia_dir_name"
-        if [ ! -d "$skia_dir" ] ;
     else
         skia_dir="$HOME/deps/$possible_skia_dir_name"
     fi
@@ -391,6 +390,7 @@ if [ ! -f "$pwd/.build/$file_skia_dir" ] ; then
         echo "Skia directory wasn't found."
         echo ""
 
+        skia_dir="$pwd/.deps/$possible_skia_dir_name"
         echo "Select Skia directory to create [$skia_dir]? "
         if [ ! $auto ] ; then
             read skia_dir_read

--- a/build.sh
+++ b/build.sh
@@ -384,21 +384,24 @@ if [ ! -f "$pwd/.build/$file_skia_dir" ] ; then
     else
         skia_dir="$HOME/deps/$possible_skia_dir_name"
     fi
-
+    # Set default location if not found
     if [ ! -d "$skia_dir" ] ; then
-        echo ""
-        echo "Skia directory wasn't found."
-        echo ""
-
         skia_dir="$pwd/.deps/$possible_skia_dir_name"
-        echo "Select Skia directory to create [$skia_dir]? "
-        if [ ! $auto ] ; then
-            read skia_dir_read
-            if [ "$skia_dir_read" != "" ] ; then
-                skia_dir="$skia_dir_read"
+
+        if [ ! -d "$skia_dir" ] ; then
+            echo ""
+            echo "Skia directory wasn't found."
+            echo ""
+
+            echo "Select Skia directory to create [$skia_dir]? "
+            if [ ! $auto ] ; then
+                read skia_dir_read
+                if [ "$skia_dir_read" != "" ] ; then
+                    skia_dir="$skia_dir_read"
+                fi
             fi
+            mkdir -p $skia_dir || exit 1
         fi
-        mkdir -p $skia_dir || exit 1
     fi
     echo $skia_dir > "$pwd/.build/$file_skia_dir"
 fi


### PR DESCRIPTION
Rather than polluting outside the cloned repository,
keep the skia dependency within the repo,
similar to how `.build` is used for build configs.

---

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing
