### PR TITLE
[win] Fix ResourceFinder::includeDesktopDir returning the default path

### DIFF
--- a/src/app/resource_finder.cpp
+++ b/src/app/resource_finder.cpp
@@ -213,7 +213,7 @@ void ResourceFinder::includeDesktopDir(const char* filename)
 #ifdef _WIN32
 
   std::vector<wchar_t> buf(MAX_PATH);
-  HRESULT hr = SHGetFolderPath(NULL, CSIDL_DESKTOPDIRECTORY, NULL, SHGFP_TYPE_DEFAULT, &buf[0]);
+  HRESULT hr = SHGetFolderPath(NULL, CSIDL_DESKTOP, NULL, SHGFP_TYPE_CURRENT, &buf[0]);
   if (hr == S_OK) {
     addPath(base::join_path(base::to_utf8(&buf[0]), filename));
   }


### PR DESCRIPTION
Fixes #5302

Uses `SHGFP_TYPE_CURRENT` which returns the Desktop that the user has configured instead of the default. Fixes Windows 11's OneDrive-by-default Desktop folder and any customizable/moved Desktop in general. Have not tested on Windows versions below 11 but we're still using the old API so it shouldn't really change anything.