### PR TITLE
Fix slice transformations not updating editors

### DIFF
--- a/src/app/ui/editor/moving_slice_state.cpp
+++ b/src/app/ui/editor/moving_slice_state.cpp
@@ -428,8 +428,8 @@ bool MovingSliceState::onMouseMove(Editor* editor, MouseMessage* msg)
   if (editor->slicesTransforms())
     drawExtraCel();
 
-  // Redraw the editor.
-  editor->invalidate();
+  // Notify changes
+  m_site.document()->notifyGeneralUpdate();
 
   // Use StandbyState implementation
   return StandbyState::onMouseMove(editor, msg);


### PR DESCRIPTION
Fixes #5225.

It's kind of an "inelegant" solution, I first attempted to use the bounds and `notifySpritePixelsModified` but it always ended up with some parts of the image not updating correctly, and since we were originally doing a full `invalidate()` I figured just using the equivalent of that but for all editors would be fine.