### PR TITLE
Fix: Prevent 1px-shift in scrollbar when clicking without dragging

### DIFF
--- a/src/ui/scroll_bar.h
+++ b/src/ui/scroll_bar.h
@@ -56,6 +56,7 @@ private:
 
   static int m_wherepos;
   static int m_whereclick;
+  static bool m_dragging;
 };
 
 } // namespace ui


### PR DESCRIPTION
### Summary
Fixes a bug where clicking on the scrollbar without moving the mouse would cause the bar to shift by 1 pixel. This issue occurred because drag logic was triggered immediately upon a mouse click, even if no mouse movement was detected.

### Description of Changes
Introduced a new static flag 'm_dragging' to ensure that drag behavior only begins after mouse movement is detected. The logic checks whether the mouse position has changed since the initial click and skips scroll calculations if it hasn't.

### Effect on Application
Prevents unintended 1px-scroll shifts when interacting with scrollbars.
