### PR TITLE
Startup optimizations

### DIFF
--- a/src/app/ui/dithering_selector.cpp
+++ b/src/app/ui/dithering_selector.cpp
@@ -180,7 +180,6 @@ DitheringSelector::DitheringSelector(Type type) : m_type(type)
   m_extChanges = extensions.DitheringMatricesChange.connect([this] { regenerate(); });
 
   setUseCustomWidget(true);
-  regenerate();
 }
 
 void DitheringSelector::onInitTheme(ui::InitThemeEvent& ev)
@@ -188,6 +187,16 @@ void DitheringSelector::onInitTheme(ui::InitThemeEvent& ev)
   ComboBox::onInitTheme(ev);
   if (getItem(0))
     setSizeHint(calcItemSizeHint(0));
+}
+
+void DitheringSelector::onVisible(bool visible)
+{
+  if (visible && !m_initialized) {
+    // Only do the expensive regeneration when we're set as visible for the first time.
+    regenerate();
+    m_initialized = true;
+  }
+  ComboBox::onVisible(visible);
 }
 
 void DitheringSelector::setSelectedItemByName(const std::string& name)

--- a/src/app/ui/dithering_selector.h
+++ b/src/app/ui/dithering_selector.h
@@ -31,6 +31,7 @@ public:
 
 protected:
   void onInitTheme(ui::InitThemeEvent& ev) override;
+  void onVisible(bool visible) override;
 
 private:
   void regenerate(int selectedItemIndex = 0);
@@ -38,6 +39,7 @@ private:
 
   Type m_type;
   obs::scoped_connection m_extChanges;
+  bool m_initialized = false;
 };
 
 } // namespace app

--- a/src/app/ui/main_menu_bar.h
+++ b/src/app/ui/main_menu_bar.h
@@ -18,11 +18,13 @@ class MainMenuBar : public ui::MenuBar {
 public:
   MainMenuBar();
 
+  void queueReload();
   void reload();
 
 private:
   obs::scoped_connection m_extKeys;
   obs::scoped_connection m_extScripts;
+  bool m_queuedReload = false;
 };
 
 } // namespace app

--- a/src/ui/manager.cpp
+++ b/src/ui/manager.cpp
@@ -196,6 +196,10 @@ Manager::Manager(const os::WindowRef& nativeWindow)
   , m_lockedWindow(nullptr)
   , m_mouseButton(kButtonNone)
 {
+  // The native window can be nullptr when running tests
+  if (nativeWindow)
+    nativeWindow->setUserData(&m_display);
+
   ASSERT(manager_thread == std::thread::id());
   manager_thread = std::this_thread::get_id();
 
@@ -237,13 +241,10 @@ Manager::Manager(const os::WindowRef& nativeWindow)
   // TODO check if this is needed
   onNewDisplayConfiguration(&m_display);
 
-  // The native window can be nullptr when running tests
   if (nativeWindow) {
-    nativeWindow->setUserData(&m_display);
-
     // Setting the drag target has a slight performance cost that we can offset by running it later.
     auto* callbackMessage = new CallbackMessage(
-      [&, nativeWindow] { nativeWindow->setDragTarget(this); });
+      [this, nativeWindow] { nativeWindow->setDragTarget(this); });
     callbackMessage->setRecipient(this);
     enqueueMessage(callbackMessage);
   }

--- a/src/ui/manager.cpp
+++ b/src/ui/manager.cpp
@@ -196,12 +196,6 @@ Manager::Manager(const os::WindowRef& nativeWindow)
   , m_lockedWindow(nullptr)
   , m_mouseButton(kButtonNone)
 {
-  // The native window can be nullptr when running tests
-  if (nativeWindow) {
-    nativeWindow->setUserData(&m_display);
-    nativeWindow->setDragTarget(this);
-  }
-
   ASSERT(manager_thread == std::thread::id());
   manager_thread = std::this_thread::get_id();
 
@@ -242,6 +236,17 @@ Manager::Manager(const os::WindowRef& nativeWindow)
 
   // TODO check if this is needed
   onNewDisplayConfiguration(&m_display);
+
+  // The native window can be nullptr when running tests
+  if (nativeWindow) {
+    nativeWindow->setUserData(&m_display);
+
+    // Setting the drag target has a slight performance cost that we can offset by running it later.
+    auto* callbackMessage = new CallbackMessage(
+      [&, nativeWindow] { nativeWindow->setDragTarget(this); });
+    callbackMessage->setRecipient(this);
+    enqueueMessage(callbackMessage);
+  }
 }
 
 Manager::~Manager()


### PR DESCRIPTION
When investigating #5018 I came across some opportunities to do some optimization to startup times, in most cases by delaying more expensive operations, which results in better perceived performance (time before seeing the window).

Haven't measured exact impact yet (hence the draft), but the DitheringSelector especially was especially taking up most of the initialization time of the main window:
![image](https://github.com/user-attachments/assets/37214eb1-ce13-4704-b378-03d47e98af4b)

Delaying initialization until the widget is visible removes even the initialize() function from the flamegraph. In theory we could apply more of these delayed initializations to other widgets and tools on a case-by-case basis, especially things that involve going through files.