### PR TITLE
[lua] Process mnemonics consistently for plugins (fix #5250)

### DIFF
--- a/src/app/script/dialog_class.cpp
+++ b/src/app/script/dialog_class.cpp
@@ -1516,6 +1516,10 @@ int Dialog_modify(lua_State* L)
     type = lua_getfield(L, 2, "text");
     if (const char* s = lua_tostring(L, -1)) {
       widget->setText(s);
+
+      // Re-process mnemonics for buttons
+      if (widget->type() == WidgetType::kButtonWidget)
+        widget->processMnemonicFromText();
       relayout = true;
     }
     lua_pop(L, 1);

--- a/src/app/script/plugin_class.cpp
+++ b/src/app/script/plugin_class.cpp
@@ -172,6 +172,7 @@ int Plugin_newCommand(lua_State* L)
       if (!group.empty() && App::instance()->isGui()) { // On CLI menus do not make sense
         if (auto appMenus = AppMenus::instance()) {
           auto menuItem = std::make_unique<AppMenuItem>(title, id);
+          menuItem->processMnemonicFromText();
           appMenus->addMenuItemIntoGroup(group, std::move(menuItem));
         }
       }


### PR DESCRIPTION
Fixes #5250.

Tried to see if I could find any other instances of this being omitted but I couldn't see any in the code.