### PR TITLE
Prioritize mouse wheel zooming with quick zoom tool

### DIFF
--- a/src/app/ui/editor/state_with_wheel_behavior.cpp
+++ b/src/app/ui/editor/state_with_wheel_behavior.cpp
@@ -74,7 +74,11 @@ bool StateWithWheelBehavior::onMouseWheel(Editor* editor, MouseMessage* msg)
   double dz = delta.x + delta.y;
   WheelAction wheelAction = WheelAction::None;
 
-  if (KeyboardShortcuts::instance()->hasMouseWheelCustomization()) {
+  if (tools::Tool* quickTool = App::instance()->activeToolManager()->quickTool();
+      quickTool && quickTool->getId() == tools::WellKnownInks::Zoom) {
+    wheelAction = WheelAction::Zoom;
+  }
+  else if (KeyboardShortcuts::instance()->hasMouseWheelCustomization()) {
     if (!Preferences::instance().editor.zoomWithSlide() && msg->preciseWheel())
       wheelAction = WheelAction::VScroll;
     else


### PR DESCRIPTION
<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the Individual Contributor License Agreement V4.0. -->
<!-- If you're a first-time contributor, please sign the CLA
     as indicated in https://github.com/igarastudio/cla#signing
     and acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing
(Not signed yet but submitted the form)

Fixes https://github.com/aseprite/aseprite/issues/2019

Before this PR: scrolling with "Zoom Tool (quick)" held down works if you assign it to a keyboard shortcut that's not used by anything else (e.g. "7"). However, scrolling if it's assigned to something like "Ctrl+Space" does not work, I think because this was line eating it:
https://github.com/aseprite/aseprite/blob/b3f4e37b69eb0ef907452624568f3bfc1f60d52d/src/app/ui/editor/state_with_wheel_behavior.cpp#L98-L101
