### PR TITLE
Fix rotate command creating copy of selection

### DIFF
--- a/src/app/ui/editor/standby_state.cpp
+++ b/src/app/ui/editor/standby_state.cpp
@@ -749,9 +749,9 @@ void StandbyState::transformSelection(Editor* editor, MouseMessage* msg, HandleT
                                                         document->mask(),
                                                         "Transformation"));
 
-    // If the Ctrl key is pressed start dragging a copy of the selection
+    // If the Ctrl key is pressed and there is a handle, start dragging a copy of the selection
     EditorCustomizationDelegate* customization = editor->getCustomizationDelegate();
-    if ((customization) &&
+    if (handle != NoHandle && customization &&
         int(customization->getPressedKeyAction(KeyContext::TranslatingSelection) &
             KeyAction::CopySelection))
       pixelsMovement->copyMask();


### PR DESCRIPTION
Fix #1330.

This PR fixes an issue where using a keyboard shortcut to rotate a selection would create a copy of the selection if certain keys were used. Copies are now only made if a handle is passed to the related code (i.e. rotation was performed through the GUI).