### PR TITLE
Add uuid field to layers

### DIFF
--- a/src/app/script/layer_class.cpp
+++ b/src/app/script/layer_class.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2024  Igara Studio S.A.
+// Copyright (C) 2018-2025  Igara Studio S.A.
 // Copyright (C) 2018  David Capello
 //
 // This program is distributed under the terms of
@@ -247,6 +247,13 @@ int Layer_get_tileset(lua_State* L)
   return 1;
 }
 
+int Layer_get_uuid(lua_State* L)
+{
+  auto* layer = get_docobj<Layer>(L, 1);
+  push_obj(L, layer->uuid());
+  return 1;
+}
+
 int Layer_set_name(lua_State* L)
 {
   auto layer = get_docobj<Layer>(L, 1);
@@ -446,6 +453,7 @@ const Property Layer_properties[] = {
   { "data",          UserData_get_text<Layer>,       UserData_set_text<Layer>       },
   { "properties",    UserData_get_properties<Layer>, UserData_set_properties<Layer> },
   { "tileset",       Layer_get_tileset,              Layer_set_tileset              },
+  { "uuid",          Layer_get_uuid,                 nullptr                        },
   { nullptr,         nullptr,                        nullptr                        }
 };
 

--- a/src/app/script/sprite_class.cpp
+++ b/src/app/script/sprite_class.cpp
@@ -1012,6 +1012,23 @@ int Sprite_set_tileManagementPlugin(lua_State* L)
   return 0;
 }
 
+int Sprite_get_uuidsForLayers(lua_State* L)
+{
+  auto* sprite = get_docobj<Sprite>(L, 1);
+  lua_pushboolean(L, sprite->uuidsForLayers());
+  return 1;
+}
+
+int Sprite_set_uuidsForLayers(lua_State* L)
+{
+  auto* sprite = get_docobj<Sprite>(L, 1);
+  if (lua_isboolean(L, 2)) {
+    const bool value = lua_toboolean(L, 2);
+    sprite->setUuidsForLayers(value);
+  }
+  return 0;
+}
+
 const luaL_Reg Sprite_methods[] = {
   { "__eq",              Sprite_eq                },
   { "resize",            Sprite_resize            },
@@ -1076,6 +1093,7 @@ const Property Sprite_properties[] = {
   { "pixelRatio",           Sprite_get_pixelRatio,           Sprite_set_pixelRatio           },
   { "events",               Sprite_get_events,               nullptr                         },
   { "tileManagementPlugin", Sprite_get_tileManagementPlugin, Sprite_set_tileManagementPlugin },
+  { "uuidsForLayers",       Sprite_get_uuidsForLayers,       Sprite_set_uuidsForLayers       },
   { nullptr,                nullptr,                         nullptr                         }
 };
 

--- a/tests/scripts/layer.lua
+++ b/tests/scripts/layer.lua
@@ -20,3 +20,44 @@ do
   l.data = "Data"
   assert(l.data == "Data")
 end
+
+-- Test layer uuid with uuidsForLayers enabled
+do
+  local s = Sprite(32, 32)
+  local l = s.layers[1]
+  assert(s.uuidsForLayers == false)
+
+  local uuid = l.uuid
+  assert(uuid ~= nil)
+
+  s.uuidsForLayers = true
+
+  assert(s.uuidsForLayers == true)
+  s.filename = "_test_layer_uuid.aseprite"
+  app.command.SaveFile()
+  app.command.CloseFile()
+
+  app.command.OpenFile { filename = "_test_layer_uuid.aseprite" }
+  assert(app.sprite.uuidsForLayers == true)
+  assert(app.sprite.layers[1].uuid == uuid)
+end
+
+-- Test layer uuid with uuidsForLayers disabled
+do
+  local s = Sprite(32, 32)
+  local l = s.layers[1]
+  assert(s.uuidsForLayers == false)
+
+  local uuid = l.uuid
+  assert(uuid ~= nil)
+
+  s.filename = "_test_layer_uuid_2.aseprite"
+  app.command.SaveFile()
+  app.command.CloseFile()
+
+  app.command.OpenFile { filename = "_test_layer_uuid_2.aseprite" }
+  assert(app.sprite.uuidsForLayers == false)
+  -- UUIDs are not equal because it was not saved due to uuidsForLayers being
+  -- disabled at the time of saving the file.
+  assert(app.sprite.layers[1].uuid ~= uuid)
+end


### PR DESCRIPTION
Fix #5033 by adding access to the layer's uuid field and the sprite's uuidsForLayers field.