### PR TITLE
Escape characters in the console that we can't show properly (fix #5324)

### DIFF
--- a/src/app/console.cpp
+++ b/src/app/console.cpp
@@ -81,7 +81,7 @@ public:
 
   ~ConsoleWindow() { TRACE_CON("CON: ~ConsoleWindow this=", this); }
 
-  void addMessage(const std::string& msg)
+  void addMessage(std::string msg)
   {
     if (!m_hasText) {
       m_hasText = true;
@@ -92,6 +92,17 @@ public:
     gfx::Size visible = m_view.visibleSize();
     gfx::Point pt = m_view.viewScroll();
     const bool autoScroll = (pt.y >= maxSize.h - visible.h);
+
+    // Escape characters we can't show properly
+    for (size_t i = 0; i < msg.size(); i++) {
+      switch (msg[i]) {
+        case '\a':
+        case '\b':
+        case '\r':
+        case '\t':
+        case '\v': msg[i] = ' ';
+      }
+    }
 
     m_textbox.setText(m_textbox.text() + msg);
 


### PR DESCRIPTION
Fixes #5324

Example code:
```lua
local t = { table = 1 }
local b = false
local n = 5.333

print("a table:", t, "a boolean:", b, "a float value:", n)

print("\\a: \a")
print("\\b: \b")
print("\\f: \f")
print("\\n: \n")
print("\\r: \r")
print("\\t: \t")
print("\\v: \v")
print("\\r: \r")
```

### Results

Before:
<img width="659" height="362" alt="Screenshot 2025-08-11 161748" src="https://github.com/user-attachments/assets/f3bcc960-ef7f-4b95-83b9-acae640eb7d7" />
After:
<img width="615" height="361" alt="Screenshot 2025-08-11 161704" src="https://github.com/user-attachments/assets/c6ea1d9c-b95a-483f-8bf7-ff56ed73ef82" />
