### PR TITLE
Improve statusbar tooltip behavior for readability

### DIFF
--- a/src/ui/popup_window.cpp
+++ b/src/ui/popup_window.cpp
@@ -157,6 +157,13 @@ bool PopupWindow::onProcessMessage(Message* msg)
             }
             break;
           }
+
+          case ClickBehavior::CloseOnClick: {
+            if (bounds().contains(mouseMsg->position())) {
+              closeWindow(nullptr);
+            }
+            break;
+          }
         }
       }
       break;

--- a/src/ui/popup_window.h
+++ b/src/ui/popup_window.h
@@ -18,7 +18,8 @@ public:
   enum class ClickBehavior {
     DoNothingOnClick,
     CloseOnClickInOtherWindow,
-    CloseOnClickOutsideHotRegion
+    CloseOnClickOutsideHotRegion,
+    CloseOnClick
   };
 
   enum class EnterBehavior {


### PR DESCRIPTION
Grabs the more accessibility-adjacent changes from #5316 (IMO), the ability to hover over a tooltip to be able to read it in full before it vanishes, and being able to click to dismiss it early.
