### PR TITLE
Add 'Show hidden' check to file selector

### DIFF
--- a/data/pref.xml
+++ b/data/pref.xml
@@ -356,6 +356,7 @@
     <section id="file_selector">
       <option id="current_folder" type="std::string" default="&quot;&lt;empty&gt;&quot;" />
       <option id="zoom" type="double" default="1.0" />
+      <option id="show_hidden" type="bool" default="false" />
     </section>
     <section id="text_tool">
       <option id="font_face" type="std::string" />

--- a/data/strings/en.ini
+++ b/data/strings/en.ini
@@ -765,6 +765,7 @@ pinned_folders = Pinned Folders
 recent_folders = Recent Folders
 all_formats = All formats
 all_files = All files
+show_hidden = Show hidden
 
 [filters]
 selected_cels = Selected

--- a/data/widgets/file_selector.xml
+++ b/data/widgets/file_selector.xml
@@ -23,6 +23,7 @@
       <combobox id="location" expansive="true" />
       <button text="" id="refresh_button" style="refresh_button"
                 tooltip="@.refresh_button_tooltip" tooltip_dir="bottom" />
+      <check id="show_hidden_check" text="@.show_hidden" />
     </box>
     <vbox id="file_view_placeholder" expansive="true" />
     <grid columns="2">

--- a/src/app/ui/file_list.cpp
+++ b/src/app/ui/file_list.cpp
@@ -45,6 +45,7 @@ FileList::FileList()
   , m_multiselect(false)
   , m_zoom(1.0)
   , m_itemsPerRow(0)
+  , m_showHidden(Preferences::instance().fileSelector.showHidden())
 {
   setFocusStop(true);
   setDoubleBuffered(true);
@@ -171,6 +172,14 @@ void FileList::animateToZoom(const double zoom)
   m_fromZoom = m_zoom;
   m_toZoom = zoom;
   startAnimation(ANI_ZOOM, 10);
+}
+
+void FileList::setShowHidden(const bool show)
+{
+  m_showHidden = show;
+  m_req_valid = false;
+  m_selected = nullptr;
+  regenerateList();
 }
 
 bool FileList::onProcessMessage(Message* msg)
@@ -825,7 +834,7 @@ void FileList::regenerateList()
     for (FileItemList::iterator it = m_list.begin(); it != m_list.end();) {
       IFileItem* fileitem = *it;
 
-      if (fileitem->isHidden())
+      if (fileitem->isHidden() && !m_showHidden)
         it = m_list.erase(it);
       else if (!fileitem->isFolder() && !fileitem->hasExtension(m_exts)) {
         it = m_list.erase(it);

--- a/src/app/ui/file_list.h
+++ b/src/app/ui/file_list.h
@@ -54,6 +54,7 @@ public:
   double zoom() const { return m_zoom; }
   void setZoom(const double zoom);
   void animateToZoom(const double zoom);
+  void setShowHidden(const bool show);
 
   obs::signal<void()> FileSelected;
   obs::signal<void()> FileAccepted;
@@ -137,6 +138,7 @@ private:
   double m_toZoom;
 
   int m_itemsPerRow;
+  bool m_showHidden;
 };
 
 } // namespace app

--- a/src/app/ui/file_selector.cpp
+++ b/src/app/ui/file_selector.cpp
@@ -316,6 +316,7 @@ FileSelector::FileSelector(FileSelectorType type) : m_type(type), m_navigationLo
   for (auto child : viewType()->children())
     child->setFocusStop(false);
 
+  showHiddenCheck()->setSelected(Preferences::instance().fileSelector.showHidden());
   m_fileList = new FileList();
   m_fileList->setId("fileview");
   m_fileName->setAssociatedFileList(m_fileList);
@@ -334,6 +335,10 @@ FileSelector::FileSelector(FileSelectorType type) : m_type(type), m_navigationLo
   viewType()->ItemChange.connect([this] { onChangeViewType(); });
   location()->CloseListBox.connect([this] { onLocationCloseListBox(); });
   fileType()->Change.connect([this] { onFileTypeChange(); });
+  showHiddenCheck()->Click.connect([this] {
+    Preferences::instance().fileSelector.showHidden(showHiddenCheck()->isSelected());
+    m_fileList->setShowHidden(showHiddenCheck()->isSelected());
+  });
   m_fileList->FileSelected.connect([this] { onFileListFileSelected(); });
   m_fileList->FileAccepted.connect([this] { onFileListFileAccepted(); });
   m_fileList->CurrentFolderChanged.connect([this] { onFileListCurrentFolderChanged(); });


### PR DESCRIPTION
Adds a checkbox to control showing hidden files in file selector window. Fix #3079.