### PR TITLE
Fix export file window not starting out centered

### DIFF
--- a/src/app/commands/cmd_save_file.cpp
+++ b/src/app/commands/cmd_save_file.cpp
@@ -395,6 +395,7 @@ void SaveFileCopyAsCommand::onExecute(Context* context)
     }
 
     win.remapWindow();
+    win.centerWindow();
     load_window_pos(&win, "ExportFile");
   again:;
     const bool result = win.show();


### PR DESCRIPTION
We were missing the call to `centerWindow()` so when loading the window for the first time it defaulted to the top left.