### PR TITLE
Add a font weight selector to the font entry

### DIFF
--- a/data/strings/en.ini
+++ b/data/strings/en.ini
@@ -800,8 +800,12 @@ empty_fonts = No system fonts were found
 [font_style]
 antialias = Antialias
 hinting = Hinting
+hinting_none = No Hinting
+hinting_slight = Slight Hinting
+hinting_full = Full Hinting
 ligatures = Ligatures
 font_weight = Font Weight
+italic = Italic
 font_weight_100 = Thin
 font_weight_200 = Extra Light
 font_weight_300 = Light

--- a/data/strings/en.ini
+++ b/data/strings/en.ini
@@ -801,6 +801,17 @@ empty_fonts = No system fonts were found
 antialias = Antialias
 hinting = Hinting
 ligatures = Ligatures
+font_weight = Font Weight
+font_weight_100 = Thin
+font_weight_200 = Extra Light
+font_weight_300 = Light
+font_weight_400 = Normal
+font_weight_500 = Medium
+font_weight_600 = Semi Bold
+font_weight_700 = Bold
+font_weight_800 = Extra Bold
+font_weight_900 = Black
+font_weight_1000 = Extra Black
 
 [frame_combo]
 all_frames = All frames

--- a/src/app/fonts/font_info.cpp
+++ b/src/app/fonts/font_info.cpp
@@ -177,6 +177,7 @@ app::FontInfo convert_to(const std::string& from)
   bool italic = false;
   app::FontInfo::Flags flags = app::FontInfo::Flags::None;
   text::FontHinting hinting = text::FontHinting::Normal;
+  text::FontStyle::Weight weight = text::FontStyle::Weight::Normal;
 
   if (!parts.empty()) {
     if (parts[0].compare(0, 5, "file=") == 0) {
@@ -214,16 +215,16 @@ app::FontInfo convert_to(const std::string& from)
         else if (hintingStr == "full")
           hinting = text::FontHinting::Full;
       }
+      else if (parts[i].compare(0, 7, "weight=") == 0) {
+        std::string weightStr = parts[i].substr(7);
+        weight = static_cast<text::FontStyle::Weight>(std::atoi(weightStr.c_str()));
+      }
     }
   }
 
-  text::FontStyle style;
-  if (bold && italic)
-    style = text::FontStyle::BoldItalic();
-  else if (bold)
-    style = text::FontStyle::Bold();
-  else if (italic)
-    style = text::FontStyle::Italic();
+  text::FontStyle style(bold ? text::FontStyle::Weight::Bold : weight,
+                        text::FontStyle::Width::Normal,
+                        italic ? text::FontStyle::Slant::Italic : text::FontStyle::Slant::Upright);
 
   return app::FontInfo(type, name, size, style, flags, hinting);
 }
@@ -243,7 +244,7 @@ std::string convert_to(const app::FontInfo& from)
   if (!result.empty()) {
     if (from.size() > 0.0f)
       result += fmt::format(",size={}", from.size());
-    if (from.style().weight() >= text::FontStyle::Weight::SemiBold)
+    if (from.style().weight() == text::FontStyle::Weight::Bold)
       result += ",bold";
     if (from.style().slant() != text::FontStyle::Slant::Upright)
       result += ",italic";
@@ -262,6 +263,8 @@ std::string convert_to(const app::FontInfo& from)
         case text::FontHinting::Full: result += "full"; break;
       }
     }
+    if (from.style().weight() != text::FontStyle::Weight::Bold)
+      result += ",weight=" + std::to_string(static_cast<int>(from.style().weight()));
   }
   return result;
 }

--- a/src/app/fonts/font_info.cpp
+++ b/src/app/fonts/font_info.cpp
@@ -11,6 +11,7 @@
 #include "app/fonts/font_info.h"
 
 #include "app/fonts/font_data.h"
+#include "app/i18n/strings.h"
 #include "app/pref/preferences.h"
 #include "base/fs.h"
 #include "base/split_string.h"
@@ -142,19 +143,22 @@ std::string FontInfo::humanString() const
   }
   result += fmt::format(" {}pt", size());
   if (!result.empty()) {
-    if (style().weight() >= text::FontStyle::Weight::SemiBold)
-      result += " Bold";
+    if (style().weight() != text::FontStyle::Weight::Normal)
+      result +=
+        " " +
+        Strings::Translate(
+          fmt::format("font_style.font_weight_{}", static_cast<int>(style().weight())).c_str());
     if (style().slant() != text::FontStyle::Slant::Upright)
-      result += " Italic";
+      result += " " + Strings::font_style_italic();
     if (antialias())
-      result += " Antialias";
+      result += " " + Strings::font_style_antialias();
     if (ligatures())
-      result += " Ligatures";
+      result += " " + Strings::font_style_ligatures();
     switch (hinting()) {
-      case text::FontHinting::None:   result += " No Hinting"; break;
-      case text::FontHinting::Slight: result += " Slight Hinting"; break;
+      case text::FontHinting::None:   result += " " + Strings::font_style_hinting(); break;
+      case text::FontHinting::Slight: result += " " + Strings::font_style_hinting_slight(); break;
       case text::FontHinting::Normal: break;
-      case text::FontHinting::Full:   result += " Full Hinting"; break;
+      case text::FontHinting::Full:   result += " " + Strings::font_style_hinting_full(); break;
     }
   }
   return result;
@@ -222,9 +226,10 @@ app::FontInfo convert_to(const std::string& from)
     }
   }
 
-  text::FontStyle style(bold ? text::FontStyle::Weight::Bold : weight,
-                        text::FontStyle::Width::Normal,
-                        italic ? text::FontStyle::Slant::Italic : text::FontStyle::Slant::Upright);
+  const text::FontStyle style(
+    bold ? text::FontStyle::Weight::Bold : weight,
+    text::FontStyle::Width::Normal,
+    italic ? text::FontStyle::Slant::Italic : text::FontStyle::Slant::Upright);
 
   return app::FontInfo(type, name, size, style, flags, hinting);
 }

--- a/src/app/ui/font_entry.h
+++ b/src/app/ui/font_entry.h
@@ -115,6 +115,7 @@ private:
   FontSize m_size;
   FontStyle m_style;
   std::unique_ptr<FontStroke> m_stroke;
+  std::vector<text::FontStyle::Weight> m_availableWeights;
   bool m_lockFace = false;
 };
 


### PR DESCRIPTION
Implements #5218. Adds a ComboBox to select the font's weight:
![Recording 2025-08-03 022925](https://github.com/user-attachments/assets/d745ccc1-6f01-4a20-9184-97a49da63f6e)

Two concerns:
 * I had to implement an ugly hack to prevent the ComboBox's window from going over the popup's size, since you couldn't click on items there, @dacap is there an easy fix for this that I'm missing? Holding the mouse button and moving down works fine, but individual clicks just fall through. I'm assuming this is because of the popup's clicking-outside-bounds-closes-it, but I don't know if we wanna get rid of that behavior. Originally I intended moving everything to a Menu and having the weights be in a submenu but those don't have checkbox support and I didn't feel like going down that particular rabbit hole... unless?
 * Right now the *B* bold button is selected when the weight is equal or above to SemiBold, now that we have granular control over font weights, do we want to keep this as-is or change it?