### PR TITLE
Fix DECORATIVE widget drawing outside of window

### DIFF
--- a/src/ui/widget.cpp
+++ b/src/ui/widget.cpp
@@ -936,6 +936,10 @@ void Widget::getDrawableRegion(gfx::Region& region, DrawableRegionFlags flags)
     if (p) {
       region &= Region(p->bounds());
     }
+    // Intersect with window bounds
+    if (this->window()) {
+      region &= Region(this->window()->bounds());
+    }
   }
 
   // Limit to the displayable area


### PR DESCRIPTION
This PR fixes a glitch I've noticed when using the undocked color sliders popup in "single native window" mode. 

Steps to reproduce:
1) Move the colors sliders to any position on the screen.
2) Reduce its width until the close button is not displayed any more.
3) Move sliders or press any of the buttons, you will see that the close button is painted outside the color sliders window:

<img width="483" height="196" alt="image" src="https://github.com/user-attachments/assets/86ea96e0-ea23-4222-b255-0daf7e59fcc3" />
