### PR TITLE
Fixes for baseline & underline font bugs

### DIFF
--- a/data/extensions/aseprite-theme/dark/theme.xml
+++ b/data/extensions/aseprite-theme/dark/theme.xml
@@ -556,7 +556,7 @@
         <style id="list_header_label" padding="2">
             <text color="text" align="left" x="2" />
         </style>
-        <style id="link">
+        <style id="link" padding="1">
             <text color="link_text" align="left" />
             <text color="link_hover" align="left" state="mouse" />
         </style>

--- a/data/extensions/aseprite-theme/theme.xml
+++ b/data/extensions/aseprite-theme/theme.xml
@@ -549,7 +549,7 @@
         <style id="list_header_label" padding="2">
             <text color="text" align="left" x="2" />
         </style>
-        <style id="link">
+        <style id="link" padding="1">
             <text color="link_text" align="left" />
             <text color="link_hover" align="left" state="mouse" />
         </style>

--- a/data/fonts/fonts.xml
+++ b/data/fonts/fonts.xml
@@ -32,12 +32,14 @@
 
   <font name="Aseprite"
         type="spritesheet"
+        descent="2"
         file="aseprite_font.png">
     <fallback font="Unicode" size="8" />
   </font>
 
   <font name="Aseprite Mini"
         type="spritesheet"
+        descent="1"
         file="aseprite_mini.png">
     <fallback font="Unicode" size="6" />
   </font>

--- a/src/app/commands/cmd_options.cpp
+++ b/src/app/commands/cmd_options.cpp
@@ -1116,19 +1116,7 @@ private:
     const bool state = fontCheckBox->isSelected();
     fontEntry->setEnabled(state);
 
-    FontInfo fi;
-    auto* theme = skin::SkinTheme::get(this);
-    text::FontMgrRef fontMgr = theme->fontMgr();
-    for (const auto& kv : Fonts::instance()->definedFonts()) {
-      if (kv.second->getFont(fontMgr, themeFont->height(), guiscale()) == themeFont) {
-        fi = FontInfo(FontInfo::Type::Name,
-                      kv.first,
-                      themeFont->height(),
-                      text::FontStyle(),
-                      themeFont->antialias() ? FontInfo::Flags::Antialias : FontInfo::Flags::None);
-        break;
-      }
-    }
+    FontInfo fi = Fonts::instance()->infoFromFont(themeFont);
     fontEntry->setInfo(fi, FontEntry::From::Init);
   }
 

--- a/src/app/commands/cmd_undo_history.cpp
+++ b/src/app/commands/cmd_undo_history.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2020-2022  Igara Studio S.A.
+// Copyright (C) 2020-2025  Igara Studio S.A.
 // Copyright (C) 2015-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -28,10 +28,12 @@
 #include "app/ui/workspace.h"
 #include "base/mem_utils.h"
 #include "fmt/format.h"
+#include "text/font_metrics.h"
 #include "ui/init_theme_event.h"
 #include "ui/listitem.h"
 #include "ui/message.h"
 #include "ui/paint_event.h"
+#include "ui/scale.h"
 #include "ui/size_hint_event.h"
 #include "ui/view.h"
 #include "undo/undo_state.h"
@@ -300,9 +302,14 @@ public:
         style = theme->styles.undoSavedItem();
       }
 
+      text::FontMetrics metrics;
+      font()->metrics(&metrics);
+      const float lineHeight = metrics.descent - metrics.ascent;
+
       ui::PaintWidgetPartInfo info;
       info.text = &itemText;
       info.styleFlags = (selected ? ui::Style::Layer::kSelected : 0);
+      info.baseline = ui::guiscaled_center(itemBounds.y, itemBounds.h, lineHeight) - metrics.ascent;
       theme->paintWidgetPart(g, style, itemBounds, info);
     }
 

--- a/src/app/commands/debugger.cpp
+++ b/src/app/commands/debugger.cpp
@@ -244,7 +244,7 @@ protected:
         for (const uint8_t* line : m_fileContent->lines) {
           ASSERT(line);
           tmp.assign((const char*)line);
-          m_maxLineWidth = std::max(m_maxLineWidth, f->textLength(tmp));
+          m_maxLineWidth = std::max<int>(m_maxLineWidth, std::ceil(f->textLength(tmp)));
         }
       }
 

--- a/src/app/fonts/font_data.cpp
+++ b/src/app/fonts/font_data.cpp
@@ -13,8 +13,8 @@
 
 #include "text/font.h"
 #include "text/font_mgr.h"
+#include "text/sprite_sheet_font.h"
 #include "ui/manager.h"
-#include "ui/scale.h"
 
 #include <set>
 
@@ -49,6 +49,9 @@ text::FontRef FontData::getFont(text::FontMgrRef& fontMgr, float size)
   switch (m_type) {
     case text::FontType::SpriteSheet:
       font = fontMgr->loadSpriteSheetFont(m_filename.c_str(), size);
+      if (font && m_descent != 0.0f) {
+        static_cast<text::SpriteSheetFont*>(font.get())->setDescent(m_descent);
+      }
       break;
     case text::FontType::FreeType: {
       font = fontMgr->loadTrueTypeFont(m_filename.c_str(), size);

--- a/src/app/fonts/font_data.cpp
+++ b/src/app/fonts/font_data.cpp
@@ -28,18 +28,21 @@ FontData::FontData(text::FontType type)
 {
 }
 
-text::FontRef FontData::getFont(text::FontMgrRef& fontMgr, int size, int uiscale)
+text::FontRef FontData::getFont(text::FontMgrRef& fontMgr, float size)
 {
   ASSERT(fontMgr);
 
-  if (m_type == text::FontType::SpriteSheet)
-    size = 1; // Same size always
-
   // Use cache
-  size *= uiscale;
-  auto it = m_fonts.find(size);
-  if (it != m_fonts.end())
-    return it->second;
+  if (m_antialias) {
+    auto it = m_antialiasFonts.find(size);
+    if (it != m_antialiasFonts.end())
+      return it->second;
+  }
+  else {
+    auto it = m_fonts.find(size);
+    if (it != m_fonts.end())
+      return it->second;
+  }
 
   text::FontRef font = nullptr;
 
@@ -64,13 +67,11 @@ text::FontRef FontData::getFont(text::FontMgrRef& fontMgr, int size, int uiscale
   }
 
   // Cache this font
-  m_fonts[size] = font;
+  if (m_antialias)
+    m_antialiasFonts[size] = font;
+  else
+    m_fonts[size] = font;
   return font;
-}
-
-text::FontRef FontData::getFont(text::FontMgrRef& fontMgr, int size)
-{
-  return getFont(fontMgr, size, ui::guiscale());
 }
 
 } // namespace app

--- a/src/app/fonts/font_data.h
+++ b/src/app/fonts/font_data.h
@@ -25,14 +25,13 @@ public:
 
   void setFilename(const std::string& filename) { m_filename = filename; }
   void setAntialias(bool antialias) { m_antialias = antialias; }
-  void setFallback(FontData* fallback, int fallbackSize)
+  void setFallback(FontData* fallback, float fallbackSize)
   {
     m_fallback = fallback;
     m_fallbackSize = fallbackSize;
   }
 
-  text::FontRef getFont(text::FontMgrRef& fontMgr, int size, int uiscale);
-  text::FontRef getFont(text::FontMgrRef& fontMgr, int size);
+  text::FontRef getFont(text::FontMgrRef& fontMgr, float size);
 
   const std::string& filename() const { return m_filename; }
 
@@ -40,9 +39,10 @@ private:
   text::FontType m_type;
   std::string m_filename;
   bool m_antialias;
-  std::map<int, text::FontRef> m_fonts; // key=font size, value=real font
+  std::map<float, text::FontRef> m_fonts; // key=font size, value=real font
+  std::map<float, text::FontRef> m_antialiasFonts;
   FontData* m_fallback;
-  int m_fallbackSize;
+  float m_fallbackSize;
 
   DISABLE_COPYING(FontData);
 };

--- a/src/app/fonts/font_data.h
+++ b/src/app/fonts/font_data.h
@@ -31,6 +31,9 @@ public:
     m_fallbackSize = fallbackSize;
   }
 
+  // Descent font metrics for sprite sheet fonts
+  void setDescent(float descent) { m_descent = descent; }
+
   text::FontRef getFont(text::FontMgrRef& fontMgr, float size);
 
   const std::string& filename() const { return m_filename; }
@@ -43,6 +46,7 @@ private:
   std::map<float, text::FontRef> m_antialiasFonts;
   FontData* m_fallback;
   float m_fallbackSize;
+  float m_descent = 0.0f;
 
   DISABLE_COPYING(FontData);
 };

--- a/src/app/fonts/font_info.h
+++ b/src/app/fonts/font_info.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (c) 2024  Igara Studio S.A.
+// Copyright (c) 2024-2025  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -11,6 +11,7 @@
 #include "base/convert_to.h"
 #include "base/enum_flags.h"
 #include "text/font_style.h"
+#include "text/font_type.h"
 #include "text/fwd.h"
 #include "text/typeface.h"
 

--- a/src/app/fonts/fonts.cpp
+++ b/src/app/fonts/fonts.cpp
@@ -50,7 +50,7 @@ FontData* Fonts::fontDataByName(const std::string& name)
   return it->second.get();
 }
 
-text::FontRef Fonts::fontByName(const std::string& name, int size)
+text::FontRef Fonts::fontByName(const std::string& name, const float size)
 {
   auto it = m_fonts.find(name);
   if (it == m_fonts.end())
@@ -91,10 +91,10 @@ text::FontRef Fonts::fontFromInfo(const FontInfo& fontInfo)
 FontInfo Fonts::infoFromFont(const text::FontRef& font)
 {
   for (const auto& kv : m_fonts) {
-    if (kv.second->getFont(m_fontMgr, font->height()) == font) {
+    if (kv.second->getFont(m_fontMgr, font->size()) == font) {
       return FontInfo(FontInfo::Type::Name,
                       kv.first,
-                      font->height(),
+                      font->size(),
                       text::FontStyle(),
                       font->antialias() ? FontInfo::Flags::Antialias : FontInfo::Flags::None);
     }

--- a/src/app/fonts/fonts.cpp
+++ b/src/app/fonts/fonts.cpp
@@ -74,7 +74,7 @@ text::FontRef Fonts::fontFromInfo(const FontInfo& fontInfo)
       font->setSize(fontInfo.size());
   }
   else {
-    const int size = (fontInfo.useDefaultSize() ? 18 : fontInfo.size());
+    const float size = (fontInfo.useDefaultSize() ? 0.0f : fontInfo.size());
     font = fontByName(fontInfo.name(), size);
 
     if (!font && fontInfo.type() == FontInfo::Type::File) {
@@ -86,6 +86,20 @@ text::FontRef Fonts::fontFromInfo(const FontInfo& fontInfo)
     font->setAntialias(fontInfo.antialias());
 
   return font;
+}
+
+FontInfo Fonts::infoFromFont(const text::FontRef& font)
+{
+  for (const auto& kv : m_fonts) {
+    if (kv.second->getFont(m_fontMgr, font->height()) == font) {
+      return FontInfo(FontInfo::Type::Name,
+                      kv.first,
+                      font->height(),
+                      text::FontStyle(),
+                      font->antialias() ? FontInfo::Flags::Antialias : FontInfo::Flags::None);
+    }
+  }
+  return {};
 }
 
 } // namespace app

--- a/src/app/fonts/fonts.h
+++ b/src/app/fonts/fonts.h
@@ -38,6 +38,7 @@ public:
   FontData* fontDataByName(const std::string& name);
   text::FontRef fontByName(const std::string& name, int size);
   text::FontRef fontFromInfo(const FontInfo& fontInfo);
+  FontInfo infoFromFont(const text::FontRef& font);
 
 private:
   text::FontMgrRef m_fontMgr;

--- a/src/app/fonts/fonts.h
+++ b/src/app/fonts/fonts.h
@@ -36,7 +36,7 @@ public:
   void addFontData(const std::string& name, std::unique_ptr<FontData>&& fontData);
 
   FontData* fontDataByName(const std::string& name);
-  text::FontRef fontByName(const std::string& name, int size);
+  text::FontRef fontByName(const std::string& name, float size);
   text::FontRef fontFromInfo(const FontInfo& fontInfo);
   FontInfo infoFromFont(const text::FontRef& font);
 

--- a/src/app/ui/browser_view.cpp
+++ b/src/app/ui/browser_view.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2024  Igara Studio S.A.
+// Copyright (C) 2018-2025  Igara Studio S.A.
 // Copyright (C) 2016-2017  David Capello
 //
 // This program is distributed under the terms of
@@ -65,7 +65,7 @@ private:
 class BrowserView::CMarkBox : public Widget {
   class Break : public Widget {
   public:
-    Break() { setMinSize(gfx::Size(0, font()->height())); }
+    Break() { setMinSize(gfx::Size(0, font()->lineHeight())); }
   };
   class OpenList : public Widget {};
   class CloseList : public Widget {};
@@ -439,7 +439,8 @@ private:
   void addSeparator()
   {
     auto sep = new SeparatorInView(std::string(), HORIZONTAL);
-    sep->setBorder(gfx::Border(0, font()->height(), 0, font()->height()));
+    float h = font()->lineHeight() / 2.0f;
+    sep->setBorder(gfx::Border(0, h, 0, h));
     sep->setExpansive(true);
     addChild(sep);
   }

--- a/src/app/ui/color_shades.cpp
+++ b/src/app/ui/color_shades.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2023  Igara Studio S.A.
+// Copyright (C) 2019-2025  Igara Studio S.A.
 // Copyright (C) 2018  David Capello
 //
 // This program is distributed under the terms of
@@ -287,6 +287,7 @@ void ColorShades::onPaint(ui::PaintEvent& ev)
     ui::PaintWidgetPartInfo info;
     const std::string& text = this->text();
     info.text = &text;
+    info.baseline = textBaseline();
     theme->paintWidgetPart(g, theme->styles.shadeEmpty(), bounds, info);
   }
 }

--- a/src/app/ui/editor/editor.cpp
+++ b/src/app/ui/editor/editor.cpp
@@ -1239,9 +1239,9 @@ void Editor::drawTileNumbers(ui::Graphics* g, const Cel* cel)
   const text::FontRef& font = g->font();
   const doc::Grid grid = getSite().grid();
   const gfx::Size tileSize = editorToScreen(grid.tileToCanvas(gfx::Rect(0, 0, 1, 1))).size();
-  const int th = font->height();
+  const int th = font->lineHeight();
   if (tileSize.h > th) {
-    const gfx::Point offset = gfx::Point(tileSize.w / 2, tileSize.h / 2 - font->height() / 2) +
+    const gfx::Point offset = gfx::Point(tileSize.w / 2, tileSize.h / 2 - font->size() / 2) +
                               mainTilePosition();
 
     int ti_offset = static_cast<LayerTilemap*>(cel->layer())->tileset()->baseIndex() - 1;

--- a/src/app/ui/editor/select_text_box_state.cpp
+++ b/src/app/ui/editor/select_text_box_state.cpp
@@ -64,8 +64,8 @@ void SelectTextBoxState::onQuickboxEnd(Editor* editor, const gfx::Rect& rect0, u
   if (rect.w <= 3 || rect.h <= 3) {
     FontInfo fontInfo = App::instance()->contextBar()->fontInfo();
     if (auto font = Fonts::instance()->fontFromInfo(fontInfo)) {
-      rect.w = std::min(4 * font->height(), editor->sprite()->width());
-      rect.h = font->height();
+      rect.w = std::min<float>(4 * std::ceil(font->size()), editor->sprite()->width());
+      rect.h = std::ceil(font->size());
     }
   }
 

--- a/src/app/ui/editor/writing_text_state.cpp
+++ b/src/app/ui/editor/writing_text_state.cpp
@@ -31,6 +31,7 @@
 #include "render/dithering.h"
 #include "render/quantization.h"
 #include "render/render.h"
+#include "text/font_metrics.h"
 #include "ui/entry.h"
 #include "ui/message.h"
 #include "ui/paint_event.h"
@@ -131,6 +132,13 @@ private:
       }
     }
     return Entry::onProcessMessage(msg);
+  }
+
+  float onGetTextBaseline() const override
+  {
+    text::FontMetrics metrics;
+    font()->metrics(&metrics);
+    return scale().y * -metrics.ascent;
   }
 
   void onInitTheme(InitThemeEvent& ev) override

--- a/src/app/ui/font_entry.h
+++ b/src/app/ui/font_entry.h
@@ -62,6 +62,7 @@ private:
   class FontSize : public ui::ComboBox {
   public:
     FontSize();
+    void updateForFont(const FontInfo& info);
 
   protected:
     void onEntryChange() override;

--- a/src/app/ui/news_listbox.cpp
+++ b/src/app/ui/news_listbox.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2020-2024  Igara Studio S.A.
+// Copyright (C) 2020-2025  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This program is distributed under the terms of
@@ -20,6 +20,7 @@
 #include "base/fs.h"
 #include "base/string.h"
 #include "base/time.h"
+#include "text/font_metrics.h"
 #include "ui/link_label.h"
 #include "ui/message.h"
 #include "ui/paint_event.h"
@@ -158,7 +159,6 @@ protected:
     auto theme = SkinTheme::get(this);
     ui::Style* style = theme->styles.newsItem();
 
-    setTextQuiet(m_title);
     gfx::Size sz = theme->calcSizeHint(this, style);
 
     if (!m_desc.empty()) {
@@ -177,15 +177,24 @@ protected:
     ui::Style* style = theme->styles.newsItem();
     ui::Style* styleDetail = theme->styles.newsItemDetail();
 
-    setTextQuiet(m_title);
+    text::FontMetrics metrics;
+    font()->metrics(&metrics);
+
     gfx::Size textSize = theme->calcSizeHint(this, style);
     gfx::Rect textBounds(bounds.x, bounds.y, bounds.w, textSize.h);
     gfx::Rect detailsBounds(bounds.x, bounds.y + textSize.h, bounds.w, bounds.h - textSize.h);
 
-    theme->paintWidget(g, this, style, textBounds);
+    gfx::Border border = theme->calcBorder(this, style);
+    gfx::Border borderDetail = theme->calcBorder(this, styleDetail);
 
-    setTextQuiet(m_desc);
-    theme->paintWidget(g, this, styleDetail, detailsBounds);
+    PaintWidgetPartInfo info(this);
+    info.text = &m_title;
+    info.baseline = border.top() - metrics.ascent;
+    theme->paintWidgetPart(g, style, bounds, info);
+
+    info.text = &m_desc;
+    info.baseline += border.bottom() + borderDetail.top() + metrics.descent - metrics.ascent;
+    theme->paintWidgetPart(g, styleDetail, detailsBounds, info);
   }
 
 private:

--- a/src/app/ui/palette_view.cpp
+++ b/src/app/ui/palette_view.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2024  Igara Studio S.A.
+// Copyright (C) 2018-2025  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -923,8 +923,8 @@ void PaletteView::onPaint(ui::PaintEvent& ev)
         g->drawText(text,
                     negColor,
                     gfx::ColorNone,
-                    gfx::Point(box2.x + box2.w / 2 - minifont->textLength(text) / 2,
-                               box2.y + box2.h / 2 - minifont->height() / 2));
+                    gfx::Point(guiscaled_center(box2.x, box2.w, minifont->textLength(text)),
+                               guiscaled_center(box2.y, box2.h, minifont->lineHeight())));
       }
 
       // Draw the selection

--- a/src/app/ui/resources_listbox.cpp
+++ b/src/app/ui/resources_listbox.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2020-2024  Igara Studio S.A.
+// Copyright (C) 2020-2025  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -63,11 +63,11 @@ void ResourceListItem::onPaint(PaintEvent& ev)
 
   static_cast<ResourcesListBox*>(parent())->paintResource(g, bounds, m_resource.get());
 
-  g->drawText(
-    text(),
-    fgcolor,
-    gfx::ColorNone,
-    gfx::Point(bounds.x + 2 * guiscale(), bounds.y + bounds.h / 2 - g->font()->height() / 2));
+  g->drawText(text(),
+              fgcolor,
+              gfx::ColorNone,
+              gfx::Point(bounds.x + 2 * guiscale(),
+                         guiscaled_center(bounds.y, bounds.h, g->font()->lineHeight())));
 }
 
 void ResourceListItem::onSizeHint(SizeHintEvent& ev)

--- a/src/app/ui/skin/skin_theme.cpp
+++ b/src/app/ui/skin/skin_theme.cpp
@@ -439,7 +439,7 @@ void SkinTheme::loadXml(BackwardCompatibility* backward)
         std::string id(idStr);
         LOG(VERBOSE, "THEME: Loading theme font %s\n", idStr);
 
-        int size = 10;
+        int size = 0;
         const char* sizeStr = xmlFont->Attribute("size");
         if (sizeStr)
           size = std::strtol(sizeStr, nullptr, 10);
@@ -447,12 +447,19 @@ void SkinTheme::loadXml(BackwardCompatibility* backward)
         const char* mnemonicsStr = xmlFont->Attribute("mnemonics");
         bool mnemonics = mnemonicsStr ? (std::string(mnemonicsStr) != "off") : true;
 
-        text::FontRef font = fontData->getFont(m_fontMgr, size);
+        text::FontRef font = fontData->getFont(m_fontMgr, size * ui::guiscale());
+
+        // SpriteSheetFonts have a default preferred size.
+        if (size == 0 && font->defaultSize() > 0.0f) {
+          size = font->defaultSize();
+          font = fontData->getFont(m_fontMgr, size * ui::guiscale());
+        }
+
         m_themeFonts[idStr] = ThemeFont(font, mnemonics);
 
         // Store a unscaled version for using when ui scaling is not desired (i.e. in a Canvas
         // widget with autoScaling enabled).
-        m_unscaledFonts[font.get()] = fontData->getFont(m_fontMgr, size, 1);
+        m_unscaledFonts[font.get()] = fontData->getFont(m_fontMgr, size);
 
         if (id == "default")
           m_defaultFont = font;

--- a/src/app/ui/status_bar.cpp
+++ b/src/app/ui/status_bar.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2023  Igara Studio S.A.
+// Copyright (C) 2018-2025  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -136,7 +136,7 @@ class StatusBar::Indicators : public HBox {
         g->drawText(text(),
                     textColor,
                     ColorNone,
-                    Point(rc.x, rc.y + rc.h / 2 - font()->height() / 2));
+                    Point(rc.x, guiscaled_center(rc.y, rc.h, font()->lineHeight())));
       }
     }
   };
@@ -180,10 +180,12 @@ class StatusBar::Indicators : public HBox {
       os::Surface* icon = m_part->bitmap(0);
 
       g->fillRect(bgColor(), rc);
+
+      const int y = guiscaled_center(rc.y, rc.h, icon->height());
       if (m_colored)
-        g->drawColoredRgbaSurface(icon, textColor, rc.x, rc.y + rc.h / 2 - icon->height() / 2);
+        g->drawColoredRgbaSurface(icon, textColor, rc.x, y);
       else
-        g->drawRgbaSurface(icon, rc.x, rc.y + rc.h / 2 - icon->height() / 2);
+        g->drawRgbaSurface(icon, rc.x, y);
     }
 
     skin::SkinPartPtr m_part;

--- a/src/app/ui/tabs.cpp
+++ b/src/app/ui/tabs.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2024  Igara Studio S.A.
+// Copyright (C) 2018-2025  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This program is distributed under the terms of
@@ -19,6 +19,7 @@
 #include "os/surface.h"
 #include "os/system.h"
 #include "text/font.h"
+#include "text/font_metrics.h"
 #include "ui/intern.h"
 #include "ui/ui.h"
 
@@ -472,6 +473,9 @@ void Tabs::onInitTheme(ui::InitThemeEvent& ev)
     setStyle(theme->styles.mainTabs());
   }
 
+  // TODO hardcoded 1.5f scalar
+  m_tabsHeight = std::max<float>(m_tabsHeight, 1.5f * textHeight());
+
   for (TabPtr& tab : m_list) {
     tab->textBlob = nullptr;
   }
@@ -555,6 +559,15 @@ void Tabs::onSizeHint(SizeHintEvent& ev)
   ev.setSizeHint(gfx::Size(0, m_tabsHeight));
 }
 
+float Tabs::onGetTextBaseline() const
+{
+  gfx::Rect box(0, 0, 1, m_tabsHeight - m_tabsBottomHeight);
+  text::FontMetrics metrics;
+  font()->metrics(&metrics);
+  const float textHeight = metrics.descent - metrics.ascent;
+  return guiscaled_center(box.y, box.h, textHeight) - metrics.ascent;
+}
+
 void Tabs::selectTabInternal(TabPtr& tab)
 {
   if (m_selected != tab) {
@@ -588,6 +601,7 @@ void Tabs::drawTab(Graphics* g, const gfx::Rect& _box, Tab* tab, int dy, bool ho
   PaintWidgetPartInfo info;
   info.styleFlags = (selected ? ui::Style::Layer::kFocus : 0) |
                     (hover ? ui::Style::Layer::kMouse : 0);
+  info.baseline = textBaseline();
   theme->paintWidgetPart(g, theme->styles.tab(), gfx::Rect(box.x, box.y + dy, box.w, box.h), info);
 
   gfx::Color tabColor = tab->color;

--- a/src/app/ui/tabs.h
+++ b/src/app/ui/tabs.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2024  Igara Studio S.A.
+// Copyright (C) 2019-2025  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -187,6 +187,7 @@ protected:
   void onPaint(ui::PaintEvent& ev) override;
   void onResize(ui::ResizeEvent& ev) override;
   void onSizeHint(ui::SizeHintEvent& ev) override;
+  float onGetTextBaseline() const override;
   void onAnimationFrame() override;
   void onAnimationStop(int animation) override;
 

--- a/src/app/ui/timeline/timeline.cpp
+++ b/src/app/ui/timeline/timeline.cpp
@@ -60,6 +60,7 @@
 #include "os/surface.h"
 #include "os/system.h"
 #include "text/font.h"
+#include "text/font_metrics.h"
 #include "ui/ui.h"
 #include "view/layers.h"
 #include "view/timeline_adapter.h"
@@ -2164,6 +2165,11 @@ void Timeline::drawPart(ui::Graphics* g,
                     (is_clicked ? ui::Style::Layer::kSelected : 0) |
                     (is_disabled ? ui::Style::Layer::kDisabled : 0);
 
+  text::FontMetrics metrics;
+  font()->metrics(&metrics);
+  info.baseline = guiscaled_center(bounds.y, bounds.h, metrics.descent - metrics.ascent) -
+                  metrics.ascent;
+
   theme()->paintWidgetPart(g, style, bounds, info);
 }
 
@@ -2663,9 +2669,11 @@ void Timeline::drawTags(ui::Graphics* g)
   SkinTheme* theme = skinTheme();
   auto& styles = theme->styles;
 
-  g->fillRect(
-    theme->colors.workspace(),
-    gfx::Rect(0, font()->height(), clientBounds().w, theme->dimensions.timelineTagsAreaHeight()));
+  g->fillRect(theme->colors.workspace(),
+              gfx::Rect(0,
+                        font()->lineHeight(),
+                        clientBounds().w,
+                        theme->dimensions.timelineTagsAreaHeight()));
 
   // Draw active frame tag band
   if (m_hot.band >= 0 && m_tagBands > 1 && m_tagFocusBand < 0) {
@@ -3107,11 +3115,11 @@ gfx::Rect Timeline::getPartBounds(const Hit& hit) const
         gfx::Rect bounds = bounds1.createUnion(bounds2);
         bounds.y -= skinTheme()->dimensions.timelineTagsAreaHeight();
 
-        int textHeight = font()->height();
+        int textHeight = font()->lineHeight();
         bounds.y -= textHeight + 2 * ui::guiscale();
         bounds.x += 3 * ui::guiscale();
         bounds.w = font()->textLength(tag->name().c_str()) + 4 * ui::guiscale();
-        bounds.h = font()->height() + 2 * ui::guiscale();
+        bounds.h = font()->lineHeight() + 2 * ui::guiscale();
 
         if (m_tagFocusBand < 0) {
           auto it = m_tagBand.find(tag);
@@ -4311,7 +4319,8 @@ int Timeline::outlineWidth() const
 
 int Timeline::oneTagHeight() const
 {
-  return font()->height() + 2 * ui::guiscale() + skinTheme()->dimensions.timelineTagsAreaHeight();
+  return font()->lineHeight() + 2 * ui::guiscale() +
+         skinTheme()->dimensions.timelineTagsAreaHeight();
 }
 
 double Timeline::zoom() const

--- a/src/app/util/render_text.cpp
+++ b/src/app/util/render_text.cpp
@@ -49,12 +49,8 @@ public:
   {
     ASSERT(info.font);
     if (info.clusters && info.glyphCount > 0) {
-      const float height = info.font->metrics(nullptr);
-
-      for (int i = 0; i < info.glyphCount; ++i) {
-        auto rc = info.getGlyphBounds(i);
-        m_bounds |= gfx::RectF(rc.x, 0, rc.w, height);
-      }
+      for (int i = 0; i < info.glyphCount; ++i)
+        m_bounds |= info.getGlyphBounds(i);
     }
   }
 
@@ -64,20 +60,6 @@ private:
 
 } // anonymous namespace
 
-text::TextBlobRef create_text_blob(const FontInfo& fontInfo, const std::string& text)
-{
-  Fonts* fonts = Fonts::instance();
-  ASSERT(fonts);
-  if (!fonts)
-    return nullptr;
-
-  const text::FontRef font = fonts->fontFromInfo(fontInfo);
-  if (!font)
-    return nullptr;
-
-  return text::TextBlob::MakeWithShaper(fonts->fontMgr(), font, text);
-}
-
 gfx::Size get_text_blob_required_size(const text::TextBlobRef& blob)
 {
   ASSERT(blob != nullptr);
@@ -86,7 +68,6 @@ gfx::Size get_text_blob_required_size(const text::TextBlobRef& blob)
   blob->visitRuns([&bounds](text::TextBlob::RunInfo& run) {
     for (int i = 0; i < run.glyphCount; ++i) {
       bounds |= run.getGlyphBounds(i);
-      bounds |= gfx::RectF(0, 0, 1, run.font->metrics(nullptr));
     }
   });
   if (bounds.w < 1)

--- a/src/app/util/render_text.h
+++ b/src/app/util/render_text.h
@@ -11,7 +11,6 @@
 
 #include "doc/image_ref.h"
 #include "gfx/color.h"
-#include "text/font_mgr.h"
 #include "text/text_blob.h"
 
 #include <string>
@@ -23,8 +22,6 @@ class FontInfo;
 namespace skin {
 class SkinTheme;
 }
-
-text::TextBlobRef create_text_blob(const FontInfo& fontInfo, const std::string& text);
 
 // Returns the exact bounds that are required to draw this TextBlob,
 // i.e. the image size that will be required in render_text_blob().

--- a/src/ui/entry.cpp
+++ b/src/ui/entry.cpp
@@ -507,7 +507,7 @@ gfx::Size Entry::sizeHintWithText(Entry* entry, const std::string& text)
 
   w = std::min(w, entry->display()->workareaSizeUIScale().w / 2);
 
-  const int h = +font->height() + entry->border().height();
+  const int h = font->lineHeight() + entry->border().height();
 
   return gfx::Size(w, h);
 }
@@ -523,7 +523,7 @@ void Entry::onSizeHint(SizeHintEvent& ev)
 
   w = std::min(w, display()->workareaSizeUIScale().w / 2);
 
-  int h = +font->height() + border().height();
+  int h = font->lineHeight() + border().height();
 
   ev.setSizeHint(w, h);
 }

--- a/src/ui/graphics.h
+++ b/src/ui/graphics.h
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2019-2024  Igara Studio S.A.
+// Copyright (C) 2019-2025  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -73,9 +73,11 @@ public:
   void drawVLine(int x, int y, int h, const Paint& paint);
   void drawVLine(gfx::Color color, int x, int y, int h);
   void drawLine(gfx::Color color, const gfx::Point& a, const gfx::Point& b);
+  void drawLine(const gfx::PointF& a, const gfx::PointF& b, const Paint& paint);
   void drawPath(gfx::Path& path, const Paint& paint);
 
   void drawRect(const gfx::Rect& rc, const Paint& paint);
+  void drawRect(const gfx::RectF& rc, const Paint& paint);
   void drawRect(gfx::Color color, const gfx::Rect& rc);
   void fillRect(gfx::Color color, const gfx::Rect& rc);
   void fillRegion(gfx::Color color, const gfx::Region& rgn);
@@ -113,15 +115,16 @@ public:
   void setFont(const text::FontRef& font);
 
   [[deprecated]]
-  void drawText(const std::string& str,
-                gfx::Color fg,
-                gfx::Color bg,
-                const gfx::Point& pt,
-                text::DrawTextDelegate* delegate = nullptr,
-                text::ShaperFeatures features = {});
+  void drawTextWithDelegate(const std::string& str,
+                            gfx::Color fg,
+                            gfx::Color bg,
+                            const gfx::Point& pt,
+                            text::DrawTextDelegate* delegate = nullptr,
+                            text::ShaperFeatures features = {});
 
   void drawTextBlob(const text::TextBlobRef& textBlob, const gfx::PointF& pt, const Paint& paint);
 
+  void drawText(const std::string& str, gfx::Color fg, gfx::Color bg, const gfx::Point& pt);
   void drawUIText(const std::string& str,
                   gfx::Color fg,
                   gfx::Color bg,

--- a/src/ui/theme.h
+++ b/src/ui/theme.h
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2020-2024  Igara Studio S.A.
+// Copyright (C) 2020-2025  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -17,6 +17,7 @@
 #include "text/fwd.h"
 #include "ui/base.h"
 #include "ui/cursor_type.h"
+#include "ui/paint.h"
 #include "ui/style.h"
 
 namespace gfx {
@@ -41,12 +42,13 @@ void set_theme(Theme* theme, const int uiscale);
 Theme* get_theme();
 
 struct PaintWidgetPartInfo {
-  gfx::Color bgColor;
-  int styleFlags; // ui::Style::Layer flags
-  const std::string* text;
+  gfx::Color bgColor = gfx::ColorNone;
+  int styleFlags = 0; // ui::Style::Layer flags
+  const std::string* text = nullptr;
   text::TextBlobRef textBlob;
-  int mnemonic;
-  os::Surface* icon;
+  float baseline = 0.0f;
+  int mnemonic = 0;
+  os::Surface* icon = nullptr;
 
   PaintWidgetPartInfo();
   PaintWidgetPartInfo(const Widget* widget);
@@ -142,6 +144,13 @@ public:
                           gfx::Color bg,
                           gfx::Color fg);
 
+  static void drawMnemonicUnderline(Graphics* g,
+                                    const std::string& text,
+                                    text::TextBlobRef textBlob,
+                                    const gfx::PointF& pt,
+                                    const int mnemonic,
+                                    const Paint& paint);
+
   static ui::Style* EmptyStyle() { return &m_emptyStyle; }
 
 protected:
@@ -155,7 +164,8 @@ private:
                   const Style* style,
                   const Style::Layer& layer,
                   const std::string& text,
-                  const text::TextBlobRef& textBlob,
+                  text::TextBlobRef textBlob,
+                  const float baseline,
                   const int mnemonic,
                   os::Surface* icon,
                   gfx::Rect& rc,

--- a/src/ui/widget.h
+++ b/src/ui/widget.h
@@ -288,6 +288,10 @@ public:
                        int icon_w = 0,
                        int icon_h = 0);
 
+  // Y-axis location where the text baseline should be located in the
+  // middle of the widget.
+  float textBaseline() const;
+
   // ===============================================================
   // REFRESH ISSUES
   // ===============================================================
@@ -435,6 +439,7 @@ protected:
   virtual double onGetTextDouble() const;
   virtual text::TextBlobRef onMakeTextBlob() const;
   virtual text::ShaperFeatures onGetTextShaperFeatures() const;
+  virtual float onGetTextBaseline() const;
 
   virtual void onDragEnter(DragEvent& e);
   virtual void onDragLeave(DragEvent& e);


### PR DESCRIPTION
There are several problems using TTF fonts:

* Missing underlined mnemonics on menus:
  ![image](https://github.com/user-attachments/assets/f4fc8fc3-1659-40ff-8834-1472895e6d3a)

* Incorrect underlined placement for button mnemonics:
  ![image](https://github.com/user-attachments/assets/fec74597-ca1f-403c-be27-a3a264f735d8)

* Misalignment with baseline on entry fields:
  ![image](https://github.com/user-attachments/assets/bd98bc61-da25-41cb-a542-26cdaa84a8c7)

This PR tries to fix these and other issues related to the correct alignment of text using multiple fonts (sprite sheet font + TTF fonts + emojis).

![image](https://github.com/user-attachments/assets/7287c24d-1a20-449b-aba3-60087f4e9e01)
![image](https://github.com/user-attachments/assets/58209abe-6c68-4ef6-88f4-c830396f5c68)
![image](https://github.com/user-attachments/assets/74d24e5e-3d03-4809-a6f5-621a60397b26)

![image](https://github.com/user-attachments/assets/2f07dcf9-382c-4ba8-bc41-a92c5e9bc607)
![image](https://github.com/user-attachments/assets/310b30f6-c687-4213-aee1-82a0abf9ff06)
![image](https://github.com/user-attachments/assets/376997b4-4fce-43fb-81c5-57c72f917d9c)

