### PR TITLE
Execute scripts in separate OS threads using lua threads

### DIFF
--- a/src/app/commands/cmd_grid.cpp
+++ b/src/app/commands/cmd_grid.cpp
@@ -52,6 +52,7 @@ protected:
     docPref.grid.snap(newValue);
 
     StatusBar::instance()->showSnapToGridWarning(newValue);
+    StatusBar::instance()->showRunningScriptsWindow(newValue);
   }
 };
 

--- a/src/app/commands/cmd_grid.cpp
+++ b/src/app/commands/cmd_grid.cpp
@@ -52,7 +52,9 @@ protected:
     docPref.grid.snap(newValue);
 
     StatusBar::instance()->showSnapToGridWarning(newValue);
+#ifdef ENABLE_SCRIPTING
     StatusBar::instance()->showRunningScriptsWindow(newValue);
+#endif
   }
 };
 

--- a/src/app/commands/cmd_run_script.cpp
+++ b/src/app/commands/cmd_run_script.cpp
@@ -73,7 +73,7 @@ void RunScriptCommand::onExecute(Context* context)
       return;
   }
 
-  App::instance()->scriptEngine()->evalUserFile(m_filename, m_params);
+  App::instance()->scriptEngine()->evalUserFileInTask(m_filename, m_params);
 
   if (context->isUIAvailable())
     ui::Manager::getDefault()->invalidate();

--- a/src/app/script/dialog_class.cpp
+++ b/src/app/script/dialog_class.cpp
@@ -170,10 +170,6 @@ struct Dialog {
   void unrefShow()
   {
     if (showRef != LUA_REFNIL) {
-      int status = lua_status(this->L);
-      TRACE("status: %d %d\n", showRef, status);
-
-      // this->L
       luaL_unref(this->L, LUA_REGISTRYINDEX, showRef);
       luaL_unref(this->L, LUA_REGISTRYINDEX, dlgStateRef);
       showRef = LUA_REFNIL;

--- a/src/app/script/engine.cpp
+++ b/src/app/script/engine.cpp
@@ -768,7 +768,7 @@ void Engine::executeTask(lua_State* parentL,
 {
   auto task = std::make_unique<RunScriptTask>(parentL, nelems, description, std::move(func));
   auto* taskPtr = task.get();
-  task->onDone([this, taskPtr](base::task_token&) { onTaskDone(taskPtr); });
+  task->onFinished([this, taskPtr](base::task_token&) { onTaskFinished(taskPtr); });
   {
     std::lock_guard<std::mutex> lock(m_mutex);
     m_tasks.push_back(std::move(task));
@@ -777,7 +777,7 @@ void Engine::executeTask(lua_State* parentL,
   taskPtr->execute(m_threadPool);
 }
 
-void Engine::onTaskDone(const RunScriptTask* task)
+void Engine::onTaskFinished(const RunScriptTask* task)
 {
   std::lock_guard<std::mutex> lock(m_mutex);
   TaskDone(task);

--- a/src/app/script/engine.h
+++ b/src/app/script/engine.h
@@ -100,6 +100,8 @@ public:
 
   int ref() const { return m_LRef; }
   const std::string& description() const { return m_description; }
+  bool isRunning() const { return m_task.running(); }
+  bool isEnqueued() const { return m_task.enqueued(); }
 
 private:
   // Lua's thread state.
@@ -136,7 +138,8 @@ public:
   std::vector<const RunScriptTask*> tasks() const
   {
     std::lock_guard<std::mutex> lock(m_mutex);
-    std::vector<const RunScriptTask*> tasks(m_tasks.size());
+    std::vector<const RunScriptTask*> tasks;
+    tasks.reserve(m_tasks.size());
     for (const auto& task : m_tasks)
       tasks.push_back(task.get());
     return tasks;
@@ -153,8 +156,11 @@ public:
 
   void startDebugger(DebuggerDelegate* debuggerDelegate);
   void stopDebugger();
-  // Stops the currently running lua chunk
-  void stopScript();
+  // Stops the specified task
+  void stopTask(const RunScriptTask* task);
+
+  obs::signal<void(const RunScriptTask*)> TaskStart;
+  obs::signal<void(const RunScriptTask*)> TaskDone;
 
 private:
   void onConsoleError(const char* text);

--- a/src/app/script/engine.h
+++ b/src/app/script/engine.h
@@ -95,7 +95,7 @@ public:
   RunScriptTask(lua_State* L, int nelems, const std::string& description, Func&& func);
   ~RunScriptTask();
 
-  void onFinished(base::task::func_t&& onFinishedFunc)
+  void onFinished(base::task::finfunc_t&& onFinishedFunc)
   {
     m_task.on_finished(std::move(onFinishedFunc));
   }

--- a/src/app/script/engine.h
+++ b/src/app/script/engine.h
@@ -93,7 +93,10 @@ public:
   RunScriptTask(lua_State* L, int nelems, const std::string& description, Func&& func);
   ~RunScriptTask();
 
-  void onDone(base::task::func_t&& funcDone) { m_task.on_done(std::move(funcDone)); }
+  void onFinished(base::task::func_t&& onFinishedFunc)
+  {
+    m_task.on_finished(std::move(onFinishedFunc));
+  }
   void execute(base::thread_pool& pool);
   void stop();
   bool wantsToStop() const { return m_wantsToStop; }
@@ -171,7 +174,7 @@ private:
                    int nelems,
                    const std::string& description,
                    RunScriptTask::Func&& func);
-  void onTaskDone(const RunScriptTask* task);
+  void onTaskFinished(const RunScriptTask* task);
   static void checkProgress(lua_State* L, lua_Debug* ar);
 
   lua_State* L;

--- a/src/app/script/engine.h
+++ b/src/app/script/engine.h
@@ -87,6 +87,8 @@ public:
 };
 
 class RunScriptTask {
+  friend class Engine;
+
 public:
   typedef std::function<void(lua_State* L)> Func;
 
@@ -98,7 +100,7 @@ public:
     m_task.on_finished(std::move(onFinishedFunc));
   }
   void execute(base::thread_pool& pool);
-  void stop();
+  void stop(base::thread_pool& pool);
   bool wantsToStop() const { return m_wantsToStop; }
 
   int ref() const { return m_LRef; }
@@ -113,6 +115,7 @@ private:
   base::task m_task;
   bool m_wantsToStop = false;
   std::string m_description;
+  base::task_token* m_token;
 };
 
 class Engine {

--- a/src/app/ui/status_bar.cpp
+++ b/src/app/ui/status_bar.cpp
@@ -22,7 +22,6 @@
 #include "app/modules/gui.h"
 #include "app/modules/palettes.h"
 #include "app/pref/preferences.h"
-#include "app/script/engine.h"
 #include "app/tools/active_tool.h"
 #include "app/tools/tool.h"
 #include "app/ui/button_set.h"
@@ -56,6 +55,10 @@
 #include "ui/ui.h"
 #include "ui/view.h"
 #include "ver/info.h"
+
+#ifdef ENABLE_SCRIPTING
+  #include "app/script/engine.h"
+#endif
 
 #include <algorithm>
 #include <cstdarg>
@@ -618,6 +621,7 @@ private:
   ui::Button m_button;
 };
 
+#ifdef ENABLE_SCRIPTING
 class StatusBar::RunningScriptsWindow : public ui::Window {
 public:
   // TODO: Replace the title by a string
@@ -680,6 +684,7 @@ private:
   ui::View m_view;
   ui::ListBox m_runningScripts;
 };
+#endif
 
 // This widget is used to show the current frame.
 class GotoFrameEntry : public Entry {
@@ -960,6 +965,7 @@ void StatusBar::showSnapToGridWarning(bool state)
   }
 }
 
+#ifdef ENABLE_SCRIPTING
 void StatusBar::showRunningScriptsWindow(bool state)
 {
   if (state) {
@@ -978,6 +984,7 @@ void StatusBar::showRunningScriptsWindow(bool state)
     m_runningScriptsWindow->closeWindow(nullptr);
   }
 }
+#endif
 
 //////////////////////////////////////////////////////////////////////
 // StatusBar message handler

--- a/src/app/ui/status_bar.cpp
+++ b/src/app/ui/status_bar.cpp
@@ -664,8 +664,7 @@ private:
       m_label.setExpansive(true);
       m_row.setExpansive(true);
       m_row.addChild(&m_label);
-      if (!task->isEnqueued())
-        m_row.addChild(&m_stop);
+      m_row.addChild(&m_stop);
       addChild(&m_row);
 
       m_stop.Click.connect([this]() { App::instance()->scriptEngine()->stopTask(m_task); });

--- a/src/app/ui/status_bar.h
+++ b/src/app/ui/status_bar.h
@@ -66,7 +66,9 @@ public:
   void showTile(int msecs, doc::tile_t tile, const std::string& text = std::string());
   void showTool(int msecs, tools::Tool* tool);
   void showSnapToGridWarning(bool state);
+#ifdef ENABLE_SCRIPTING
   void showRunningScriptsWindow(bool state);
+#endif
 
   // Used by AppEditor to update the zoom level in the status bar.
   void updateFromEditor(Editor* editor);
@@ -121,8 +123,10 @@ private:
   class SnapToGridWindow;
   SnapToGridWindow* m_snapToGridWindow;
 
+#ifdef ENABLE_SCRIPTING
   class RunningScriptsWindow;
   RunningScriptsWindow* m_runningScriptsWindow;
+#endif
 };
 
 } // namespace app

--- a/src/app/ui/status_bar.h
+++ b/src/app/ui/status_bar.h
@@ -66,6 +66,7 @@ public:
   void showTile(int msecs, doc::tile_t tile, const std::string& text = std::string());
   void showTool(int msecs, tools::Tool* tool);
   void showSnapToGridWarning(bool state);
+  void showRunningScriptsWindow(bool state);
 
   // Used by AppEditor to update the zoom level in the status bar.
   void updateFromEditor(Editor* editor);
@@ -119,6 +120,9 @@ private:
   // Snap to grid window
   class SnapToGridWindow;
   SnapToGridWindow* m_snapToGridWindow;
+
+  class RunningScriptsWindow;
+  RunningScriptsWindow* m_runningScriptsWindow;
 };
 
 } // namespace app

--- a/src/ui/await.h
+++ b/src/ui/await.h
@@ -1,0 +1,57 @@
+// Aseprite UI Library
+// Copyright (C) 2025  Igara Studio S.A.
+// Copyright (C) 2001-2018  David Capello
+//
+// This file is released under the terms of the MIT license.
+// Read LICENSE.txt for more information.
+
+#ifndef UI_AWAIT_H_INCLUDED
+#define UI_AWAIT_H_INCLUDED
+#include <type_traits>
+#pragma once
+
+#include "os/event.h"
+#include "os/event_queue.h"
+#include "ui/system.h"
+
+#include <functional>
+#include <future>
+
+namespace ui {
+
+// Awaits for the future result of the function passed.
+// It is meant to be used from background threads to ask something to the main
+// thread and wait for its result.
+// If await is called from the main thread it just executes the function
+// and returns the result.
+template<typename T>
+T await(std::function<T()>&& func)
+{
+  if (ui::is_ui_thread())
+    return func();
+
+  std::promise<T> promise;
+  std::future<T> future = promise.get_future();
+
+  // Queue the event
+  os::Event ev;
+  ev.setType(os::Event::Callback);
+  ev.setCallback([func, &promise]() {
+    try {
+      if constexpr (std::is_void<T>())
+        func();
+      else
+        promise.set_value(func());
+    }
+    catch (...) {
+      promise.set_exception(std::current_exception());
+    }
+  });
+  os::queue_event(ev);
+  // Wait for the future
+  return future.get();
+}
+
+} // namespace ui
+
+#endif


### PR DESCRIPTION
This PR demonstrates the possibility to use lua threads along OS threads (using base::task and base::thread_pool) to handle scripts execution. This is at a very draft stage, in its current form it doesn't execute most of the scripts because it lacks of the necessary adjustments. 
The idea of this work is just to evaluate the possibility and viability of the approach. One thing I had in mind while doing this is that maybe the extensions should keep running as is, or at least at the beginning (if we decide to implement this).

The issue with the current script execution mechanism is that it makes impossible to avoid getting the UI blocked by a script running in an infinite loop for instance. So the user cannot stop the script because of the unresponsiveness of the UI.
 
Once finished it should fix #4425

Here is a video demonstrating this PR in action:

https://github.com/user-attachments/assets/91f4428c-19d3-40ea-87e8-714beeca209b

This is the script used:
```lua
local function doSomething()
end

do
  local dialog = Dialog("Test")
  :button { id = "hang", text = "To the infinity and beyond",
            onclick=function()
                     local a = 0
                     local b = 0
                     while true do
                      a = a + 1
                      b = b + 1
                      doSomething()
                     end
                   end
  }

  dialog:show{wait = false}
end
```
DISCLAIMER: I didn't test how all this works with the current debugger, so crashes are expected.
