### PR TITLE
Fix marquee tool escape deselection

### DIFF
--- a/src/app/ui/editor/moving_pixels_state.cpp
+++ b/src/app/ui/editor/moving_pixels_state.cpp
@@ -477,13 +477,12 @@ bool MovingPixelsState::onKeyDown(Editor* editor, KeyMessage* msg)
 
   if (msg->scancode() == kKeyEnter || // TODO make this key customizable
       msg->scancode() == kKeyEnterPad || msg->scancode() == kKeyEsc) {
-    dropPixels();
-
-    // The escape key drop pixels and deselect the mask.
     if (msg->scancode() == kKeyEsc) { // TODO make this key customizable
-      Command* cmd = Commands::instance()->byId(CommandId::DeselectMask());
-      UIContext::instance()->executeCommandFromMenuOrShortcut(cmd);
+      m_pixelsMovement->discardImage(PixelsMovement::DontCommitChanges);
+      m_discarded = true;
     }
+
+    dropPixels();
 
     return true;
   }


### PR DESCRIPTION
This PR fixes an issue when pressing the escape key in the marquee tool. Instead of deselecting the selection, it should now undo the movement and match the functionality of the X button.

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing
