### PR TITLE
Copy tags when copying frames from one sprite to another (#4979)

### DIFF
--- a/src/app/doc_api.cpp
+++ b/src/app/doc_api.cpp
@@ -51,6 +51,7 @@
 #include "app/transaction.h"
 #include "app/util/autocrop.h"
 #include "app/util/layer_utils.h"
+#include "cmd/set_user_data.h"
 #include "doc/algorithm/flip_image.h"
 #include "doc/algorithm/shrink_bounds.h"
 #include "doc/cel.h"
@@ -325,10 +326,12 @@ void DocApi::addFrame(Sprite* sprite, frame_t newFrame)
   copyFrame(sprite, newFrame - 1, newFrame, kDropBeforeFrame, kDefaultTagsAdjustment);
 }
 
-void DocApi::addEmptyFrame(Sprite* sprite, frame_t newFrame)
+void DocApi::addEmptyFrame(Sprite* sprite, frame_t newFrame, bool adjust)
 {
   m_transaction.execute(new cmd::AddFrame(sprite, newFrame));
-  adjustTags(sprite, newFrame, +1, kDropBeforeFrame, kDefaultTagsAdjustment);
+
+  if (adjust)
+    adjustTags(sprite, newFrame, +1, kDropBeforeFrame, kDefaultTagsAdjustment);
 }
 
 void DocApi::addEmptyFramesTo(Sprite* sprite, frame_t newFrame)
@@ -807,6 +810,22 @@ void DocApi::setPalette(Sprite* sprite, frame_t frame, const Palette* newPalette
   if (from >= 0 && to >= from) {
     m_transaction.execute(new cmd::SetPalette(sprite, frame, newPalette));
   }
+}
+
+// Copies the given source tag onto the destination sprite, copying everything except for the
+// frames.
+void DocApi::copyTag(Tag* sourceTag, Sprite* dstSprite, const frame_t fromFrame)
+{
+  auto* dstTag = new Tag(*sourceTag);
+  m_transaction.execute(new cmd::AddTag(dstSprite, dstTag));
+  m_transaction.execute(
+    new cmd::SetUserData(dstTag, sourceTag->userData(), static_cast<Doc*>(dstSprite->document())));
+  setTagRange(dstTag, fromFrame, fromFrame);
+}
+
+void DocApi::setTagRange(Tag* tag, const frame_t fromFrame, const frame_t toFrame)
+{
+  m_transaction.execute(new cmd::SetTagRange(tag, fromFrame, toFrame));
 }
 
 void DocApi::adjustTags(Sprite* sprite,

--- a/src/app/doc_api.h
+++ b/src/app/doc_api.h
@@ -22,6 +22,9 @@
 #include <map>
 
 namespace doc {
+class Tag;
+}
+namespace doc {
 class Cel;
 class CelData;
 class Image;
@@ -73,7 +76,7 @@ public:
 
   // Frames API
   void addFrame(Sprite* sprite, frame_t newFrame);
-  void addEmptyFrame(Sprite* sprite, frame_t newFrame);
+  void addEmptyFrame(Sprite* sprite, frame_t newFrame, bool adjustTags = true);
   void addEmptyFramesTo(Sprite* sprite, frame_t newFrame);
   void copyFrame(Sprite* sprite,
                  frame_t fromFrame,
@@ -149,6 +152,10 @@ public:
                                InsertionPoint insert,
                                DroppedOn droppedOn,
                                DocProvider& provider);
+
+  // Tags API
+  void copyTag(Tag* sourceTag, Sprite* dstSprite, frame_t fromFrame);
+  void setTagRange(Tag* tag, frame_t fromFrame, frame_t Frame);
 
 private:
   void cropImageLayer(LayerImage* layer, const gfx::Rect& bounds, const bool trimOutside);

--- a/src/app/util/clipboard.cpp
+++ b/src/app/util/clipboard.cpp
@@ -724,7 +724,7 @@ void Clipboard::paste(Context* ctx, const bool interactive, const gfx::Point* po
           auto dstLayers = dstSpr->allBrowsableLayers();
 
           for (frame_t srcFrame : srcRange.selectedFrames()) {
-            api.addEmptyFrame(dstSpr, dstFrame);
+            api.addEmptyFrame(dstSpr, dstFrame, false);
             api.setFrameDuration(dstSpr, dstFrame, srcSpr->frameDuration(srcFrame));
 
             auto srcIt = srcLayers.begin();
@@ -741,6 +741,42 @@ void Clipboard::paste(Context* ctx, const bool interactive, const gfx::Point* po
 
               if (Cel* cel = srcLayer->cel(srcFrame)) {
                 api.copyCel(srcLayer, srcFrame, dstLayer, dstFrame);
+              }
+            }
+
+            // Copy any tags from these frames, if available.
+            for (Tag* tag : srcSpr->tags()) {
+              if (!tag->contains(srcFrame))
+                continue;
+
+              Tag* existingTag = nullptr;
+              for (Tag* destTag : dstSpr->tags().getInternalList()) {
+                if (destTag->toFrame() < site.frame() ||
+                    destTag->fromFrame() > site.frame() + srcRange.frames())
+                  continue; // Ignore tags that exist outside our selection range
+
+                if (destTag->name() == tag->name()) {
+                  if (existingTag && !destTag->contains(dstFrame))
+                    continue;
+
+                  existingTag = destTag;
+                }
+              }
+
+              if (existingTag) {
+                // If this tag already exists fully, bail instead of attaching
+                if (existingTag->fromFrame() == tag->fromFrame() &&
+                    existingTag->toFrame() == tag->toFrame()) {
+                  continue;
+                }
+
+                if (dstFrame == existingTag->toFrame() + 1) {
+                  // Only attach these together if they're next to each other.
+                  api.setTagRange(existingTag, existingTag->fromFrame(), dstFrame);
+                }
+              }
+              else {
+                api.copyTag(tag, dstSpr, dstFrame);
               }
             }
 


### PR DESCRIPTION
Fixes [#4979](https://github.com/aseprite/aseprite/issues/4979).

https://github.com/user-attachments/assets/333db7b2-a6e2-4620-829a-2e73b3152c34

There's still some edge-cases where things could get duplicated - and there's no way to disable the copying of tags, that'd come as a part of #2324 which I could tackle next.

I also took the opportunity to localize some of the transaction names, but I could put those in another PR with the rest of them, since most of them (but not all) are not translated.