### PR TITLE
Fix #4999

### DIFF
--- a/src/app/util/tiled_mode.h
+++ b/src/app/util/tiled_mode.h
@@ -41,12 +41,12 @@ public:
   gfx::Point mainTilePosition() const
   {
     gfx::Point pt(0, 0);
-    if (int(m_mode) & int(filters::TiledMode::X_AXIS)) {
-      pt.x += m_canvas->width();
-    }
-    if (int(m_mode) & int(filters::TiledMode::Y_AXIS)) {
-      pt.y += m_canvas->height();
-    }
+    //if (int(m_mode) & int(filters::TiledMode::X_AXIS)) {
+      //pt.x += m_canvas->width();
+    //}
+    //if (int(m_mode) & int(filters::TiledMode::Y_AXIS)) {
+      //pt.y += m_canvas->height();
+    //}
     return pt;
   }
 


### PR DESCRIPTION
Fix for tile_mode header file
made main tile position lines up with where the 
SHIFT + pencil line feature draws from when 
tiled mode is enabled

I have signed the CLA
following the steps given in 
https://github.com/igarastudio/cla#signing