### PR TITLE
Palette picker pinning, loading speed, misc improvements (fix #2365)

### DIFF
--- a/data/strings/en.ini
+++ b/data/strings/en.ini
@@ -1671,6 +1671,11 @@ n_slices_removed = {} slice(s) removed
 x_removed = Layer "{}" removed
 layers_removed = Layers removed
 
+[resource_listbox]
+loading = Loading
+pin = Pin this item
+unpin = Unpin this item
+
 [save_file]
 title = Save File
 save_as = Save As

--- a/src/app/ui/icon_button.cpp
+++ b/src/app/ui/icon_button.cpp
@@ -28,6 +28,12 @@ IconButton::IconButton(const SkinPartPtr& part) : Button(""), m_part(part)
   initTheme();
 }
 
+void IconButton::setIcon(const skin::SkinPartPtr& part)
+{
+  m_part = part;
+  invalidate();
+}
+
 void IconButton::onInitTheme(InitThemeEvent& ev)
 {
   Button::onInitTheme(ev);
@@ -44,7 +50,7 @@ void IconButton::onSizeHint(SizeHintEvent& ev)
 
 void IconButton::onPaint(PaintEvent& ev)
 {
-  auto theme = SkinTheme::get(this);
+  const auto* theme = SkinTheme::get(this);
   Graphics* g = ev.graphics();
   gfx::Color fg, bg;
 
@@ -61,9 +67,11 @@ void IconButton::onPaint(PaintEvent& ev)
     bg = bgColor();
   }
 
-  g->fillRect(bg, g->getClipBounds());
+  if (!isTransparent()) {
+    g->fillRect(bg, g->getClipBounds());
+  }
 
-  gfx::Rect bounds = clientBounds();
+  const gfx::Rect bounds = clientBounds();
   os::Surface* icon = m_part->bitmap(0);
   g->drawColoredRgbaSurface(icon,
                             fg,

--- a/src/app/ui/icon_button.h
+++ b/src/app/ui/icon_button.h
@@ -15,7 +15,8 @@ namespace app {
 
 class IconButton : public ui::Button {
 public:
-  IconButton(const skin::SkinPartPtr& part);
+  explicit IconButton(const skin::SkinPartPtr& part);
+  void setIcon(const skin::SkinPartPtr& part);
 
 protected:
   void onInitTheme(ui::InitThemeEvent& ev) override;

--- a/src/app/ui/palettes_listbox.cpp
+++ b/src/app/ui/palettes_listbox.cpp
@@ -14,33 +14,33 @@
 #include "app/app.h"
 #include "app/doc.h"
 #include "app/extensions.h"
+#include "app/i18n/strings.h"
+#include "app/ini_file.h"
 #include "app/modules/palettes.h"
 #include "app/res/palette_resource.h"
 #include "app/res/palettes_loader_delegate.h"
 #include "app/ui/doc_view.h"
 #include "app/ui/editor/editor.h"
 #include "app/ui/icon_button.h"
+#include "app/ui/separator_in_view.h"
 #include "app/ui/skin/skin_theme.h"
 #include "app/ui_context.h"
+#include "base/fs.h"
 #include "base/launcher.h"
 #include "doc/palette.h"
 #include "doc/sprite.h"
 #include "os/surface.h"
 #include "ui/graphics.h"
-#include "ui/listitem.h"
 #include "ui/message.h"
-#include "ui/paint_event.h"
-#include "ui/resize_event.h"
 #include "ui/size_hint_event.h"
 #include "ui/tooltips.h"
-#include "ui/view.h"
 
 namespace app {
 
 using namespace ui;
 using namespace app::skin;
 
-static bool is_url_char(int chr)
+static constexpr bool is_url_char(const int chr)
 {
   return ((chr >= 'a' && chr <= 'z') || (chr >= 'A' && chr <= 'Z') || (chr >= '0' && chr <= '9') ||
           (chr == ':' || chr == '/' || chr == '@' || chr == '?' || chr == '!' || chr == '#' ||
@@ -49,26 +49,21 @@ static bool is_url_char(int chr)
            chr == ')' || chr == '$' || chr == '\''));
 }
 
+constexpr const char* kSectionName = "PinnedPalettes";
+constexpr const uint8_t kPinnedLimit = 9999;
+
 class PalettesListItem : public ResourceListItem {
   class CommentButton : public IconButton {
   public:
-    CommentButton(const std::string& comment)
+    explicit CommentButton(const std::string& comment)
       : IconButton(SkinTheme::instance()->parts.iconUserData())
       , m_comment(comment)
     {
       setFocusStop(false);
-      initTheme();
+      setTransparent(true);
     }
 
   private:
-    void onInitTheme(InitThemeEvent& ev) override
-    {
-      IconButton::onInitTheme(ev);
-
-      auto theme = SkinTheme::get(this);
-      setBgColor(theme->colors.listitemNormalFace());
-    }
-
     void onClick() override
     {
       IconButton::onClick();
@@ -85,46 +80,201 @@ class PalettesListItem : public ResourceListItem {
   };
 
 public:
-  PalettesListItem(Resource* resource, TooltipManager* tooltips)
+  PalettesListItem(Resource* resource, TooltipManager* tooltips, bool isPinned)
     : ResourceListItem(resource)
-    , m_comment(nullptr)
+    , m_resource(resource)
+    , m_tooltips(tooltips)
   {
-    std::string comment = static_cast<PaletteResource*>(resource)->palette()->comment();
+    auto* filler = new BoxFiller;
+    m_hbox.setFocusStop(false);
+    m_hbox.setTransparent(true);
+    filler->setTransparent(true);
+    filler->setFocusStop(false);
+    m_hbox.addChild(filler);
+
+    const std::string& comment = static_cast<PaletteResource*>(resource)->palette()->comment();
     if (!comment.empty()) {
-      addChild(m_comment = new CommentButton(comment));
-
-      tooltips->addTooltipFor(m_comment, comment, LEFT);
+      auto* commentButton = new CommentButton(comment);
+      tooltips->addTooltipFor(commentButton, comment, LEFT);
+      m_hbox.addChild(commentButton);
     }
+
+    setPinned(isPinned);
+
+    addChild(&m_hbox);
+    m_hbox.setVisible(false);
+    m_initialized = true;
   }
 
-private:
-  void onResize(ResizeEvent& ev) override
+  void setPinned(bool isPinned)
   {
-    ResourceListItem::onResize(ev);
+    const auto& part = isPinned ? SkinTheme::instance()->parts.pinned() :
+                                  SkinTheme::instance()->parts.unpinned();
+    IconButton* pinnedButton;
 
-    if (m_comment) {
-      auto reqSz = m_comment->sizeHint();
-      m_comment->setBounds(gfx::Rect(ev.bounds().x + ev.bounds().w - reqSz.w,
-                                     ev.bounds().y + ev.bounds().h / 2 - reqSz.h / 2,
-                                     reqSz.w,
-                                     reqSz.h));
+    if (m_initialized) {
+      pinnedButton = static_cast<IconButton*>(m_hbox.lastChild());
+      pinnedButton->setIcon(part);
+      m_tooltips->removeTooltipFor(pinnedButton);
     }
+    else {
+      pinnedButton = new IconButton(part);
+      pinnedButton->setTransparent(true);
+      pinnedButton->setFocusStop(false);
+
+      const std::string resourceId = m_resource->id();
+      pinnedButton->Click.connect([&, resourceId] {
+        if (auto* p = dynamic_cast<PalettesListBox*>(parent()))
+          p->togglePinned(resourceId);
+      });
+
+      m_hbox.addChild(pinnedButton);
+    }
+
+    m_tooltips->addTooltipFor(
+      pinnedButton,
+      isPinned ? Strings::resource_listbox_unpin() : Strings::resource_listbox_pin(),
+      LEFT);
   }
 
-  CommentButton* m_comment;
+  bool onProcessMessage(Message* msg) override
+  {
+    switch (msg->type()) {
+      case kMouseLeaveMessage: {
+        m_hbox.setVisible(false);
+        invalidate();
+        break;
+      }
+      case kMouseEnterMessage: {
+        m_hbox.setVisible(true);
+        invalidate();
+        break;
+      }
+    }
+
+    return ResourceListItem::onProcessMessage(msg);
+  }
+
+  bool m_initialized = false;
+  Resource* m_resource;
+  TooltipManager* m_tooltips;
+  HBox m_hbox;
 };
 
 PalettesListBox::PalettesListBox()
   : ResourcesListBox(new ResourcesLoader(std::make_unique<PalettesLoaderDelegate>()))
+  , m_pinnedSeparator("", HORIZONTAL)
 {
+  m_pinnedSeparator.setFocusStop(false);
+  m_pinnedSeparator.InitTheme.connect(
+    [&] { m_pinnedSeparator.setBorder(m_pinnedSeparator.border() * guiscale() * 2); });
+
   addChild(&m_tooltips);
+
+  loadPinnedQuiet();
+  FinishLoading.connect(&PalettesListBox::loadPinned, this);
 
   m_extPaletteChanges = App::instance()->extensions().PalettesChange.connect(
     [this] { markToReload(); });
   m_extPresetsChanges = App::instance()->PalettePresetsChange.connect([this] { markToReload(); });
 }
 
-const doc::Palette* PalettesListBox::selectedPalette()
+void PalettesListBox::togglePinned(const std::string& paletteId)
+{
+  ASSERT(!paletteId.empty());
+
+  bool isPinning = false;
+  auto it = std::find(m_pinned.begin(), m_pinned.end(), paletteId);
+  if (it != m_pinned.end()) {
+    m_pinned.erase(it);
+  }
+  else {
+    isPinning = true;
+
+    if (m_pinned.size() >= kPinnedLimit)
+      m_pinned.erase(m_pinned.begin()); // Pop the oldest one when going over.
+
+    m_pinned.push_back(paletteId);
+  }
+
+  for (Widget* child : children()) {
+    if (auto* item = dynamic_cast<PalettesListItem*>(child);
+        item && item->m_resource->id() == paletteId) {
+      item->setPinned(isPinning);
+
+      if (isPinning) {
+        item->setSelected(true);
+      }
+
+      // Hack to avoid the buttons lingering when re-sorting
+      item->sendMessage(new Message(kMouseLeaveMessage));
+
+      // We could break here, but that wouldn't let us deselect every child so our
+      // new pinned can be selected and then we can center on it.
+    }
+    else if (child != nullptr && isPinning) {
+      child->setSelected(false);
+    }
+  }
+
+  toggleSeparator();
+  savePinned();
+  sortItems();
+  layout();
+
+  if (isPinning)
+    centerScroll();
+}
+
+void PalettesListBox::loadPinned()
+{
+  const bool wasEmpty = m_pinned.empty();
+  loadPinnedQuiet();
+
+  if (wasEmpty && m_pinned.empty())
+    return; // Avoid a relayout with no changes and no pinned palettes.
+
+  toggleSeparator();
+  sortItems();
+  layout();
+}
+
+void PalettesListBox::toggleSeparator()
+{
+  // For some reason, just toggling visibility does not work properly, so we have to reparent.
+  if (!m_pinned.empty() && m_pinnedSeparator.parent() == nullptr)
+    addChild(&m_pinnedSeparator);
+  else if (m_pinned.empty() && m_pinnedSeparator.parent() == this)
+    removeChild(&m_pinnedSeparator);
+}
+
+void PalettesListBox::savePinned()
+{
+  for (const auto& key : enum_config_keys(kSectionName)) {
+    del_config_value(kSectionName, key.c_str());
+  }
+
+  // Crudely compare the outgoing pins to the current list so that we can remove any that don't
+  // exist anymore, faster than checking the filesystem for the palette file or doing the check when
+  // we load.
+  const auto& c = children();
+  std::vector<std::string_view> ids;
+  ids.resize(c.size());
+  for (size_t i = 0; i < c.size(); ++i) {
+    ids[i] = c[i]->text();
+  }
+
+  for (size_t i = 0; i < m_pinned.size(); ++i) {
+    const auto& pinned = m_pinned[i];
+    auto it = std::find(ids.begin(), ids.end(), pinned);
+    if (it == ids.end())
+      continue;
+
+    set_config_string(kSectionName, fmt::format("{:04d}", i).c_str(), pinned.c_str());
+  }
+}
+
+const Palette* PalettesListBox::selectedPalette()
 {
   Resource* resource = selectedResource();
   if (!resource)
@@ -135,7 +285,10 @@ const doc::Palette* PalettesListBox::selectedPalette()
 
 ResourceListItem* PalettesListBox::onCreateResourceItem(Resource* resource)
 {
-  return new PalettesListItem(resource, &m_tooltips);
+  return new PalettesListItem(
+    resource,
+    &m_tooltips,
+    std::find(m_pinned.begin(), m_pinned.end(), resource->id()) != m_pinned.end());
 }
 
 void PalettesListBox::onResourceChange(Resource* resource)
@@ -176,6 +329,29 @@ void PalettesListBox::onPaintResource(Graphics* g, gfx::Rect& bounds, Resource* 
 void PalettesListBox::onResourceSizeHint(Resource* resource, gfx::Size& size)
 {
   size = gfx::Size(0, (2 + 16 + 2) * guiscale());
+}
+
+void PalettesListBox::loadPinnedQuiet()
+{
+  m_pinned.clear();
+  for (const auto& key : enum_config_keys(kSectionName)) {
+    m_pinned.push_back(get_config_string(kSectionName, key.c_str(), nullptr));
+  }
+  if (m_pinned.size() >= kPinnedLimit)
+    m_pinned.resize(kPinnedLimit);
+}
+
+void PalettesListBox::sortItems()
+{
+  ListBox::sortItems([&](const Widget* a, const Widget* b) {
+    const bool aPinned = std::find(m_pinned.begin(), m_pinned.end(), a->text()) != m_pinned.end();
+    const bool bPinned = std::find(m_pinned.begin(), m_pinned.end(), b->text()) != m_pinned.end();
+
+    if (aPinned == bPinned)
+      return base::compare_filenames(a->text(), b->text()) < 0;
+
+    return (aPinned && !bPinned);
+  });
 }
 
 } // namespace app

--- a/src/app/ui/palettes_listbox.h
+++ b/src/app/ui/palettes_listbox.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "app/ui/resources_listbox.h"
+#include "app/ui/separator_in_view.h"
 #include "obs/connection.h"
 #include "ui/tooltips.h"
 
@@ -24,6 +25,10 @@ public:
 
   const doc::Palette* selectedPalette();
 
+  void sortItems() override;
+  void togglePinned(const std::string& paletteId);
+  void loadPinned();
+
   obs::signal<void(const doc::Palette*)> PalChange;
 
 protected:
@@ -31,8 +36,14 @@ protected:
   virtual void onResourceChange(Resource* resource) override;
   virtual void onPaintResource(ui::Graphics* g, gfx::Rect& bounds, Resource* resource) override;
   virtual void onResourceSizeHint(Resource* resource, gfx::Size& size) override;
+  void loadPinnedQuiet();
+  void savePinned();
+  void toggleSeparator();
 
+private:
+  std::vector<std::string> m_pinned;
   ui::TooltipManager m_tooltips;
+  app::SeparatorInView m_pinnedSeparator;
   obs::scoped_connection m_extPaletteChanges;
   obs::scoped_connection m_extPresetsChanges;
 };

--- a/src/app/ui/resources_listbox.cpp
+++ b/src/app/ui/resources_listbox.cpp
@@ -11,6 +11,7 @@
 
 #include "app/ui/resources_listbox.h"
 
+#include "app/i18n/strings.h"
 #include "app/res/resource.h"
 #include "app/res/resources_loader.h"
 #include "app/ui/skin/skin_theme.h"
@@ -80,20 +81,12 @@ void ResourceListItem::onSizeHint(SizeHintEvent& ev)
 
 class ResourcesListBox::LoadingItem : public ListItem {
 public:
-  LoadingItem() : ListItem("Loading"), m_state(0) {}
+  LoadingItem() : ListItem(Strings::resource_listbox_loading()), m_state(0) {}
 
   void makeProgress()
   {
-    std::string text = "Loading ";
-
-    switch ((++m_state) % 4) {
-      case 0: text += "/"; break;
-      case 1: text += "-"; break;
-      case 2: text += "\\"; break;
-      case 3: text += "|"; break;
-    }
-
-    setText(text);
+    constexpr char progress[] = { '/', '-', '\\', '|' };
+    setText(fmt::format("{} {}", Strings::resource_listbox_loading(), progress[((++m_state) % 4)]));
   }
 
 private:
@@ -201,26 +194,26 @@ void ResourcesListBox::onTick()
   if (!m_loadingItem) {
     m_loadingItem = new LoadingItem;
     addChild(m_loadingItem);
+    layout();
   }
   m_loadingItem->makeProgress();
 
   std::unique_ptr<Resource> resource;
-  std::string name;
 
   while (m_resourcesLoader->next(resource)) {
     std::unique_ptr<ResourceListItem> listItem(onCreateResourceItem(resource.get()));
     insertChild(getItemsCount() - 1, listItem.get());
-    sortItems();
-    layout();
-
-    if (View* view = View::getView(this))
-      view->updateView();
-
     resource.release();
     listItem.release();
   }
 
   if (m_resourcesLoader->isDone()) {
+    // Delay sorting and layout until we're fully loaded, for perfomance with big lists.
+    if (View* view = View::getView(this))
+      view->updateView();
+    sortItems();
+    layout();
+
     FinishLoading();
     stop();
   }

--- a/src/ui/listbox.cpp
+++ b/src/ui/listbox.cpp
@@ -26,11 +26,6 @@
 
 namespace ui {
 
-static inline bool sort_by_text(Widget* a, Widget* b)
-{
-  return (base::compare_filenames(a->text(), b->text()) < 0);
-}
-
 using namespace gfx;
 
 ListBox::ListBox()
@@ -182,10 +177,12 @@ void ListBox::centerScroll()
 
 void ListBox::sortItems()
 {
-  sortItems(&sort_by_text);
+  sortItems([](const Widget* a, const Widget* b) {
+    return (base::compare_filenames(a->text(), b->text()) < 0);
+  });
 }
 
-void ListBox::sortItems(bool (*cmp)(Widget* a, Widget* b))
+void ListBox::sortItems(const std::function<bool(Widget*, Widget*)>& cmp)
 {
   WidgetsList widgets = children();
   std::sort(widgets.begin(), widgets.end(), cmp);

--- a/src/ui/listbox.h
+++ b/src/ui/listbox.h
@@ -35,8 +35,8 @@ public:
 
   void makeChildVisible(Widget* item);
   void centerScroll();
-  void sortItems();
-  void sortItems(bool (*cmp)(Widget* a, Widget* b));
+  virtual void sortItems();
+  void sortItems(const std::function<bool(Widget*, Widget*)>& cmp);
 
   obs::signal<void()> Change;
   obs::signal<void()> DoubleClickItem;


### PR DESCRIPTION
Implements #2365:

 - Adds pinning to the palette resource list, stored in the ini file.
 - Restores the broken functionality of the "Loading" indicator inside resource lists.
 - Improved loading performance.
 - Makes it so transparent IconButton can be more easily used inside these kinds of widgets by not drawing the background.

Result:

https://github.com/user-attachments/assets/0587a1a3-cc13-411d-86a5-c91bc2bcaf77

