### PR TITLE
Prevent using an invalid point as the last drawing point

### DIFF
--- a/src/app/ui/editor/editor.cpp
+++ b/src/app/ui/editor/editor.cpp
@@ -2366,8 +2366,10 @@ void Editor::onTiledModeChange()
   screenPos = editorToScreen(spritePos);
 
   auto lastPoint = document()->lastDrawingPoint();
-  lastPoint += mainTilePosition() - m_oldMainTilePos;
-  document()->setLastDrawingPoint(lastPoint);
+  if (lastPoint != Doc::NoLastDrawingPoint()) {
+    lastPoint += mainTilePosition() - m_oldMainTilePos;
+    document()->setLastDrawingPoint(lastPoint);
+  }
 
   centerInSpritePoint(spritePos);
 }


### PR DESCRIPTION
This PR just introduces an if clause to avoid setting an invalid point to the document's last drawing point. This situation happens when there is no point set yet, so the last drawing point doesn't exist. 
Fix #5055
