### PR TITLE
Implement tool loop for selection tools

### DIFF
--- a/src/app/doc.h
+++ b/src/app/doc.h
@@ -195,6 +195,7 @@ public:
   const MaskBoundaries& maskBoundaries() const { return m_maskBoundaries; }
 
   MaskBoundaries& maskBoundaries() { return m_maskBoundaries; }
+  void setMaskBoundaries(const MaskBoundaries& segs) { m_maskBoundaries = segs; }
 
   bool hasMaskBoundaries() const { return !m_maskBoundaries.isEmpty(); }
 

--- a/src/app/tools/inks.h
+++ b/src/app/tools/inks.h
@@ -292,8 +292,15 @@ public:
       m_maxBounds |= rc;
     else {
       rc &= loop->getDstImage()->bounds();
-      for (int v = rc.y; v < rc.y2(); ++v)
-        BaseInk::inkHline(rc.x, v, rc.x2() - 1, loop);
+      if (loop->isSelectionToolLoop())
+        loop->addSelectionToolPoint(rc);
+
+      // NOTE: this condition is here for drawing mode switches, remove/rework after testing
+      if (!loop->isSelectionToolLoop() ||
+          (loop->getPointShape()->isFloodFill() || !loop->getPreviewFilled())) {
+        for (int v = rc.y; v < rc.y2(); ++v)
+          BaseInk::inkHline(rc.x, v, rc.x2() - 1, loop);
+      }
     }
   }
 
@@ -457,8 +464,15 @@ public:
     }
     else {
       rc &= loop->getDstImage()->bounds();
-      for (int v = rc.y; v < rc.y2(); ++v)
-        BaseInk::inkHline(rc.x, v, rc.x2() - 1, loop);
+      if (loop->isSelectionToolLoop())
+        loop->addSelectionToolPoint(rc);
+
+      // NOTE: this condition is here for drawing mode switches, remove/rework after testing
+      if (!loop->isSelectionToolLoop() ||
+          (loop->getPointShape()->isFloodFill() || !loop->getPreviewFilled())) {
+        for (int v = rc.y; v < rc.y2(); ++v)
+          BaseInk::inkHline(rc.x, v, rc.x2() - 1, loop);
+      }
     }
   }
 

--- a/src/app/tools/tool_loop.h
+++ b/src/app/tools/tool_loop.h
@@ -264,6 +264,11 @@ public:
   virtual void onSliceRect(const gfx::Rect& bounds) = 0;
 
   virtual const app::TiledModeHelper& getTiledModeHelper() = 0;
+
+  // Used by selection tools
+  virtual bool isSelectionToolLoop() const = 0;
+  virtual void addSelectionToolPoint(const gfx::Rect& rc) = 0;
+  virtual void clearSelectionToolMask(const bool finalStep) = 0;
 };
 
 } // namespace tools

--- a/src/app/tools/tool_loop_manager.cpp
+++ b/src/app/tools/tool_loop_manager.cpp
@@ -271,6 +271,8 @@ void ToolLoopManager::doLoopStep(bool lastStep)
   }
 
   m_toolLoop->validateDstImage(m_dirtyArea);
+  if (!lastStep && m_toolLoop->isSelectionToolLoop())
+    m_toolLoop->clearSelectionToolMask(false);
 
   // Join or fill user points
   if (fillStrokes)
@@ -339,6 +341,13 @@ void ToolLoopManager::calculateDirtyArea(const Strokes& strokes)
                                                  r2);
 
     m_dirtyArea.createUnion(m_dirtyArea, Region(r1.createUnion(r2)));
+  }
+
+  // This ensures the Selection Tool Mask doesn't leave a 'trail' behind
+  if (m_toolLoop->isSelectionToolLoop()) {
+    auto bounds = m_dirtyArea.bounds();
+    bounds.enlarge(1);
+    m_dirtyArea |= gfx::Region(bounds);
   }
 
   // Merge new dirty area with the previous one (for tools like line

--- a/src/app/ui/editor/drawing_state.cpp
+++ b/src/app/ui/editor/drawing_state.cpp
@@ -219,6 +219,8 @@ bool DrawingState::onMouseUp(Editor* editor, MouseMessage* msg)
     if (m_toolLoopManager->releaseButton(m_lastPointer))
       return true;
   }
+  if (m_toolLoop->isSelectionToolLoop())
+    m_toolLoop->clearSelectionToolMask(true);
 
   destroyLoop(editor);
 
@@ -403,6 +405,9 @@ void DrawingState::destroyLoopIfCanceled(Editor* editor)
 {
   // Cancel drawing loop
   if (m_toolLoopManager->isCanceled()) {
+    if (m_toolLoop->isSelectionToolLoop())
+      m_toolLoop->clearSelectionToolMask(true);
+
     destroyLoop(editor);
 
     // Change to standby state

--- a/src/app/ui/editor/editor.cpp
+++ b/src/app/ui/editor/editor.cpp
@@ -205,6 +205,7 @@ Editor::Editor(Doc* document, EditorFlags flags, EditorStatePtr state)
   m_symmetryModeConn = Preferences::instance().symmetryMode.enabled.AfterChange.connect(
     [this] { invalidateIfActive(); });
   m_showExtrasConn = m_docPref.show.AfterChange.connect([this] { onShowExtrasChange(); });
+  m_selectionToolMask = std::unique_ptr<Mask>(new Mask());
 
   m_document->add_observer(this);
 
@@ -1011,8 +1012,20 @@ void Editor::drawSpriteUnclippedRect(ui::Graphics* g, const gfx::Rect& _rc)
   }
 
   // Draw the mask
-  if (m_document->hasMaskBoundaries())
-    drawMask(g);
+  const bool haveSegs = m_document->hasMaskBoundaries();
+  if (haveSegs)
+    drawMask(g, MaskIndex::Document);
+
+  if (!m_selectionToolMask->isEmpty()) {
+    const auto segs = m_document->maskBoundaries();
+    m_document->generateMaskBoundaries(m_selectionToolMask.get());
+    drawMask(g, MaskIndex::SelectionTool);
+
+    if (haveSegs)
+      m_document->setMaskBoundaries(segs);
+    else
+      m_document->destroyMaskBoundaries();
+  }
 
   // Post-render decorator.
   if ((m_flags & kShowDecorators) && m_decorator) {
@@ -1047,9 +1060,10 @@ void Editor::drawSpriteClipped(const gfx::Region& updateRegion)
  * regenerate boundaries, use the sprite_generate_mask_boundaries()
  * routine.
  */
-void Editor::drawMask(Graphics* g)
+void Editor::drawMask(Graphics* g, const MaskIndex index)
 {
-  if ((m_flags & kShowMask) == 0 || !m_docPref.show.selectionEdges())
+  if (index == MaskIndex::Document &&
+      ((m_flags & kShowMask) == 0 || !m_docPref.show.selectionEdges()))
     return;
 
   ASSERT(m_document->hasMaskBoundaries());
@@ -1064,10 +1078,25 @@ void Editor::drawMask(Graphics* g)
 
   ui::Paint paint;
   paint.style(ui::Paint::Stroke);
-  set_checkered_paint_mode(paint,
-                           m_antsOffset,
-                           gfx::rgba(0, 0, 0, 255),
-                           gfx::rgba(255, 255, 255, 255));
+  if (index == MaskIndex::Document) {
+    set_checkered_paint_mode(paint,
+                             m_antsOffset,
+                             gfx::rgba(0, 0, 0, 255),
+                             gfx::rgba(255, 255, 255, 255));
+  }
+  else {
+    // NOTE: this condition is here for drawing mode switches, remove/rework after testing
+    if ((int(getToolLoopModifiers()) & (int(tools::ToolLoopModifiers::kSubtractSelection) |
+                                        int(tools::ToolLoopModifiers::kIntersectSelection))) != 0) {
+      set_checkered_paint_mode(paint,
+                               m_antsOffset,
+                               gfx::rgba(0, 32, 64, 255),
+                               gfx::rgba(0, 128, 255, 255));
+    }
+    else {
+      paint.color(gfx::rgba(0, 0, 0, 255));
+    }
+  }
 
   // We translate the path instead of applying a matrix to the
   // ui::Graphics so the "checkered" pattern is not scaled too.
@@ -1079,10 +1108,12 @@ void Editor::drawMask(Graphics* g)
 
 void Editor::drawMaskSafe()
 {
-  if ((m_flags & kShowMask) == 0)
+  if (((m_flags & kShowMask) == 0 && !m_selectionToolMask->isEmpty()) ||
+      !(isVisible() && m_document))
     return;
 
-  if (isVisible() && m_document && m_document->hasMaskBoundaries()) {
+  const bool haveSegs = m_document->hasMaskBoundaries();
+  if (haveSegs || !m_selectionToolMask->isEmpty()) {
     Region region;
     getDrawableRegion(region, kCutTopWindows);
     region.offset(-bounds().origin());
@@ -1090,10 +1121,27 @@ void Editor::drawMaskSafe()
     HideBrushPreview hide(m_brushPreview);
     GraphicsPtr g = getGraphics(clientBounds());
 
-    for (const gfx::Rect& rc : region) {
-      IntersectClip clip(g.get(), rc);
-      if (clip)
-        drawMask(g.get());
+    if (haveSegs) {
+      for (const gfx::Rect& rc : region) {
+        IntersectClip clip(g.get(), rc);
+        if (clip)
+          drawMask(g.get(), MaskIndex::Document);
+      }
+    }
+
+    if (!m_selectionToolMask->isEmpty()) {
+      const auto segs = m_document->maskBoundaries();
+      m_document->generateMaskBoundaries(m_selectionToolMask.get());
+      for (const gfx::Rect& rc : region) {
+        IntersectClip clip(g.get(), rc);
+        if (clip)
+          drawMask(g.get(), MaskIndex::SelectionTool);
+      }
+
+      if (haveSegs)
+        m_document->setMaskBoundaries(segs);
+      else
+        m_document->destroyMaskBoundaries();
     }
   }
 }
@@ -2375,7 +2423,10 @@ void Editor::onPaint(ui::PaintEvent& ev)
 
       // Draw the mask boundaries
       if (m_document->hasMaskBoundaries()) {
-        drawMask(g);
+        drawMask(g, MaskIndex::Document);
+        m_antsTimer.start();
+      }
+      else if (!m_selectionToolMask->isEmpty()) {
         m_antsTimer.start();
       }
       else {

--- a/src/app/ui/editor/editor.h
+++ b/src/app/ui/editor/editor.h
@@ -318,6 +318,7 @@ public:
   void showUnhandledException(const std::exception& ex, const ui::Message* msg);
 
   static void registerCommands();
+  Mask* getSelectionToolMask() { return m_selectionToolMask.get(); }
 
 protected:
   bool onProcessMessage(ui::Message* msg) override;
@@ -361,7 +362,8 @@ private:
   void drawBackground(ui::Graphics* g);
   void drawSpriteUnclippedRect(ui::Graphics* g, const gfx::Rect& rc);
   void drawMaskSafe();
-  void drawMask(ui::Graphics* g);
+  enum MaskIndex { Document, SelectionTool, Count };
+  void drawMask(ui::Graphics* g, MaskIndex index);
   void drawGrid(ui::Graphics* g,
                 const gfx::Rect& spriteBounds,
                 const gfx::Rect& gridBounds,
@@ -504,6 +506,9 @@ private:
   // same document can show the same preview image/stroke being drawn
   // (search for Render::setPreviewImage()).
   static std::unique_ptr<EditorRender> m_renderEngine;
+
+  // Used for selection tool feedback
+  std::unique_ptr<Mask> m_selectionToolMask;
 };
 
 } // namespace app

--- a/src/app/ui/editor/standby_state.cpp
+++ b/src/app/ui/editor/standby_state.cpp
@@ -458,8 +458,10 @@ bool StandbyState::onSetCursor(Editor* editor, const gfx::Point& mouseScreenPos)
   return StateWithWheelBehavior::onSetCursor(editor, mouseScreenPos);
 }
 
+static bool selectionToolLoopEnabled = true;
 bool StandbyState::onKeyDown(Editor* editor, KeyMessage* msg)
 {
+  selectionToolLoopEnabled = true;
   if (Preferences::instance().editor.straightLinePreview() &&
       checkStartDrawingStraightLine(editor, nullptr, nullptr))
     return false;
@@ -471,6 +473,8 @@ bool StandbyState::onKeyDown(Editor* editor, KeyMessage* msg)
     // in a selection-like tool
     if (keys.size() == 1 && keys[0]->wheelAction() == WheelAction::BrushSize &&
         editor->getCurrentEditorInk()->isSelection()) {
+      // TEST: disable new tool loop implementation for selection tools
+      selectionToolLoopEnabled = false;
       return false;
     }
 
@@ -620,7 +624,8 @@ DrawingState* StandbyState::startDrawingState(Editor* editor,
                                                UIContext::instance(),
                                                pointer.button(),
                                                (drawingType == DrawingType::LineFreehand),
-                                               (drawingType == DrawingType::SelectTiles));
+                                               (drawingType == DrawingType::SelectTiles),
+                                               selectionToolLoopEnabled);
   if (!toolLoop)
     return nullptr;
 

--- a/src/app/ui/editor/tool_loop_impl.h
+++ b/src/app/ui/editor/tool_loop_impl.h
@@ -58,7 +58,8 @@ tools::ToolLoop* create_tool_loop(Editor* editor,
                                   Context* context,
                                   const tools::Pointer::Button button,
                                   const bool convertLineToFreehand,
-                                  const bool selectTiles);
+                                  const bool selectTiles,
+                                  const bool selectionToolLoopEnabled);
 
 tools::ToolLoop* create_tool_loop_preview(Editor* editor,
                                           const doc::BrushRef& brush,


### PR DESCRIPTION
This adds a new tool loop for use with selection tools (and slice, too): it simply makes it so one can see their strokes no matter the zoom level. Fix #2852.

For testing purposes (comparing the old tool loop to the new one), I've added a bool to toggle between them: holding down the keys for a 'change brush size' action while in standby state with a selection tool will enable the old implementation, and 'deselect all' re-enables the new one.

I am unsure whether it would be best to use a solid color for drawing the mask or a marching ants pattern, and which color or colors to use for it. There are many possibilities with this, could be worth it to make it customizable later on. I was tempted to make the colors depend on whether one is adding, subtracting, replacing or intersecting, but I held off on it as it seemed like too much.

Anyway, for now I've made it so the new implementation looks almost identical to the original, so as to not overcomplicate things. I've left a few additional switches to quickly swap between some alternatives, again just for testing purposes:
- With `kReplaceSelection` modifier (default), the mask is drawn over the ink as a solid black, so it *almost* looks the same as the old implementation.
- With `kAddSelection` modifier, only the mask is used.
- With `kSubtractSelection` modifier, the mask is drawn over the ink using a marching ants pattern.
- With `kIntersectSelection` modifier, only the mask is used, and drawk with a marching ants pattern.

Side note: I think that for the defaut case the mask could be disabled when zoomed in, as it's not necessary, and activated only when zoomed out and the ink becomes less visible. I didn't add this just to keep things simple, but it's fairly easy to do.

Finally, there's only a few minor details left to handle:
- When selecting, the mask can draw over the right and bottom edges of the canvas, and these are not always cleared, so the mask leaves a 'trail' over them. I couldn't find a way to redraw these two edges, save for forcing an `updateEditor()`, but I can tell that's not quite right. Needless to say, this is actually unnoticeable if the mask is the same color as the edges.
- Because I needed to access the mask from both the tool loop instance and the editor itself, I wasn't entirely sure where it was best to store it. I've simply added it to the editor class for now, in the new `m_selectionToolMask` member variable, but maybe there's a more appropriate place for it.
- In order to avoid code duplication, I made a *second* base class for tool loops, from which the old and new implementation are derived. This one essentially just holds all the methods and member variables that I am certain are needed by both, however, I haven't yet removed logic specific to slice/selection tools from the old implementation: this is so it can still be used for testing/comparison purposes.
- Following from the last point, this second base class would have to be slightly reworked if the old implementation is to be stripped of logic specific to slice/selection tools. But this is mostly just moving code from the base class to the derived one.