### PR TITLE
See defaults when the saved font info is empty or invalid (fix #5339)

### DIFF
--- a/src/app/fonts/font_info.cpp
+++ b/src/app/fonts/font_info.cpp
@@ -10,9 +10,12 @@
 
 #include "app/fonts/font_info.h"
 
+#include "app/app.h"
 #include "app/fonts/font_data.h"
 #include "app/i18n/strings.h"
 #include "app/pref/preferences.h"
+#include "app/ui/main_window.h"
+#include "app/ui/skin/skin_theme.h"
 #include "base/fs.h"
 #include "base/split_string.h"
 #include "fmt/format.h"
@@ -115,6 +118,12 @@ FontInfo FontInfo::getFromPreferences()
   // New configuration
   if (!pref.textTool.fontInfo().empty()) {
     fontInfo = base::convert_to<FontInfo>(pref.textTool.fontInfo());
+  }
+
+  if (!fontInfo.isValid()) {
+    // No valid settings found, use the default widget font
+    fontInfo = static_cast<app::skin::SkinTheme*>(App::instance()->mainWindow()->theme())
+                 ->getDefaultFontInfo();
   }
 
   return fontInfo;

--- a/src/app/ui/font_entry.cpp
+++ b/src/app/ui/font_entry.cpp
@@ -386,6 +386,11 @@ void FontEntry::setInfo(const FontInfo& info, const From fromField)
 {
   m_info = info;
 
+  if (fromField == From::Init && !info.findTypeface(theme()->fontMgr())) {
+    // Revert to default if we are initialized with an invalid/non-existent font
+    m_info = skin::SkinTheme::get(this)->getDefaultFontInfo();
+  }
+
   auto family = theme()->fontMgr()->matchFamily(m_info.name());
   bool hasBold = false;
   m_availableWeights.clear();
@@ -431,6 +436,7 @@ void FontEntry::setInfo(const FontInfo& info, const From fromField)
 
   if (fromField != From::Face) {
     m_face.setText(m_info.title());
+    m_face.setPlaceholder(m_info.title());
   }
 
   if (fromField != From::Size) {


### PR DESCRIPTION
Attempts to fix the font selector showing an empty field and 0px when there's no text tool preferences saved (on first run)
<img width="588" height="62" alt="image" src="https://github.com/user-attachments/assets/a1780a15-5ffe-431f-af55-d6084adebdd0" />

Now it should show the font we're actually using, the theme one. I'm not sure if there's a cleaner way to do this, I spent a while going around the code to find a place where we could more cleanly get this but it seems like it's just using the widget font when there's nothing available, so I'm defaulting to that.

This also now checks at initialization time in the font selector if the font is available, otherwise deleting a font from the system would still show it as selected (and revert to the default theme font silently).