### PR TITLE
Use the CLI paste when incoming masks have no bitmap (fix #5361)

### DIFF
--- a/src/app/util/clipboard.cpp
+++ b/src/app/util/clipboard.cpp
@@ -485,7 +485,8 @@ void Clipboard::paste(Context* ctx, const bool interactive, const gfx::Point* po
                                                      0));
       }
 
-      if (editor && interactive) {
+      bool validMask = (m_data->mask && m_data->mask->bitmap());
+      if (editor && interactive && validMask) {
         // TODO we don't support pasting in multiple cels at the
         //      moment, so we clear the range here (same as in
         //      PasteTextCommand::onExecute())
@@ -529,12 +530,14 @@ void Clipboard::paste(Context* ctx, const bool interactive, const gfx::Point* po
             site.palette(),
             255,
             BlendMode::NORMAL);
-          doc::blend_image(result.get(),
-                           src_image.get(),
-                           gfx::Clip(*position - resultBounds.origin(), src_image->bounds()),
-                           site.palette(),
-                           255,
-                           BlendMode::NORMAL);
+          doc::blend_image(
+            result.get(),
+            src_image.get(),
+            gfx::Clip(position ? *position - resultBounds.origin() : resultBounds.origin(),
+                      src_image->bounds()),
+            site.palette(),
+            255,
+            BlendMode::NORMAL);
         }
 
         ContextWriter writer(ctx);


### PR DESCRIPTION
Fixes #5361, switches over to "CLI" pasting when the incoming mask has no bitmap, since that can cause problems with the interactive selection, I think this is cleaner than my previous attempt to prevent this kind of thing from getting into the clipboard in the first place, this way things can get pasted "properly" even if they're just a blank image with no selection.