### PR TITLE
Allow typing numbers into Slider widgets

### DIFF
--- a/src/ui/slider.h
+++ b/src/ui/slider.h
@@ -9,6 +9,7 @@
 #define UI_SLIDER_H_INCLUDED
 #pragma once
 
+#include "base/time.h"
 #include "obs/signal.h"
 #include "ui/widget.h"
 
@@ -67,6 +68,9 @@ private:
   int m_value;
   bool m_readOnly;
   SliderDelegate* m_delegate;
+
+  base::tick_t m_keyTiming = 0;
+  std::string m_keyBuffer;
 };
 
 } // namespace ui


### PR DESCRIPTION
Adds the ability for the user to use the number keys change the value of slider widgets, including negative numbers. Pressing backspace also deletes a number like in a text input, serves as both a power user feature and an accessibility one, for fine grained control and keyboard navigation.

https://github.com/user-attachments/assets/2c247a63-cb91-4ccb-aff9-cfff3138896f

<sub>(I should've recorded this with some kind of input overlay, hopefully it's understandable enough)</sub>