### PR TITLE
Fix mouse gestures not working after switching documents

### DIFF
--- a/src/app/ui_context.cpp
+++ b/src/app/ui_context.cpp
@@ -25,6 +25,7 @@
 #include "app/ui/workspace.h"
 #include "app/ui/workspace_tabs.h"
 #include "doc/sprite.h"
+#include "ui/manager.h"
 #include "ui/system.h"
 
 #include <algorithm>
@@ -119,6 +120,10 @@ void UIContext::setActiveView(DocView* docView)
 
   mainWin->getTimeline()->updateUsingEditor(editor);
   mainWin->getPreviewEditor()->updateUsingEditor(editor);
+
+  // Update mouse widgets immediately after changing views rather
+  // than waiting for mouse movement.
+  mainWin->manager()->_updateMouseWidgets();
 
   // Change the image-type of color bar.
   ColorBar::instance()->setPixelFormat(app_get_current_pixel_format());


### PR DESCRIPTION
Fix #4388.

This PR fixes an issue where mouse gestures such as zooming in/out would not work immediately after switching tabs with ctrl+tab or ctrl+shift+tab; mouse movement was required for the functionality to work. The mouse widget should now automatically update after switching tabs and immediately allow for zooming to be done.