### PR TITLE
Allow gif encoding to be stopped (fix #2619)

### DIFF
--- a/src/app/file/gif_format.cpp
+++ b/src/app/file/gif_format.cpp
@@ -1095,6 +1095,9 @@ public:
     gifframe_t nframes = totalFrames();
     for (gifframe_t gifFrame = 0; gifFrame < nframes; ++gifFrame) {
       ASSERT(frame_it != frame_end);
+      if (m_fop->isStop())
+        break;
+
       frame_t frame = *frame_it;
       ++frame_it;
 


### PR DESCRIPTION
Fixes #2619, here's a test file with a lot of frames to try it: [f500.zip](https://github.com/user-attachments/files/21555653/f500.zip)
