### PR TITLE
Add placeholder property to Entry, default placeholder for SearchEntry

### DIFF
--- a/data/strings/en.ini
+++ b/data/strings/en.ini
@@ -826,6 +826,7 @@ same_in_all_tools = Same in all Tools
 opacity = Opacity:
 tolerance = Tolerance:
 show_more = Show more...
+search = Search
 
 [general_text]
 copy = &Copy

--- a/src/app/ui/skin/skin_theme.cpp
+++ b/src/app/ui/skin/skin_theme.cpp
@@ -1452,11 +1452,13 @@ void SkinTheme::drawEntryText(ui::Graphics* g, ui::Entry* widget)
   DrawEntryTextDelegate delegate(widget, g, bounds.origin(), widget->textHeight());
   int scroll = delegate.index();
 
-  // Full text to paint: widget text + suffix
-  const std::string textString = widget->text() + widget->getSuffix();
+  const std::string& fullText = widget->text() + widget->getSuffix();
 
-  if (!textString.empty()) {
-    base::utf8_decode dec(textString);
+  // Full text to paint: widget text + suffix or placeholder
+  const std::string& paintText = fullText.empty() ? widget->placeholder() : fullText;
+
+  if (!paintText.empty()) {
+    base::utf8_decode dec(paintText);
     auto pos = dec.pos();
     for (int i = 0; i < scroll && dec.next(); ++i)
       pos = dec.pos();
@@ -1473,8 +1475,8 @@ void SkinTheme::drawEntryText(ui::Graphics* g, ui::Entry* widget)
         baselineAdjustment += metrics.ascent;
       }
 
-      g->drawTextWithDelegate(std::string(pos, textString.end()), // TODO use a string_view()
-                              colors.text(),
+      g->drawTextWithDelegate(std::string(pos, paintText.end()), // TODO use a string_view()
+                              fullText.empty() ? colors.disabled() : colors.text(),
                               ColorNone,
                               gfx::Point(bounds.x, baselineAdjustment),
                               &delegate);

--- a/src/app/widget_loader.cpp
+++ b/src/app/widget_loader.cpp
@@ -253,6 +253,9 @@ Widget* WidgetLoader::convertXmlElementToWidget(const XMLElement* elem,
     if (suffix)
       ((Entry*)widget)->setSuffix(suffix);
 
+    if (elem->Attribute("placeholder"))
+      ((Entry*)widget)->setPlaceholder(m_xmlTranslator(elem, "placeholder"));
+
     if (elem_name == "expr" && decimals)
       ((ExprEntry*)widget)->setDecimals(strtol(decimals, nullptr, 10));
   }
@@ -529,6 +532,11 @@ Widget* WidgetLoader::convertXmlElementToWidget(const XMLElement* elem,
   else if (elem_name == "search") {
     if (!widget)
       widget = new SearchEntry;
+
+    if (elem->Attribute("placeholder"))
+      ((SearchEntry*)widget)->setPlaceholder(m_xmlTranslator(elem, "placeholder"));
+    else
+      ((SearchEntry*)widget)->setPlaceholder(Strings::general_search());
   }
   else if (elem_name == "font") {
     if (!widget)

--- a/src/ui/entry.cpp
+++ b/src/ui/entry.cpp
@@ -531,6 +531,16 @@ gfx::Size Entry::sizeHintWithText(Entry* entry, const std::string& text)
   return gfx::Size(w, h);
 }
 
+void Entry::setPlaceholder(const std::string& placeholder)
+{
+  m_placeholder = placeholder;
+}
+
+const std::string& Entry::placeholder()
+{
+  return m_placeholder;
+}
+
 void Entry::onSizeHint(SizeHintEvent& ev)
 {
   const auto& font = this->font();

--- a/src/ui/entry.h
+++ b/src/ui/entry.h
@@ -73,6 +73,9 @@ public:
 
   static gfx::Size sizeHintWithText(Entry* entry, const std::string& text);
 
+  void setPlaceholder(const std::string& placeholder);
+  const std::string& placeholder();
+
   // Signals
   obs::signal<void()> Change;
 
@@ -155,6 +158,8 @@ private:
   // case you are going to display/paint the text scaled and want to
   // convert the mouse position correctly.
   gfx::PointF m_scale;
+
+  std::string m_placeholder;
 };
 
 } // namespace ui


### PR DESCRIPTION
Adds a "placeholder" property to Entry widgets, and a new default "Search" placeholder for SeachEntry widgets. This is an excerpt from the work I'm doing on the command runner, figured it's very self contained so it deserves its own PR.

<img width="179" height="99" alt="image" src="https://github.com/user-attachments/assets/038be75d-cba0-4417-8f63-4ed52e977f98" />

