### PR TITLE
[lua] Prevent adding a mask without a bitmap to the clipboard (fix #5361)

### DIFF
--- a/src/app/script/app_clipboard_object.cpp
+++ b/src/app/script/app_clipboard_object.cpp
@@ -199,7 +199,7 @@ int Clipboard_set_content(lua_State* L)
   type = lua_getfield(L, 2, "selection");
   if (type != LUA_TNIL) {
     mask = get_mask_from_arg(L, -1);
-    if (!mask)
+    if (!mask || !mask->bitmap())
       return luaL_error(L, "invalid selection provided");
   }
   lua_pop(L, 1);


### PR DESCRIPTION
Fixes #5361, the pasting code expects a mask with a bitmap, at least for the initial one. Fixing this on the Lua side seemed more practical, but I'm not sure if there's a case where we'd want the user to add a selection like this to the clipboard? In that case it'd probably need a refactor of some kind to the pasting/pixelsmovement code.
