### PR TITLE
Fix crash painting deleted cels while applying filter (fix #4991)

### DIFF
--- a/src/app/commands/filters/filter_manager_impl.cpp
+++ b/src/app/commands/filters/filter_manager_impl.cpp
@@ -325,8 +325,13 @@ void FilterManagerImpl::applyToTarget()
 void FilterManagerImpl::initTransaction()
 {
   ASSERT(!m_tx);
-  m_writer.reset(new ContextWriter(m_reader));
+  m_writer = std::make_unique<ContextWriter>(m_reader);
   m_tx.reset(new Tx(*m_writer, m_filter->getName(), ModifyDocument));
+}
+
+void FilterManagerImpl::updateWriterThread()
+{
+  document()->updateWriterThread();
 }
 
 bool FilterManagerImpl::isTransaction() const

--- a/src/app/commands/filters/filter_manager_impl.h
+++ b/src/app/commands/filters/filter_manager_impl.h
@@ -93,6 +93,7 @@ public:
   void applyToTarget();
 
   void initTransaction();
+  void updateWriterThread();
   bool isTransaction() const;
   void commitTransaction();
 

--- a/src/app/doc.cpp
+++ b/src/app/doc.cpp
@@ -124,6 +124,11 @@ Doc::LockResult Doc::upgradeToWrite(int timeout)
   return res;
 }
 
+void Doc::updateWriterThread()
+{
+  m_rwLock.updateWriterThread();
+}
+
 void Doc::downgradeToRead(LockResult lockResult)
 {
   DOC_TRACE("DOC: downgradeToRead", this, (int)lockResult);

--- a/src/app/doc.h
+++ b/src/app/doc.h
@@ -82,6 +82,7 @@ public:
   LockResult readLock(int timeout);
   LockResult writeLock(int timeout);
   LockResult upgradeToWrite(int timeout);
+  void updateWriterThread();
   void downgradeToRead(LockResult lockResult);
   void unlock(LockResult lockResult);
 


### PR DESCRIPTION
This could happen in Editor::onPaint() or Timeline::onPaint(), these functions were able to read-lock the document because the document is write-lock from the UI thread.