### PR TITLE
Add QOL File Sequence Opening To Include Parenthesis

### DIFF
--- a/src/app/file/split_filename.cpp
+++ b/src/app/file/split_filename.cpp
@@ -26,11 +26,44 @@ int split_filename(const std::string& filename, std::string& left, std::string& 
   if (!right.empty())
     right.insert(right.begin(), '.');
 
-  // Remove all trailing numbers in the "left" side.
-  std::string result_str;
   width = 0;
   int num = -1;
   int order = 1;
+
+  // Case 1: Parenthesis or square brackets
+  if (left.size() >= 3 && (left.back() == ')' || left.back() == ']')) {
+    char closing = left.back();
+    char opening = (closing == ')') ? '(' : '[';
+
+    auto it = left.rbegin();
+    auto end = left.rend();
+    ++it;
+
+    while (it != end) {
+      const int chr = *it;
+      if (chr >= '0' && chr <= '9') {
+        if (num < 0)
+          num = 0;
+        num += order * (chr - '0');
+        order *= 10;
+        ++width;
+        ++it;
+      }
+      else
+        break;
+    }
+
+    if (width > 0 && it != end && *it == opening) {
+      left.erase(it.base(), left.end());
+      right.insert(right.begin(), closing);
+    }
+
+    return num;
+  }
+
+  // Case 2: Default behavior
+  num = -1;
+  order = 1;
 
   auto it = left.rbegin();
   auto end = left.rend();

--- a/src/app/file/split_filename.cpp
+++ b/src/app/file/split_filename.cpp
@@ -26,11 +26,45 @@ int split_filename(const std::string& filename, std::string& left, std::string& 
   if (!right.empty())
     right.insert(right.begin(), '.');
 
-  // Remove all trailing numbers in the "left" side.
-  std::string result_str;
   width = 0;
   int num = -1;
   int order = 1;
+
+  // Case 1: Parenthesis or square brackets
+  if (left.size() >= 3 && (left.back() == ')' || left.back() == ']')) {
+    char closing = left.back();
+    char opening = (closing == ')') ? '(' : '[';
+
+    auto it = left.rbegin();
+    auto end = left.rend();
+    ++it;
+
+    while (it != end) {
+      const int chr = *it;
+      if (chr >= '0' && chr <= '9') {
+        if (num < 0)
+          num = 0;
+
+        num += order * (chr - '0');
+        order *= 10;
+        ++width;
+        ++it;
+      }
+      else
+        break;
+    }
+
+    if (width > 0 && it != end && *it == opening) {
+      left.erase(it.base(), left.end());
+      right.insert(right.begin(), closing);
+    }
+
+    return num;
+  }
+
+  // Case 2: Default behavior
+  num = -1;
+  order = 1;
 
   auto it = left.rbegin();
   auto end = left.rend();

--- a/src/app/file/split_filename.cpp
+++ b/src/app/file/split_filename.cpp
@@ -33,7 +33,7 @@ int split_filename(const std::string& filename, std::string& left, std::string& 
   // Case 1: Parenthesis or square brackets
   if (left.size() >= 3 && (left.back() == ')' || left.back() == ']')) {
     char const closing = left.back();
-    char opening = (closing == ')') ? '(' : '[';
+    char const opening = (closing == ')') ? '(' : '[';
 
     auto it = left.rbegin();
     auto end = left.rend();

--- a/src/app/file/split_filename.cpp
+++ b/src/app/file/split_filename.cpp
@@ -32,7 +32,7 @@ int split_filename(const std::string& filename, std::string& left, std::string& 
 
   // Case 1: Parenthesis or square brackets
   if (left.size() >= 3 && (left.back() == ')' || left.back() == ']')) {
-    char closing = left.back();
+    char const closing = left.back();
     char opening = (closing == ')') ? '(' : '[';
 
     auto it = left.rbegin();


### PR DESCRIPTION
Adressing issue #5442 about opening files in sequences that have
parenthesis or square brackets surrounding them (e.g. img [1], img [2])
Now possible to open them this way, where they were unincluded before
Also removed seemingly unnecessary result_str string to avoid confusion
Also created new commit that did nothing for some reason, sorry lol

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the Individual Contributor License Agreement V4.0. -->
<!-- If you're a first-time contributor, please sign the CLA
     as indicated in https://github.com/igarastudio/cla#signing
     and acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing
