### PR TITLE
Unify ContextBar updates when moving pixels, tooltips (fix #5329)

### DIFF
--- a/data/strings/en.ini
+++ b/data/strings/en.ini
@@ -621,6 +621,14 @@ current_layer = Current Layer
 first_ref_layer = First Reference Layer
 pick = Pick:
 sample = Sample:
+position_label = P:
+rotation_label = R:
+position_x = X Position
+position_y = Y Position
+size_width = Width
+size_height = Height
+rotation_angle = Angle
+rotation_skew = Skew
 
 [convolution_matrix]
 reload_stock = &Reload Stock

--- a/src/app/ui/context_bar.cpp
+++ b/src/app/ui/context_bar.cpp
@@ -1001,12 +1001,12 @@ public:
     m_angle.setSuffix("°");
     m_skew.setSuffix("°");
 
-    addChild(new Label("P:"));
+    addChild(new Label(Strings::context_bar_position_label()));
     addChild(&m_x);
     addChild(&m_y);
     addChild(&m_w);
     addChild(&m_h);
-    addChild(new Label("R:"));
+    addChild(new Label(Strings::context_bar_rotation_label()));
     addChild(&m_angle);
     addChild(&m_skew);
 
@@ -1045,6 +1045,16 @@ public:
     });
     m_angle.Change.connect([this] { onChangeAngle(); });
     m_skew.Change.connect([this] { onChangeSkew(); });
+  }
+
+  void setupTooltips(TooltipManager* tooltipManager)
+  {
+    tooltipManager->addTooltipFor(&m_x, Strings::context_bar_position_x(), BOTTOM);
+    tooltipManager->addTooltipFor(&m_y, Strings::context_bar_position_y(), BOTTOM);
+    tooltipManager->addTooltipFor(&m_w, Strings::context_bar_size_width(), BOTTOM);
+    tooltipManager->addTooltipFor(&m_h, Strings::context_bar_size_height(), BOTTOM);
+    tooltipManager->addTooltipFor(&m_angle, Strings::context_bar_rotation_angle(), BOTTOM);
+    tooltipManager->addTooltipFor(&m_skew, Strings::context_bar_rotation_skew(), BOTTOM);
   }
 
   void update(const Transformation& t)
@@ -2626,6 +2636,7 @@ void ContextBar::setupTooltips(TooltipManager* tooltipManager)
   m_dropPixels->setupTooltips(tooltipManager);
   m_symmetry->setupTooltips(tooltipManager);
   m_sliceFields->setupTooltips(tooltipManager);
+  m_transformation->setupTooltips(tooltipManager);
 }
 
 void ContextBar::registerCommands()

--- a/src/app/ui/editor/moving_pixels_state.cpp
+++ b/src/app/ui/editor/moving_pixels_state.cpp
@@ -286,9 +286,6 @@ bool MovingPixelsState::onMouseDown(Editor* editor, MouseMessage* msg)
   UIContext* ctx = UIContext::instance();
   ctx->setActiveView(editor->getDocView());
 
-  ContextBar* contextBar = App::instance()->contextBar();
-  contextBar->updateForMovingPixels(getTransformation(editor));
-
   // Start scroll loop
   if (editor->checkForScroll(msg) || editor->checkForZoom(msg))
     return true;
@@ -442,10 +439,6 @@ void MovingPixelsState::onCommitMouseMove(Editor* editor, const gfx::PointF& spr
   // Drag the image to that position
   m_pixelsMovement->moveImage(spritePos, moveModifier);
 
-  // Update context bar and status bar
-  ContextBar* contextBar = App::instance()->contextBar();
-  contextBar->updateForMovingPixels(transformation);
-
   m_editor->updateStatusBar();
 }
 
@@ -528,6 +521,10 @@ bool MovingPixelsState::onUpdateStatusBar(Editor* editor)
 
   const Transformation& transform(getTransformation(editor));
   gfx::Size imageSize = m_pixelsMovement->getInitialImageSize();
+
+  // Update the context bar along with the status bar
+  ContextBar* contextBar = App::instance()->contextBar();
+  contextBar->updateForMovingPixels(transform);
 
   int w = int(transform.bounds().w);
   int h = int(transform.bounds().h);


### PR DESCRIPTION
Fixes #5329, and I took an extra second to add some tooltips & localization for consistency while I was there.
