### PR TITLE
Fix pixel-perfect intertwine tile painting (fix #5394)

### DIFF
--- a/src/app/tools/intertwiners.h
+++ b/src/app/tools/intertwiners.h
@@ -614,24 +614,25 @@ private:
     loop->getTiledModeHelper().wrapPosition(rgn);
     loop->getTiledModeHelper().collapseRegionByTiledMode(rgn);
 
-    for (auto a : rgn) {
+    for (auto& a : rgn) {
       a.offset(-loop->getCelOrigin());
+
+      ImageRef i(crop_image(loop->getDstImage(), a, loop->getDstImage()->maskColor()));
 
       if (m_tempTileset) {
         forEachTilePos(loop,
                        m_dstGrid.tilesInCanvasRegion(gfx::Region(a)),
-                       [loop](const doc::ImageRef existentTileImage, const gfx::Point tilePos) {
-                         loop->getDstImage()->copy(existentTileImage.get(),
-                                                   gfx::Clip(tilePos.x,
-                                                             tilePos.y,
-                                                             0,
-                                                             0,
-                                                             existentTileImage->width(),
-                                                             existentTileImage->height()));
+                       [loop, i](const doc::ImageRef existentTileImage, const gfx::Point tilePos) {
+                         i->copy(existentTileImage.get(),
+                                 gfx::Clip(tilePos.x,
+                                           tilePos.y,
+                                           0,
+                                           0,
+                                           existentTileImage->width(),
+                                           existentTileImage->height()));
                        });
       }
 
-      ImageRef i(crop_image(loop->getDstImage(), a, loop->getDstImage()->maskColor()));
       m_savedAreas.push_back(SavedArea{ i, pt, a });
     }
   }


### PR DESCRIPTION
Fixes #5394.

This fix was a bit trial and error because I'm not 100% sure how everything in the surrounded systems work, but the main thing was that the `forEachTilePos` was modifying the destination image directly and then that was being saved, which might've worked for non-flipped tiles and gone unnoticed, but I think goes against what the logic here is trying to do (using a temporary image and then restoring it).