### PR TITLE
Fix tilemap layer copy/paste

### DIFF
--- a/src/app/ui/editor/editor.cpp
+++ b/src/app/ui/editor/editor.cpp
@@ -2730,7 +2730,10 @@ void Editor::setZoomAndCenterInMouse(const Zoom& zoom,
   }
 }
 
-void Editor::pasteImage(const Image* image, const Mask* mask, const gfx::Point* position)
+void Editor::pasteImage(const Image* image,
+                        const Mask* mask,
+                        const gfx::Point* position,
+                        const Tileset* srcTileset)
 {
   ASSERT(image);
 
@@ -2821,6 +2824,10 @@ void Editor::pasteImage(const Image* image, const Mask* mask, const gfx::Point* 
 
   PixelsMovementPtr pixelsMovement(
     new PixelsMovement(UIContext::instance(), site, image, &mask2, "Paste"));
+
+  // Adjust image when copying between tilemap layers
+  if (site.tilemapMode() == TilemapMode::Tiles && srcTileset != nullptr)
+    pixelsMovement->remapTilesForPaste(srcTileset);
 
   setState(EditorStatePtr(new MovingPixelsState(this, NULL, pixelsMovement, NoHandle)));
 }

--- a/src/app/ui/editor/editor.h
+++ b/src/app/ui/editor/editor.h
@@ -244,7 +244,8 @@ public:
 
   void pasteImage(const Image* image,
                   const Mask* mask = nullptr,
-                  const gfx::Point* position = nullptr);
+                  const gfx::Point* position = nullptr,
+                  const Tileset* srcTileset = nullptr);
 
   void startSelectionTransformation(const gfx::Point& move, double angle);
   void startFlipTransformation(doc::algorithm::FlipType flipType);

--- a/src/app/ui/editor/pixels_movement.h
+++ b/src/app/ui/editor/pixels_movement.h
@@ -130,6 +130,9 @@ public:
   const Transformation& getTransformation() const { return m_currentData; }
   void setTransformation(const Transformation& t);
 
+  // For copy/paste between tilemap layers
+  void remapTilesForPaste(const Tileset* srcTileset);
+
 private:
   void setTransformationBase(const Transformation& t);
   void adjustPivot();


### PR DESCRIPTION
Addresses copy/paste of tilemap layers from the timeline as well as copying a portion with the selection tool (and `site.tilemapMode() == TilemapMode::Tiles`). Fix #4872 in the immediate sense, but there's some loose ends that I think could be tackled in this patch too (see notes below). Making this PR a draft as I need feedback on some of these points.

Notes:
When copying from the timeline, a reference to the source tileset _could_ be used instead, but that causes two problems:
- Modifications to the destination could affect the source.
- Pasting from one document to another "works" with references so to speak, but segfaults abound.

The more I thought about it, the more involved the logic got, so a hard copy is always made for now. An option could be added to control this behavior, but we would have to consider these problems.

Then, for copying with the selection tool, some matching and remapping is necessary when the destination and source are different. The code for the operation is pretty simple, but it requires adding missing tiles to the destination through `cmd::AddTile`, so I moved it to `PixelsMovement` to make it all a single transaction/undo. There's a few things about this:
- I'm not a 100% sure if the way I did it is correct: I wanted to call the function I added (`PixelsMovement::remapTilesForPaste()`) from `Editor::pasteImage()` to make sure it's only ever used in that specific case, but to do so I had to make it public, which I feel is a bit confusing.
  * An alternative would be calling the function from the `PixelsMovement` constructor, that works too, it's just that it'd be nice to check that the operation is indeed a paste. I could do something like `strcmp(operationName, "Paste")` here but that doesn't *quite* feel right either.
- The call to `PixelsMovement::remapTilesForPaste()` should be skipped when source and destination layer are the same, but I can't perform the check as no reference to the source layer is stored in this situation, and comparing the `Tileset*`s won't work either as the source tileset is itself a copy.
- The implementation may actually need to be somewhere else to allow reuse for the non-interactive version, I'm just not sure where to put it. Maybe we can also reuse some other code from `PixelsMovement` for this too, like the `merge_tilemaps()`?

Lastly, there was no check for pasting between two tilemap layers with a different tile size, so for now I added a quick exception to catch that. Pasting in this case anyway doesn't seem to cause a crash (far as I tested), but it can give weird results when the destination layer has a smaller tile width or height.