### PR TITLE
[lua] Fix new layers not going to the top when selected (fix #5364)

### DIFF
--- a/src/app/commands/cmd_new_layer.cpp
+++ b/src/app/commands/cmd_new_layer.cpp
@@ -267,16 +267,8 @@ void NewLayerCommand::onExecute(Context* context)
     bool afterBackground = false;
 
     switch (m_type) {
-      case Type::Layer:
-
-        if (m_place == Place::BeforeActiveLayer) {
-          layer = api.newLayer(parent, name);
-          api.restackLayerBefore(layer, parent, activeLayer);
-        }
-        else
-          layer = api.newLayerAfter(parent, name, activeLayer);
-        break;
-      case Type::Group: layer = api.newGroupAfter(parent, name, activeLayer); break;
+      case Type::Layer: layer = api.newLayer(parent, name); break;
+      case Type::Group: layer = api.newGroup(parent, name); break;
       case Type::ReferenceLayer:
         layer = api.newLayer(parent, name);
         if (layer)
@@ -310,6 +302,15 @@ void NewLayerCommand::onExecute(Context* context)
       return;
 
     ASSERT(layer->parent());
+
+    // Reorder the resulting layer.
+    switch (m_place) {
+      case Place::AfterActiveLayer:  api.restackLayerAfter(layer, parent, activeLayer); break;
+      case Place::BeforeActiveLayer: api.restackLayerBefore(layer, parent, activeLayer); break;
+      case Place::Top:
+        api.restackLayerAfter(layer, sprite->root(), sprite->root()->lastLayer());
+        break;
+    }
 
     // Put new layer as an overlay of the background or in the first
     // layer in case the sprite is transparent.


### PR DESCRIPTION
Fixes #5364, this _seems_ like an oversight where the code just wasn't there, but it might be this way for legacy reasons.