### PR TITLE
[lua] Add sprite.undoHistory

### DIFF
--- a/src/app/script/site_class.cpp
+++ b/src/app/script/site_class.cpp
@@ -13,6 +13,8 @@
 #include "app/console.h"
 #include "app/context.h"
 #include "app/context_observer.h"
+#include "app/doc.h"
+#include "app/doc_undo.h"
 #include "app/script/docobj.h"
 #include "app/script/engine.h"
 #include "app/script/luacpp.h"

--- a/tests/scripts/sprite.lua
+++ b/tests/scripts/sprite.lua
@@ -228,3 +228,69 @@ do
   c = app.open(fn)
   assert(c.tileManagementPlugin == nil)
 end
+
+-- Undo History
+
+function test_undo_history()
+  local sprite = Sprite(1, 1)
+
+  assert(sprite.undoHistory.undoSteps == 0)
+  assert(sprite.undoHistory.redoSteps == 0)
+
+  sprite:resize(10, 10)
+
+  assert(sprite.undoHistory.undoSteps == 1)
+  assert(sprite.undoHistory.redoSteps == 0)
+
+  sprite:resize(10, 15)
+
+  assert(sprite.undoHistory.undoSteps == 2)
+  assert(sprite.undoHistory.redoSteps == 0)
+
+  sprite:resize(10, 30)
+
+  assert(sprite.undoHistory.undoSteps == 3)
+  assert(sprite.undoHistory.redoSteps == 0)
+
+  app.undo()
+  assert(sprite.undoHistory.undoSteps == 2)
+  assert(sprite.undoHistory.redoSteps == 1)
+
+  app.undo()
+  assert(sprite.undoHistory.undoSteps == 1)
+  assert(sprite.undoHistory.redoSteps == 2)
+
+  app.redo()
+  assert(sprite.undoHistory.undoSteps == 2)
+  assert(sprite.undoHistory.redoSteps == 1)
+
+  app.undo()
+  app.undo()
+
+  assert(sprite.undoHistory.undoSteps == 0)
+  assert(sprite.undoHistory.redoSteps == 3)
+
+  sprite:resize(10, 30)
+
+  if (app.preferences.undo.allow_nonlinear_history) then
+    assert(sprite.undoHistory.undoSteps == 4)
+    assert(sprite.undoHistory.redoSteps == 0)
+  else
+    assert(sprite.undoHistory.undoSteps == 1)
+    assert(sprite.undoHistory.redoSteps == 0)
+  end
+end
+
+do
+  local prevSetting = app.preferences.undo.allow_nonlinear_history
+  app.preferences.undo.allow_nonlinear_history = true
+  test_undo_history()
+  app.preferences.undo.allow_nonlinear_history = prevSetting
+end
+
+do
+  local prevSetting = app.preferences.undo.allow_nonlinear_history
+  app.preferences.undo.allow_nonlinear_history = false
+  test_undo_history()
+  app.preferences.undo.allow_nonlinear_history = prevSetting
+end


### PR DESCRIPTION
Implements #5205. ~I'm not 100% convinced by the API names, alternatively we can use something like `undoStatesCount` or call them `undoSteps` (or stepCount) -- I also figured `Site` was the place to put this but it could be moved without much issue as long as we have document access, it makes sense to me since it's a level above the sprite and scripting has no concept of a "document".~