### PR TITLE
CMake: Use find_package(PkgConfig) instead of direct include

### DIFF
--- a/cmake/FindHarfBuzz.cmake
+++ b/cmake/FindHarfBuzz.cmake
@@ -30,7 +30,7 @@
 # HARFBUZZ_INCLUDE_DIRS - containg the HarfBuzz headers
 # HARFBUZZ_LIBRARIES - containg the HarfBuzz library
 
-include(FindPkgConfig)
+find_package(PkgConfig QUIET)
 
 pkg_check_modules(PC_HARFBUZZ harfbuzz>=0.9.7)
 


### PR DESCRIPTION
This gets rid of the following warning:

```
CMake Warning (dev) at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:441 (message):
  The package name passed to `find_package_handle_standard_args` (PkgConfig)
  does not match the name of the calling package (HarfBuzz).  This can lead
  to problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindPkgConfig.cmake:114 (find_package_handle_standard_args)
  aseprite/cmake/FindHarfBuzz.cmake:33 (include)
  CMakeLists.txt:173 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

By applying the following change: https://github.com/WebKit/WebKit/commit/407fa892d9dfa41738fd985f274485be63d26cfb

The file could use further updates based on the upstream version.

---

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing
