### PR TITLE
Call parent's class onOpen 

### DIFF
--- a/src/app/commands/cmd_options.cpp
+++ b/src/app/commands/cmd_options.cpp
@@ -1046,7 +1046,11 @@ public:
   }
 
 protected:
-  void onOpen(Event& evt) override { sectionListbox()->selectIndex(m_curSection); }
+  void onOpen(Event& evt) override
+  {
+    sectionListbox()->selectIndex(m_curSection);
+    app::gen::Options::onOpen(evt);
+  }
 
 private:
   void onInitTheme(InitThemeEvent& ev) override


### PR DESCRIPTION
Fix #5209 by calling the parent's calls onOpen() virtual method which in turn makes the window's Open signal to be triggered as usual. Since the Preferences dialog made use of the Open signal to show the "Extension Installation Alert" dialog, this was broken.

