### PR TITLE
Fix default font for CJK and other translations (fix #5210)

### DIFF
--- a/data/fonts/fonts.xml
+++ b/data/fonts/fonts.xml
@@ -34,14 +34,14 @@
         type="spritesheet"
         descent="2"
         file="aseprite_font.png">
-    <fallback font="Unicode" size="8" />
+    <fallback font="Unicode" size="14" />
   </font>
 
   <font name="Aseprite Mini"
         type="spritesheet"
         descent="1"
         file="aseprite_mini.png">
-    <fallback font="Unicode" size="6" />
+    <fallback font="Unicode" size="10" />
   </font>
 
 </fonts>

--- a/src/app/commands/cmd_options.cpp
+++ b/src/app/commands/cmd_options.cpp
@@ -1368,8 +1368,8 @@ private:
     if (!item)
       return;
     const std::string lang = item->langId();
-    const bool state = (lang == "ar" || lang == "ja" || lang == "ko" || lang == "yue_Hant" ||
-                        lang == "zh_Hans" || lang == "zh_Hant");
+    const bool state = (lang == "ar" || lang == "ja" || lang == "ko" || lang == "th" ||
+                        lang == "yue_Hant" || lang == "zh_Hans" || lang == "zh_Hant");
     fontWarningFiller()->setVisible(state);
     fontWarning()->setVisible(state);
     layout();

--- a/src/app/fonts/font_data.cpp
+++ b/src/app/fonts/font_data.cpp
@@ -15,6 +15,7 @@
 #include "text/font_mgr.h"
 #include "text/sprite_sheet_font.h"
 #include "ui/manager.h"
+#include "ui/scale.h"
 
 #include <set>
 
@@ -87,9 +88,9 @@ text::FontRef FontData::getFont(text::FontMgrRef& fontMgr, float size)
 
   // Load fallback
   if (m_fallback) {
-    text::FontRef fallback = m_fallback->getFont(fontMgr, m_fallbackSize);
+    text::FontRef fallback = m_fallback->getFont(fontMgr, m_fallbackSize * ui::guiscale());
     if (font)
-      font->setFallback(fallback.get());
+      font->setFallback(fallback);
     else
       return fallback; // Don't double-cache the fallback font
   }

--- a/src/app/ui/skin/skin_theme.cpp
+++ b/src/app/ui/skin/skin_theme.cpp
@@ -311,6 +311,9 @@ static FontData* load_font(const XMLElement* xmlFont, const std::string& xmlFile
     if (!font && systemStr) {
       font = try_to_load_system_font(xmlFont);
     }
+
+    if (font && nameStr)
+      font->setName(nameStr);
   }
   else {
     throw base::Exception(
@@ -1440,14 +1443,10 @@ void SkinTheme::drawEntryText(ui::Graphics* g, ui::Entry* widget)
 
     IntersectClip clip(g, bounds);
     if (clip) {
-      text::FontMetrics metrics;
-      widget->font()->metrics(&metrics);
-      const float baselineShift = -metrics.ascent - widget->textBlob()->baseline();
-
       g->drawTextWithDelegate(std::string(pos, textString.end()), // TODO use a string_view()
                               colors.text(),
                               ColorNone,
-                              gfx::Point(bounds.x, bounds.y + baselineShift),
+                              bounds.origin(),
                               &delegate);
     }
   }

--- a/src/app/ui/status_bar.cpp
+++ b/src/app/ui/status_bar.cpp
@@ -136,7 +136,7 @@ class StatusBar::Indicators : public HBox {
         g->drawText(text(),
                     textColor,
                     ColorNone,
-                    Point(rc.x, guiscaled_center(rc.y, rc.h, font()->lineHeight())));
+                    Point(rc.x, guiscaled_center(rc.y, rc.h, textHeight())));
       }
     }
   };

--- a/src/ui/theme.cpp
+++ b/src/ui/theme.cpp
@@ -656,10 +656,8 @@ void Theme::measureLayer(const Widget* widget,
         }
         else {
           // We can use Widget::textSize() because we're going to use
-          // the widget font and, probably, the cached TextBlob width.
-          text::FontMetrics metrics;
-          widget->font()->metrics(&metrics);
-          textSize = gfx::Size(widget->textSize().w, metrics.descent - metrics.ascent);
+          // the widget font and, probably, the cached TextBlob size.
+          textSize = widget->textSize();
         }
 
         textHint.offset(layer.offset());
@@ -1044,7 +1042,8 @@ void Theme::drawMnemonicUnderline(Graphics* g,
     decode.next(); // Go to first char
     size_t glyphUtf8Begin = 0;
 
-    textBlob->visitRuns([g, mnemonicUtf8Pos, pt, &paint, &decode, &glyphUtf8Begin, &text](
+    float baseline = textBlob->baseline();
+    textBlob->visitRuns([g, baseline, mnemonicUtf8Pos, pt, &paint, &decode, &glyphUtf8Begin, &text](
                           text::TextBlob::RunInfo& info) {
       for (int i = 0; i < info.glyphCount; ++i, decode.next()) {
         // TODO This doesn't work because the TextBlob::RunInfo::clusters is nullptr at this
@@ -1061,11 +1060,10 @@ void Theme::drawMnemonicUnderline(Graphics* g,
           if (thickness < 1.0f)
             thickness = 1.0f;
 
-          mnemonicBounds = gfx::RectF(
-            pt.x + mnemonicBounds.x,
-            pt.y - metrics.ascent + metrics.underlinePosition * guiscale(),
-            mnemonicBounds.w,
-            thickness);
+          mnemonicBounds = gfx::RectF(pt.x + mnemonicBounds.x,
+                                      pt.y + baseline + metrics.underlinePosition * guiscale(),
+                                      mnemonicBounds.w,
+                                      thickness);
 
           g->drawRect(mnemonicBounds, paint);
           break;

--- a/src/ui/widget.cpp
+++ b/src/ui/widget.cpp
@@ -965,6 +965,9 @@ int Widget::textWidth() const
 
 int Widget::textHeight() const
 {
+  if (auto blob = textBlob())
+    return blob->textHeight();
+
   text::FontMetrics metrics;
   font()->metrics(&metrics);
   return metrics.descent - metrics.ascent;
@@ -1896,14 +1899,16 @@ text::ShaperFeatures Widget::onGetTextShaperFeatures() const
 
 float Widget::onGetTextBaseline() const
 {
-  text::FontMetrics metrics;
-  font()->metrics(&metrics);
-  // Here we only use the descent+ascent to measure the text height,
-  // without the metrics.leading part (which is the used to separate
-  // text lines in a paragraph, but here'd make widgets too big)
-  const float textHeight = metrics.descent - metrics.ascent;
+  // Here we use TextBlob::textHeight() which is calculated as
+  // descent+ascent to measure the text height, without the
+  // metrics.leading part (which is the used to separate text lines in
+  // a paragraph, but here'd make widgets too big).
+  text::TextBlobRef blob = textBlob();
+  if (!blob)
+    return 0.0f;
+
   const gfx::Rect rc = clientChildrenBounds();
-  return guiscaled_center(rc.y, rc.h, textHeight) - metrics.ascent;
+  return guiscaled_center(rc.y, rc.h, blob->textHeight()) + blob->baseline();
 }
 
 void Widget::onDragEnter(DragEvent& e)


### PR DESCRIPTION
Now we use the correct fallback font with its size for non-existent glyph in the sprite sheet font.
