### PR TITLE
fix build.sh input acceptance for build type

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -265,7 +265,7 @@ else
     # New build
     if [[ "$build_n" == "n" || "$build_n" == "N" ]] ; then
         read -p "Select build type [RELEASE/debug]? "
-        if [[ "${REPLY,,}" == "debug" ]] ; then
+        if [[ "${REPLY}" == "debug" ]] ; then
             build_type=Debug
             new_build_name=aseprite-debug
         else


### PR DESCRIPTION
Disclaimer:
------------
<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the Individual Contributor License Agreement V4.0. -->
<!-- If you're a first-time contributor, please sign the CLA
     as indicated in https://github.com/igarastudio/cla#signing
     and acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing



Description of the fix:
----------------------
While attempting to build an executable using the `build.sh` script included in the repo I found that it crashed constantly during installation because it couldn't assign the input I've provided at the release type prompt for the user.
I looked into the script and quickly found that line (see '_File changed_' for reference) that didn't look right to me - I modified it and tried again - worked perfectly! like it should.