### PR TITLE
Feat: export user & extension defined properties

### DIFF
--- a/src/app/doc_exporter.cpp
+++ b/src/app/doc_exporter.cpp
@@ -119,7 +119,7 @@ void serialize_properties(const doc::UserData::Properties& props, std::ostream& 
   bool first = true;
   for (const auto& [key, value] : props) {
     if (!first)
-      os << ",";
+      os << ", ";
     first = false;
     os << "\"" << escape_for_json(key) << "\": ";
     serialize_variant(value, os);
@@ -143,14 +143,14 @@ void serialize_userdata_properties(const doc::UserData& data, std::ostream& os)
     for (const auto& [group, props] : propsMaps) {
       if (!props.empty()) {
         if (!firstProp)
-          os << ",";
+          os << ", ";
         firstProp = false;
         if (group.empty()) {
           // Default group: flatten its keys at the top level
           bool firstKey = true;
           for (const auto& [key, value] : props) {
             if (!firstKey)
-              os << ",";
+              os << ", ";
             firstKey = false;
             os << "\"" << escape_for_json(key) << "\": ";
             serialize_variant(value, os);

--- a/src/app/doc_exporter.cpp
+++ b/src/app/doc_exporter.cpp
@@ -76,34 +76,40 @@ void serialize_properties(const doc::UserData::Properties& props, std::ostream& 
 void serialize_variant(const doc::UserData::Variant& value, std::ostream& os)
 {
   using Properties = doc::UserData::Properties;
-  std::visit(
-    [&os](auto&& arg) {
-      using T = std::decay_t<decltype(arg)>;
-      if constexpr (std::is_same_v<T, bool>) {
-        os << (arg ? "true" : "false");
-      }
-      // Handle all integer types
-      else if constexpr (std::is_same_v<T, int8_t> || std::is_same_v<T, uint8_t> ||
-                         std::is_same_v<T, int16_t> || std::is_same_v<T, uint16_t> ||
-                         std::is_same_v<T, int32_t> || std::is_same_v<T, uint32_t> ||
-                         std::is_same_v<T, int64_t> || std::is_same_v<T, uint64_t>) {
-        os << static_cast<int64_t>(arg); // or static_cast<int64_t>(arg) for uniformity
-      }
-      else if constexpr (std::is_same_v<T, float> || std::is_same_v<T, double>) {
-        os << arg;
-      }
-      else if constexpr (std::is_same_v<T, std::string>) {
-        os << "\"" << escape_for_json(arg) << "\"";
-      }
-      else if constexpr (std::is_same_v<T, Properties>) {
-        serialize_properties(arg, os);
-      }
-      else {
-        std::cerr << "serialize_variant: unsupported type: " << typeid(T).name() << std::endl;
-        os << "\"[unsupported type]\"";
-      }
-    },
-    value);
+  switch (value.index()) {
+    case USER_DATA_PROPERTY_TYPE_BOOL: os << (get_value<bool>(value) ? "true" : "false"); break;
+    case USER_DATA_PROPERTY_TYPE_INT8: os << static_cast<int64_t>(get_value<int8_t>(value)); break;
+    case USER_DATA_PROPERTY_TYPE_UINT8:
+      os << static_cast<int64_t>(get_value<uint8_t>(value));
+      break;
+    case USER_DATA_PROPERTY_TYPE_INT16:
+      os << static_cast<int64_t>(get_value<int16_t>(value));
+      break;
+    case USER_DATA_PROPERTY_TYPE_UINT16:
+      os << static_cast<int64_t>(get_value<uint16_t>(value));
+      break;
+    case USER_DATA_PROPERTY_TYPE_INT32:
+      os << static_cast<int64_t>(get_value<int32_t>(value));
+      break;
+    case USER_DATA_PROPERTY_TYPE_UINT32:
+      os << static_cast<int64_t>(get_value<uint32_t>(value));
+      break;
+    case USER_DATA_PROPERTY_TYPE_INT64:
+      os << static_cast<int64_t>(get_value<int64_t>(value));
+      break;
+    case USER_DATA_PROPERTY_TYPE_UINT64:
+      os << static_cast<int64_t>(get_value<uint64_t>(value));
+      break;
+    case USER_DATA_PROPERTY_TYPE_FLOAT:  os << get_value<float>(value); break;
+    case USER_DATA_PROPERTY_TYPE_DOUBLE: os << get_value<double>(value); break;
+    case USER_DATA_PROPERTY_TYPE_STRING:
+      os << "\"" << escape_for_json(get_value<std::string>(value)) << "\"";
+      break;
+    case USER_DATA_PROPERTY_TYPE_PROPERTIES:
+      serialize_properties(get_value<Properties>(value), os);
+      break;
+    default: os << "\"[unsupported type]\""; break;
+  }
 }
 
 // Serializes a map of properties

--- a/tests/scripts/userdata_json.lua
+++ b/tests/scripts/userdata_json.lua
@@ -1,0 +1,98 @@
+-- Copyright (C) 2024  Igara Studio S.A.
+-- Released under the MIT license. See LICENSE.txt.
+
+dofile('./test_utils.lua')
+
+-- Helper to export sprite to JSON and parse it
+local function export_json(sprite, filename)
+  -- Create a subfolder for test outputs
+  local out_dir = app.fs.joinPath(app.fs.userConfigPath, "userdata_json")
+  if not app.fs.isDirectory(out_dir) then
+    app.fs.makeDirectory(out_dir)
+  end
+
+  local out_json = app.fs.joinPath(out_dir, "_test_userdata_json.json")
+  local out_png  = app.fs.joinPath(out_dir, "_test_userdata_json.png")
+  local out_ase  = app.fs.joinPath(out_dir, "_test_userdata_json.aseprite")
+
+  print("Exporting to:")
+  print("  out_json: " .. out_json)
+  print("  out_png:  " .. out_png)
+  print("  out_ase:  " .. out_ase)
+
+  sprite:saveAs(out_ase)
+  app.command.ExportSpriteSheet{
+    ui=false,
+    type=SpriteSheetType.PACKED,
+    data=SpriteSheetDataFormat.JSON_HASH,
+    dataFilename=out_json,
+    textureFilename=out_png
+  }
+  sprite:close()
+
+  print("Trying to open: " .. out_json)
+  local f = io.open(out_json, "r")
+  if not f then
+    print("FAILED to open: " .. out_json)
+  end
+  local content = f and f:read("*a") or ""
+  if f then f:close() end
+  return json.decode(content)
+end
+
+do
+  -- Create a sprite and set various user/extension properties
+  local spr = Sprite(16, 16)
+  spr.properties.user_defined_data = true
+  spr.properties("my_plugin").extension_defined_data = "sample data"
+
+  spr:newLayer()
+  spr.layers[2].properties.user_defined_data = true
+  spr.layers[2].properties("my_plugin").extension_defined_data = "sample data"
+
+  spr:newTag(0, 0)
+  spr.tags[1].properties.user_defined_data = "sample data"
+  spr.tags[1].properties("my_plugin").extension_defined_data = 42
+
+  spr:newCel(spr.layers[2], 1)
+  spr.layers[2].cels[1].properties.user_defined_data = 42
+  spr.layers[2].cels[1].properties("my_plugin").extension_defined_data = "sample data"
+
+  spr:newSlice(0, 0, 8, 8)
+  spr.slices[1].properties.user_defined_data = "sample data"
+  spr.slices[1].properties("my_plugin").extension_defined_data = false
+
+  local meta = export_json(spr, "_test_userdata_json.aseprite").meta
+
+  -- Sprite properties
+  if meta.properties then
+    assert(meta.properties.user_defined_data == true)
+    assert(meta.properties["my_plugin"].foo == "sample data")
+  end
+
+  -- Layer properties
+  local layer = meta.layers[2] -- Assuming Layer 2 is at index 2
+  assert(layer ~= nil)
+  assert(layer.properties.user_defined_data == true)
+  assert(layer.properties["my_plugin"].extension_defined_data == "sample data")
+
+  -- Tag properties
+  local tag = meta.frameTags[1]
+  assert(tag ~= nil)
+  assert(tag.properties.user_defined_data == "sample data")
+  assert(tag.properties["my_plugin"].extension_defined_data == 42)
+
+  -- Cel properties
+  local cel = meta.layers[2].cels and meta.layers[2].cels[1]
+  assert(cel ~= nil)
+  assert(cel.properties.user_defined_data == 42)
+  assert(cel.properties["my_plugin"].extension_defined_data == "sample data")
+
+  -- Slice properties
+  local slice = meta.slices[1]
+  assert(slice ~= nil)
+  assert(slice.properties.user_defined_data == "sample data")
+  assert(slice.properties["my_plugin"].extension_defined_data == false)
+end
+
+print("userdata_json.lua: All user data JSON export tests passed!")

--- a/tests/scripts/userdata_json.lua
+++ b/tests/scripts/userdata_json.lua
@@ -71,7 +71,7 @@ do
   end
 
   -- Layer properties
-  local layer = meta.layers[2] -- Assuming Layer 2 is at index 2
+  local layer = meta.layers[2]
   assert(layer ~= nil)
   assert(layer.properties.user_defined_data == true)
   assert(layer.properties["my_plugin"].extension_defined_data == "sample data")


### PR DESCRIPTION
I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing

-----------------------------------------------------

### Related Issue(s):
Resolves https://github.com/aseprite/aseprite/issues/5186

### Context:
Since [Aseprite 1.3-rc1](https://aseprite.org/api/properties#properties) you can have user-defined and extension-defined properties for each of these objects. 

However, these properties are currently not exported into the JSON file.

This would be a very handy feature so that plugins can fully take advantage of these custom properties when parsing aseprite json files in other tools (Unity, etc...).

### Solution:

- **Full serialization of custom properties for Tags, Layers, Cels, and Slices:**  
  The exported JSON now includes all user-defined and extension-defined properties for these objects, under a `"properties"` key. This ensures that any metadata added by users or extensions is preserved and accessible in downstream tools.
- **Generic, type-safe serialization helper:**  
  Introduced a reusable, type-constrained helper function (`serialize_userdata_properties`) that serializes the properties of any object derived from `WithUserData`. This ensures consistent and safe handling of properties across all supported object types.
- **Accurate variant type handling:**  
  The serialization logic for property values robustly supports all integer types and other supported types in `UserData::Variant`, guaranteeing correct JSON output for all property values, regardless of how they are stored or loaded.



### Testing:

#### Compilation:
- [x] Control compilation at base `master` (SHA `66123e9d5739fdf870336fd4eda91e0054421ea0`)
- [x] Compilation at tip of this feature branch (SHA `42e386b701064b9e8a4de9409ec7cbf39f40a7e4`)

#### Functional Test Cases:
- [x] Frame Tags
- [x] Layer
- [x] Cel
- [x] Slice

In each case, a similar lua snippet was run to add a user and group/extension property to each of the above objects.
```
function injectPropertiesFor(targetType)
  local target = app[targetType]
  if not target then
    app.alert("No active " .. targetType .. ".")
    return
  end
  target.properties = {}
  target.properties.user_defined_data = targetType .. " user defined data"
  local props = target.properties("my-plugin")
  if not props then
    target.properties("my-plugin", {})
    props = target.properties("my-plugin")
  end
  props.extension_defined_data = targetType .. " extension defined data"
  app.alert("Injected " .. targetType .. " properties.")
end
```

JSON Result:
[meta.json](https://github.com/user-attachments/files/20544825/meta.json)

_(Note that the meta data has been manually vertically restructured just for the purpose of better visibility in this MR. I haven't changed any logic for how it formats in the actual exported JSON (flat/wide))_





