### PR TITLE
Do not export every tag to JSON when there's one selected (#5085)

### DIFF
--- a/src/app/commands/cmd_export_sprite_sheet.cpp
+++ b/src/app/commands/cmd_export_sprite_sheet.cpp
@@ -273,6 +273,7 @@ Doc* generate_sprite_sheet_from_params(DocExporter& exporter,
   exporter.setSplitTags(splitTags);
   exporter.setIgnoreEmptyCels(ignoreEmpty);
   exporter.setMergeDuplicates(mergeDuplicates);
+  exporter.setSelectedTag(tagName);
   if (listLayers)
     exporter.setListLayers(true);
   if (listTags)

--- a/src/app/doc_exporter.cpp
+++ b/src/app/doc_exporter.cpp
@@ -1411,6 +1411,9 @@ void DocExporter::createDataFile(const Samples& samples, std::ostream& os, doc::
       includedSprites.insert(sprite->id());
 
       for (Tag* tag : sprite->tags()) {
+        if (!m_selectedTagName.empty() && m_selectedTagName != tag->name())
+          continue; // Ignore unselected tags if we picked a specific one.
+
         if (firstTag)
           firstTag = false;
         else
@@ -1421,12 +1424,21 @@ void DocExporter::createDataFile(const Samples& samples, std::ostream& os, doc::
           format = "{tag}";
         }
 
+        frame_t fromFrame = tag->fromFrame();
+        frame_t toFrame = tag->toFrame();
+        if (!m_selectedTagName.empty()) {
+          // Reset the frame offset when we're only exporting one frame tag so they're consistent
+          // with the exported frame list.
+          toFrame = toFrame - fromFrame;
+          fromFrame = 0;
+        }
+
         FilenameInfo fnInfo;
         fnInfo.filename(doc->filename()).innerTagName(tag->name());
         std::string tagname = filename_formatter(format, fnInfo);
         os << "\n   { \"name\": \"" << escape_for_json(tagname) << "\","
-           << " \"from\": " << (tag->fromFrame()) << ","
-           << " \"to\": " << (tag->toFrame())
+           << " \"from\": " << fromFrame << ","
+           << " \"to\": " << toFrame
            << ","
               " \"direction\": \""
            << escape_for_json(convert_anidir_to_string(tag->aniDir())) << "\"";

--- a/src/app/doc_exporter.h
+++ b/src/app/doc_exporter.h
@@ -79,6 +79,7 @@ public:
   void setListLayers(bool value) { m_listLayers = value; }
   void setListLayerHierarchy(bool value) { m_listLayerHierarchy = value; }
   void setListSlices(bool value) { m_listSlices = value; }
+  void setSelectedTag(const std::string& tagName) { m_selectedTagName = tagName; }
 
   void addImage(Doc* doc, const doc::ImageRef& image);
 
@@ -153,6 +154,7 @@ private:
   std::string m_textureFilename;
   std::string m_filenameFormat;
   std::string m_tagnameFormat;
+  std::string m_selectedTagName;
   int m_textureWidth;
   int m_textureHeight;
   int m_textureColumns;


### PR DESCRIPTION
Fixes #5085 by giving the exporter knowledge of a selected tag and filtering them there.