### PR TITLE
Add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 for cmake compatibility

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -143,7 +143,7 @@ And then
     cd aseprite
     mkdir build
     cd build
-    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DLAF_BACKEND=skia -DSKIA_DIR=C:\deps\skia -DSKIA_LIBRARY_DIR=C:\deps\skia\out\Release-x64 -DSKIA_LIBRARY=C:\deps\skia\out\Release-x64\skia.lib -G Ninja ..
+    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DLAF_BACKEND=skia -DSKIA_DIR=C:\deps\skia -DSKIA_LIBRARY_DIR=C:\deps\skia\out\Release-x64 -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DSKIA_LIBRARY=C:\deps\skia\out\Release-x64\skia.lib -G Ninja ..
     ninja aseprite
 
 In this case, `C:\deps\skia` is the directory where Skia was compiled


### PR DESCRIPTION
I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing

This PR fixes a compilation issue that occurs during the installation phase when using CMake versions above 3.5. Running the following command:
```
cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DLAF_BACKEND=skia -DSKIA_DIR=C:\deps\skia -DSKIA_LIBRARY_DIR=C:\deps\skia\out\Release-x64 -DSKIA_LIBRARY=C:\deps\skia\out\Release-x64\skia.lib -G Ninja ..
```

Results in a CMake error, causing the installation process to fail.
To maintain backward compatibility and prevent this error, we add the flag: `-DCMAKE_POLICY_VERSION_MINIMUM=3.5`

Error Message:
<img width="811" alt="CMake_Windows_Fix" src="https://github.com/user-attachments/assets/a86714d1-0fb7-4ff6-aaee-5c30214dc462" />



