### PR TITLE
Fix file dialog size not being loaded properly

### DIFF
--- a/src/app/ui/file_selector.cpp
+++ b/src/app/ui/file_selector.cpp
@@ -408,7 +408,8 @@ bool FileSelector::show(const std::string& title,
 
   remapWindow();
   centerWindow();
-  load_window_pos(this, kConfigSection);
+  // The minimum size is large, so do not limit the minimum loaded size
+  load_window_pos(this, kConfigSection, false);
 
   // Change the file formats/extensions to be shown
   std::string initialExtension = base::get_file_extension(initialPath);


### PR DESCRIPTION
Fix #4460.

This PR fixes an issue where the file selector dialog would not load its size in some cases when using the Aseprite file dialog. Since the minimum size set on the dialog is fairly large, the minimum limit on the loaded size has been removed to allow for users to adjust the size more to their liking.