### PR TITLE
[lua] Refresh timeline when changing layer collapsed status (fix #5366)

### DIFF
--- a/src/app/script/layer_class.cpp
+++ b/src/app/script/layer_class.cpp
@@ -22,6 +22,7 @@
 #include "app/script/luacpp.h"
 #include "app/script/userdata.h"
 #include "app/tx.h"
+#include "app/ui/timeline/timeline.h"
 #include "doc/layer.h"
 #include "doc/layer_tilemap.h"
 #include "doc/sprite.h"
@@ -355,6 +356,9 @@ int Layer_set_isCollapsed(lua_State* L)
 {
   auto layer = get_docobj<Layer>(L, 1);
   layer->setCollapsed(lua_toboolean(L, 2));
+
+  if (auto* timeline = App::instance()->timeline())
+    timeline->refresh();
   return 0;
 }
 
@@ -362,6 +366,9 @@ int Layer_set_isExpanded(lua_State* L)
 {
   auto layer = get_docobj<Layer>(L, 1);
   layer->setCollapsed(!lua_toboolean(L, 2));
+
+  if (auto* timeline = App::instance()->timeline())
+    timeline->refresh();
   return 0;
 }
 

--- a/src/app/ui/timeline/timeline.cpp
+++ b/src/app/ui/timeline/timeline.cpp
@@ -4321,6 +4321,13 @@ void Timeline::clearAndInvalidateRange()
   }
 }
 
+void Timeline::refresh()
+{
+  regenerateCols();
+  regenerateRows();
+  invalidate();
+}
+
 app::gen::GlobalPref::Timeline& Timeline::timelinePref() const
 {
   return Preferences::instance().timeline;

--- a/src/app/ui/timeline/timeline.h
+++ b/src/app/ui/timeline/timeline.h
@@ -155,6 +155,8 @@ public:
 
   void clearAndInvalidateRange();
 
+  void refresh();
+
 protected:
   bool onProcessMessage(ui::Message* msg) override;
   void onInitTheme(ui::InitThemeEvent& ev) override;


### PR DESCRIPTION
Fixes #5366, had to add a function to force the relayouting of rows, unclear if there's a way to do this through more "proper" event stuff but this seems logical.