### PR TITLE
Allow to use the close button when a popup window/menu box is displayed

### DIFF
--- a/src/ui/popup_window.cpp
+++ b/src/ui/popup_window.cpp
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2020-2021  Igara Studio S.A.
+// Copyright (C) 2020-2025  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -100,6 +100,11 @@ bool PopupWindow::onProcessMessage(Message* msg)
       break;
 
     case kCloseMessage: stopFilteringMessages(); break;
+
+    case kCloseDisplayMessage:
+      // Close the popup when the main native window (os::Window) is closed.
+      closeWindow(nullptr);
+      break;
 
     case kMouseLeaveMessage:
       if (m_hotRegion.isEmpty() && m_fixed)
@@ -205,6 +210,7 @@ void PopupWindow::startFilteringMessages()
     m_filtering = true;
 
     Manager* manager = Manager::getDefault();
+    manager->addMessageFilter(kCloseDisplayMessage, this);
     manager->addMessageFilter(kMouseMoveMessage, this);
     manager->addMessageFilter(kMouseDownMessage, this);
     manager->addMessageFilter(kKeyDownMessage, this);
@@ -217,6 +223,7 @@ void PopupWindow::stopFilteringMessages()
     m_filtering = false;
 
     Manager* manager = Manager::getDefault();
+    manager->removeMessageFilter(kCloseDisplayMessage, this);
     manager->removeMessageFilter(kMouseMoveMessage, this);
     manager->removeMessageFilter(kMouseDownMessage, this);
     manager->removeMessageFilter(kKeyDownMessage, this);


### PR DESCRIPTION
Fix #5111, related to #5134

This fixes works even for menus (like ink or palette menus) or menus inside popups like the brush options:

![image](https://github.com/user-attachments/assets/48fd2f14-7a7b-48b7-84a2-eeac42873edb)
