### PR TITLE
Add "layerchange" event to Sprite, continuous event

### DIFF
--- a/src/app/doc.cpp
+++ b/src/app/doc.cpp
@@ -320,6 +320,13 @@ void Doc::notifyTilesetChanged(Tileset* tileset)
   notify_observers<DocEvent&>(&DocObserver::onTilesetChanged, ev);
 }
 
+void Doc::notifyLayerContinuousChange(Layer* layer)
+{
+  DocEvent ev(this);
+  ev.layer(layer);
+  notify_observers<DocEvent&>(&DocObserver::onLayerContinuousChange, ev);
+}
+
 void Doc::notifyLayerGroupCollapseChange(Layer* layer)
 {
   DocEvent ev(this);

--- a/src/app/doc.h
+++ b/src/app/doc.h
@@ -140,6 +140,7 @@ public:
   void notifySelectionBoundariesChanged();
   void notifyTilesetChanged(Tileset* tileset);
   void notifyLayerGroupCollapseChange(Layer* layer);
+  void notifyLayerContinuousChange(Layer* layer);
   void notifyAfterAddTile(LayerTilemap* layer, frame_t frame, tile_index ti);
 
   //////////////////////////////////////////////////////////////////////

--- a/src/app/doc_observer.h
+++ b/src/app/doc_observer.h
@@ -59,6 +59,7 @@ public:
   virtual void onLayerBlendModeChange(DocEvent& ev) {}
   virtual void onLayerRestacked(DocEvent& ev) {}
   virtual void onLayerMergedDown(DocEvent& ev) {}
+  virtual void onLayerContinuousChange(DocEvent& ev) {}
 
   virtual void onCelMoved(DocEvent& ev) {}
   virtual void onCelCopied(DocEvent& ev) {}
@@ -96,6 +97,9 @@ public:
 
   // The collapsed/expanded flag of a specific layer changed.
   virtual void onLayerCollapsedChanged(DocEvent& ev) {}
+
+  // The continuous flag of a specific layer changed.
+  virtual void onLayerContinuousChanged(DocEvent& ev) {}
 
   // The visibility flag of a specific layer is going to change/changed.
   virtual void onBeforeLayerVisibilityChange(DocEvent& ev, bool newState) {}

--- a/src/app/script/events_class.cpp
+++ b/src/app/script/events_class.cpp
@@ -358,6 +358,18 @@ private:
   obs::scoped_connection m_resizeConn;
 };
 
+// Layer Change events, TODO: Do we want this in a struct/script constant?
+const std::string kLayerChangeVisibility = "visibility";
+const std::string kLayerChangeAdded = "added";
+const std::string kLayerChangeRemoved = "removed";
+const std::string kLayerChangeEditable = "editable";
+const std::string kLayerChangeBlendMode = "blendmode";
+const std::string kLayerChangeCollapsed = "collapsed";
+const std::string kLayerChangeMergedDown = "mergeddown";
+const std::string kLayerChangeOpacity = "opacity";
+const std::string kLayerChangeRestacked = "restacked";
+const std::string kLayerChangeContinuous = "continuous";
+
 class SpriteEvents : public Events,
                      public DocUndoObserver,
                      public DocObserver {
@@ -370,6 +382,7 @@ public:
 #if ENABLE_REMAP_TILESET_EVENT
     RemapTileset,
 #endif
+    LayerChange,
   };
 
   SpriteEvents(const Sprite* sprite) : m_spriteId(sprite->id()) { doc()->add_observer(this); }
@@ -401,6 +414,8 @@ public:
     else if (std::strcmp(eventName, "remaptileset") == 0)
       return RemapTileset;
 #endif
+    else if (std::strcmp(eventName, "layerchange") == 0)
+      return LayerChange;
     else
       return Unknown;
   }
@@ -413,6 +428,106 @@ public:
     if (it != g_spriteEvents.end()) {
       // As this is an unique_ptr, here we are calling ~SpriteEvents()
       g_spriteEvents.erase(it);
+    }
+  }
+
+  void onAfterLayerVisibilityChange(DocEvent& ev) override
+  {
+    call(LayerChange,
+         {
+           { "layer", ev.layer()             },
+           { "type",  kLayerChangeVisibility }
+    });
+  }
+
+  void onAddLayer(DocEvent& ev) override
+  {
+    call(LayerChange,
+         {
+           { "layer", ev.layer()        },
+           { "type",  kLayerChangeAdded }
+    });
+  }
+
+  void onBeforeRemoveLayer(DocEvent& ev) override
+  {
+    call(LayerChange,
+         {
+           { "layer", ev.layer()          },
+           { "type",  kLayerChangeRemoved }
+    });
+  }
+
+  void onBeforeLayerEditableChange(DocEvent& ev, bool newState) override
+  {
+    call(LayerChange,
+         {
+           { "layer",    ev.layer()           },
+           { "type",     kLayerChangeEditable },
+           // TODO: Do we want to an "after" event to avoid this?
+           { "newState", newState             }
+    });
+  }
+
+  void onLayerContinuousChange(DocEvent& ev) override
+  {
+    call(LayerChange,
+         {
+           { "layer", ev.layer()             },
+           { "type",  kLayerChangeContinuous }
+    });
+  }
+
+  void onLayerBlendModeChange(DocEvent& ev) override
+  {
+    call(LayerChange,
+         {
+           { "layer", ev.layer()            },
+           { "type",  kLayerChangeBlendMode }
+    });
+  }
+  void onLayerCollapsedChanged(DocEvent& ev) override
+  {
+    call(LayerChange,
+         {
+           { "layer", ev.layer()            },
+           { "type",  kLayerChangeCollapsed }
+    });
+  }
+  void onLayerMergedDown(DocEvent& ev) override
+  {
+    call(LayerChange,
+         {
+           { "layer", ev.layer()             },
+           { "type",  kLayerChangeMergedDown }
+    });
+  }
+  void onLayerOpacityChange(DocEvent& ev) override
+  {
+    call(LayerChange,
+         {
+           { "layer", ev.layer()          },
+           { "type",  kLayerChangeOpacity }
+    });
+  }
+
+  void onLayerRestacked(DocEvent& ev) override
+  {
+    call(LayerChange,
+         {
+           { "layer", ev.layer()            },
+           { "type",  kLayerChangeRestacked }
+    });
+  }
+
+  void onLayerNameChange(DocEvent& ev) override
+  {
+    {
+      call(LayerChange,
+           {
+             { "layer", ev.layer() },
+             { "type",  "name"     }
+      });
     }
   }
 

--- a/src/app/ui/timeline/timeline.cpp
+++ b/src/app/ui/timeline/timeline.cpp
@@ -4709,6 +4709,7 @@ void Timeline::setLayerContinuousFlag(const layer_t l, const bool state)
 
   if (layer->isImage() && layer->isContinuous() != state) {
     layer->setContinuous(state);
+    m_document->notifyLayerContinuousChange(layer);
     invalidate();
   }
 }


### PR DESCRIPTION
Implements #5164, first draft. Could use some feedback on the API, tried to keep it as simple (and consistent) as possible, so I added a DocObserver event for the continuous mode.

Adds a `'layerchange'` event to `Sprite` with a given `event.type` that can be one of `visibility, added, removed, editable, blendmode, collapsed, mergeddown, opacity, restacked, continuous`.

Some of my doubts:
 * Right now changing the layer visibility for all layers by clicking the header sends an event for each layer, but doing this for `editable` or `continuous` doesn't, should I go ahead and change the timeline/event code for that, or would that have any unintended consequences?
 * As commented in the code, right now we only `onBeforeLayerEditableChange`, do we want to add `onAfterLayerEditableChange` or just expose things as they are?