### PR TITLE
Check mask validity before pasting (fix #5361)

### DIFF
--- a/src/app/ui/editor/editor.cpp
+++ b/src/app/ui/editor/editor.cpp
@@ -2763,7 +2763,7 @@ void Editor::pasteImage(const Image* image, const Mask* mask, const gfx::Point* 
   ASSERT(image);
 
   std::unique_ptr<Mask> temp_mask;
-  if (!mask) {
+  if (!mask || mask->bounds().isEmpty()) {
     gfx::Rect visibleBounds = getVisibleSpriteBounds();
     gfx::Rect imageBounds = image->bounds();
 


### PR DESCRIPTION
Fixes #5361, supersedes #5363, found a much more elegant solution. Now we check for both the mask pointer existing and it not being empty before pasting, so it can create the proper temp mask.
