### PR TITLE
Fix timeline's vertical scrolling behavior

### DIFF
--- a/src/app/commands/cmd_new_layer.cpp
+++ b/src/app/commands/cmd_new_layer.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2024  Igara Studio S.A.
+// Copyright (C) 2019-2025  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -268,11 +268,15 @@ void NewLayerCommand::onExecute(Context* context)
 
     switch (m_type) {
       case Type::Layer:
-        layer = api.newLayer(parent, name);
-        if (m_place == Place::BeforeActiveLayer)
+
+        if (m_place == Place::BeforeActiveLayer) {
+          layer = api.newLayer(parent, name);
           api.restackLayerBefore(layer, parent, activeLayer);
+        }
+        else
+          layer = api.newLayerAfter(parent, name, activeLayer);
         break;
-      case Type::Group: layer = api.newGroup(parent, name); break;
+      case Type::Group: layer = api.newGroupAfter(parent, name, activeLayer); break;
       case Type::ReferenceLayer:
         layer = api.newLayer(parent, name);
         if (layer)
@@ -296,9 +300,7 @@ void NewLayerCommand::onExecute(Context* context)
           tsi = tilesetInfo.tsi;
         }
 
-        layer = new LayerTilemap(sprite, tsi);
-        layer->setName(name);
-        api.addLayer(parent, layer, parent->lastLayer());
+        layer = api.newTilemapAfter(parent, name, tsi, activeLayer);
         break;
       }
     }
@@ -319,10 +321,6 @@ void NewLayerCommand::onExecute(Context* context)
         else
           api.restackLayerBefore(layer, sprite->root(), first);
       }
-    }
-    // Move the layer above the active one.
-    else if (activeLayer && m_place == Place::AfterActiveLayer) {
-      api.restackLayerAfter(layer, activeLayer->parent(), activeLayer);
     }
 
     // Put all selected layers inside the group

--- a/src/app/doc_api.cpp
+++ b/src/app/doc_api.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2024  Igara Studio S.A.
+// Copyright (C) 2019-2025  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -52,6 +52,7 @@
 #include "doc/algorithm/flip_image.h"
 #include "doc/algorithm/shrink_bounds.h"
 #include "doc/cel.h"
+#include "doc/layer_tilemap.h"
 #include "doc/mask.h"
 #include "doc/palette.h"
 #include "doc/slice.h"
@@ -605,6 +606,18 @@ LayerImage* DocApi::newLayer(LayerGroup* parent, const std::string& name)
   return newLayer;
 }
 
+LayerImage* DocApi::newLayerAfter(LayerGroup* parent, const std::string& name, Layer* afterThis)
+{
+  LayerImage* newLayer = new LayerImage(parent->sprite());
+  newLayer->setName(name);
+
+  if (!afterThis)
+    afterThis = parent->lastLayer();
+
+  addLayer(parent, newLayer, afterThis);
+  return newLayer;
+}
+
 LayerGroup* DocApi::newGroup(LayerGroup* parent, const std::string& name)
 {
   LayerGroup* newLayerGroup = new LayerGroup(parent->sprite());
@@ -612,6 +625,33 @@ LayerGroup* DocApi::newGroup(LayerGroup* parent, const std::string& name)
 
   addLayer(parent, newLayerGroup, parent->lastLayer());
   return newLayerGroup;
+}
+
+LayerGroup* DocApi::newGroupAfter(LayerGroup* parent, const std::string& name, Layer* afterThis)
+{
+  LayerGroup* newLayerGroup = new LayerGroup(parent->sprite());
+  newLayerGroup->setName(name);
+
+  if (!afterThis)
+    afterThis = parent->lastLayer();
+
+  addLayer(parent, newLayerGroup, afterThis);
+  return newLayerGroup;
+}
+
+LayerTilemap* DocApi::newTilemapAfter(LayerGroup* parent,
+                                      const std::string& name,
+                                      tileset_index tsi,
+                                      Layer* afterThis)
+{
+  LayerTilemap* newTilemap = new LayerTilemap(parent->sprite(), tsi);
+  newTilemap->setName(name);
+
+  if (!afterThis)
+    afterThis = parent->lastLayer();
+
+  addLayer(parent, newTilemap, afterThis);
+  return newTilemap;
 }
 
 void DocApi::addLayer(LayerGroup* parent, Layer* newLayer, Layer* afterThis)

--- a/src/app/doc_api.h
+++ b/src/app/doc_api.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2024  Igara Studio S.A.
+// Copyright (C) 2019-2025  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -15,6 +15,7 @@
 #include "doc/color.h"
 #include "doc/frame.h"
 #include "doc/image_ref.h"
+#include "doc/tile.h"
 #include "gfx/rect.h"
 
 #include <map>
@@ -26,6 +27,7 @@ class Image;
 class Layer;
 class LayerGroup;
 class LayerImage;
+class LayerTilemap;
 class Mask;
 class Palette;
 class Sprite;
@@ -104,7 +106,13 @@ public:
 
   // Layers API
   LayerImage* newLayer(LayerGroup* parent, const std::string& name);
+  LayerImage* newLayerAfter(LayerGroup* parent, const std::string& name, Layer* afterThis);
   LayerGroup* newGroup(LayerGroup* parent, const std::string& name);
+  LayerGroup* newGroupAfter(LayerGroup* parent, const std::string& name, Layer* afterThis);
+  LayerTilemap* newTilemapAfter(LayerGroup* parent,
+                                const std::string& name,
+                                tileset_index tsi,
+                                Layer* afterThis);
   void addLayer(LayerGroup* parent, Layer* newLayer, Layer* afterThis);
   void removeLayer(Layer* layer);
   void restackLayerAfter(Layer* layer, LayerGroup* parent, Layer* afterThis);


### PR DESCRIPTION
Fixes #4930 by avoiding re-stacking of layers. 
The issue was that the new layer was being added as the last layer first, which fired some notifications and made the timeline update its vertical scroll to make the new layer visible, then a re-stack of layers was being done to put the new layer in the correct position inside the list of layers, firing some notifications again making the timeline to update its vertical scroll again. 

The solution in this PR introduced some new methods in DocApi to allow creating a layer after a specified layer directly, thus avoiding the steps of adding it as the last layer first and re-stack the layers then.
