### PR TITLE
[lua] Make Dialog:separator more in line with other widgets (fix #4989)

### DIFF
--- a/data/extensions/aseprite-theme/dark/theme.xml
+++ b/data/extensions/aseprite-theme/dark/theme.xml
@@ -713,6 +713,7 @@
             <background color="window_face" />
             <background-border part="separator_horz" align="middle" />
             <text color="separator_label" x="4" align="left middle" />
+            <text color="disabled" x="4" align="left middle" state="disabled"/>
         </style>
         <style id="menu_separator" extends="horizontal_separator" />
         <style id="separator_in_view" extends="horizontal_separator">

--- a/data/extensions/aseprite-theme/theme.xml
+++ b/data/extensions/aseprite-theme/theme.xml
@@ -706,6 +706,7 @@
             <background color="window_face" />
             <background-border part="separator_horz" align="middle" />
             <text color="separator_label" x="4" align="left middle" />
+            <text color="disabled" x="4" align="left middle" state="disabled"/>
         </style>
         <style id="menu_separator" extends="horizontal_separator" />
         <style id="separator_in_view" extends="horizontal_separator">


### PR DESCRIPTION
The goal is to make Dialog:separator more in line with other Dialog widgets, making it compatible with more basic properties.

Notable examples are :
- Separators visibility can be initialized to false (Fixes #4989)
- Separators can be disabled and labeled, providing additional formatting options

![separatorPRgif](https://github.com/user-attachments/assets/14d290c6-a874-4794-96ea-17a3bc972091)

**Example code:**
``` Lua
Subsection1Show = false
Subsection1Enabled = false
Subsection2Show = false
Subsection2Enabled = false

DialogSeparatorPRLabelOffset = "        "

function generateDialogSeparatorPR()
	if DialogSeparatorPR ~= nil then
		DialogSeparatorPR:close(); return;
	end
	DialogSeparatorPR = Dialog{
		id="DialogSeparatorPR",
		title="DialogSeparatorPR",
        onclose=function() DialogSeparatorPR=nil end
	}


    DialogSeparatorPR:separator{text ="THIS SEPARATOR SHOULD BE INVISIBLE", visible=false}

    DialogSeparatorPR:separator{text ="Major section 1", focus=true}

    DialogSeparatorPR:separator{text ="Subsection", label=DialogSeparatorPRLabelOffset}
    DialogSeparatorPR:button{text ="Show/Hide [1]", onclick=function() Subsection1Show = not Subsection1Show; updateDialogSeparatorPR()  end}
    DialogSeparatorPR:button{id = "edb1w", text ="Enable/Disable [1]", onclick=function() Subsection1Enabled = not Subsection1Enabled; updateDialogSeparatorPR()  end}
    DialogSeparatorPR:separator{id="s1w_s", label="", text="[1]"}
    DialogSeparatorPR:entry{id="e1w", text = "Mock subsection [1] widget"}
    DialogSeparatorPR:separator{id="s1w_e", label=""}

    -- DialogSeparatorPR:newrow{}
    DialogSeparatorPR:button{text ="Show/Hide [2]", onclick=function() Subsection2Show = not Subsection2Show; updateDialogSeparatorPR()  end}
    DialogSeparatorPR:button{id = "edb2w", text ="Enable/Disable [2]", onclick=function() Subsection2Enabled = not Subsection2Enabled; updateDialogSeparatorPR() end}
    DialogSeparatorPR:separator{id="s2w_s", label="", text="[2]"}
    DialogSeparatorPR:entry{id="e2w", text = "Mock subsection [2] widget"}
    DialogSeparatorPR:separator{id="s2w_e", label=""}

    DialogSeparatorPR:separator{text ="Major section 2"}
    DialogSeparatorPR:button{text = "Mock button 1"}
    DialogSeparatorPR:button{text = "Mock button 2"}
    DialogSeparatorPR:button{text = "Mock button 3"}

    updateDialogSeparatorPR()
    DialogSeparatorPR:show{wait = false}
end
function updateDialogSeparatorPR()
    DialogSeparatorPR:modify{id="edb1w", enabled = Subsection1Show}
    DialogSeparatorPR:modify{id="s1w_s", visible = Subsection1Show, enabled = Subsection1Enabled}
    DialogSeparatorPR:modify{id="e1w", visible = Subsection1Show, enabled = Subsection1Enabled}
    DialogSeparatorPR:modify{id="s1w_e", visible = Subsection1Show, enabled = Subsection1Enabled}

    DialogSeparatorPR:modify{id="edb2w", enabled = Subsection2Show}
    DialogSeparatorPR:modify{id="s2w_s", visible = Subsection2Show, enabled = Subsection2Enabled}
    DialogSeparatorPR:modify{id="e2w", visible = Subsection2Show, enabled = Subsection2Enabled}
    DialogSeparatorPR:modify{id="s2w_e", visible = Subsection2Show, enabled = Subsection2Enabled}
end

generateDialogSeparatorPR()
```
---

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing
