### PR TITLE
Allow the app to be closed when a PopupWindow is open in the foreground

### DIFF
--- a/src/ui/popup_window.h
+++ b/src/ui/popup_window.h
@@ -41,6 +41,8 @@ public:
   void setClickBehavior(ClickBehavior behavior);
   void setEnterBehavior(EnterBehavior behavior);
 
+  ClickBehavior getClickBehavior() { return m_clickBehavior; };
+
   void makeFloating();
   void makeFixed();
 


### PR DESCRIPTION
Adds a check when processing the `kCloseDisplayMessage` message that checks if the foreground window is a PopupWindow - specifically one that if interacted with would close (to preserve a way to make a fully modal popup window if necessary in future, but we could remove this if it's not desirable).

Fixes #5111
