### PR TITLE
[cli] Add quotes to aseprite-thumbnailer

### DIFF
--- a/src/desktop/linux/aseprite-thumbnailer
+++ b/src/desktop/linux/aseprite-thumbnailer
@@ -9,11 +9,11 @@ if [ $# -ge 2 -a $# -lt 4 ]; then
   mkdir -p /tmp/Aseprite
   filename=${1//\//.}$RANDOM
   if [ $# -eq 2 ]; then
-    aseprite -b --frame-range "0,0" $1 --sheet /tmp/Aseprite/$filename.png
+    aseprite -b --frame-range "0,0" "$1" --sheet "/tmp/Aseprite/$filename.png"
   elif [ $# -eq 3 ]; then
-    aseprite -b --frame-range "0,0" $1 --shrink-to "$3,$3" --sheet /tmp/Aseprite/$filename.png
+    aseprite -b --frame-range "0,0" "$1" --shrink-to "$3,$3" --sheet "/tmp/Aseprite/$filename.png"
   fi
-  mkdir -p $(dirname "$2"); mv /tmp/Aseprite/$filename.png $2;
+  mkdir -p "$(dirname "$2")"; mv "/tmp/Aseprite/$filename.png" "$2";
 else
   echo "Parameters for aseprite thumbnailer are: inputfile outputfile [size]"
 fi


### PR DESCRIPTION
Without quotes, the thumbnailer could silently fail if the source or destination happens to have a space anywhere in the path, e.g. /home/myself/My Sprites/character.aseprite. The quotes help prevent this misunderstanding.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the Individual Contributor License Agreement V4.0. -->
<!-- If you're a first-time contributor, please sign the CLA
     as indicated in https://github.com/igarastudio/cla#signing
     and acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing
