### PR TITLE
Fix Straight line via SHIFT + Tiled mode starts at wrong position

### DIFF
--- a/src/app/ui/editor/editor.cpp
+++ b/src/app/ui/editor/editor.cpp
@@ -2364,6 +2364,10 @@ void Editor::onTiledModeChange()
   spritePos += mainTilePosition();
   screenPos = editorToScreen(spritePos);
 
+  auto lastPoint = document()->lastDrawingPoint();
+  lastPoint += mainTilePosition() - m_oldMainTilePos;
+  document()->setLastDrawingPoint(lastPoint);
+
   centerInSpritePoint(spritePos);
 }
 


### PR DESCRIPTION

The issue id is #4999.The strokes are drawn based on the m_lastDrawingPoint stored in the Doc class.However,when the tile mode is modified,this coordinate reference does not update accordingly. This results in strokes being rendered at incorrect positions relative to the updated tile layout.

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing
