### PR TITLE
Add ignore empty frames toggle to Export As window

### DIFF
--- a/data/pref.xml
+++ b/data/pref.xml
@@ -575,6 +575,7 @@
       <option id="apply_pixel_ratio" type="bool" default="false" />
       <option id="for_twitter" type="bool" default="false" />
       <option id="play_subtags" type="bool" default="true" />
+      <option id="ignore_empty" type="bool" default="false" />
     </section>
     <section id="sprite_sheet">
       <option id="defined" type="bool" default="false" />

--- a/data/strings/en.ini
+++ b/data/strings/en.ini
@@ -686,6 +686,7 @@ pixel_ratio = Apply pixel ratio
 for_twitter = Export for Twitter
 for_twitter_tooltip = Adjust the duration of the last frame to 1/4 so\nTwitter reproduces the animation correctly
 adjust_resize = Adjust resize to {0}%
+ignore_empty = Ignore empty frames
 export = &Export
 cancel = &Cancel
 

--- a/data/widgets/export_file.xml
+++ b/data/widgets/export_file.xml
@@ -44,6 +44,8 @@
         <button id="adjust_resize" text="@.adjust_resize" style="mini_button" />
       </hbox>
 
+      <check id="ignore_empty" text="@.ignore_empty" cell_hspan="3" />
+
       <hbox cell_hspan="3">
         <boxfiller />
         <hbox homogeneous="true">

--- a/src/app/commands/cmd_save_file.cpp
+++ b/src/app/commands/cmd_save_file.cpp
@@ -353,6 +353,7 @@ void SaveFileCopyAsCommand::onExecute(Context* context)
   doc::AniDir aniDirValue = params().aniDir();
   bool isPlaySubtags = params().playSubtags();
   bool isForTwitter = false;
+  bool isIgnoreEmpty = params().ignoreEmpty();
 
   if (params().ui() && context->isUIAvailable()) {
     ExportFileWindow win(doc);
@@ -429,6 +430,7 @@ void SaveFileCopyAsCommand::onExecute(Context* context)
     aniDirValue = win.aniDirValue();
     isForTwitter = win.isForTwitter();
     isPlaySubtags = win.isPlaySubtags();
+    isIgnoreEmpty = win.isIgnoreEmpty();
   }
 
   gfx::PointF scaleXY(scale, scale);
@@ -497,6 +499,7 @@ void SaveFileCopyAsCommand::onExecute(Context* context)
     if (!bounds.isEmpty())
       params().bounds(bounds);
     params().playSubtags(isPlaySubtags);
+    params().ignoreEmpty(isIgnoreEmpty);
 
     // TODO This should be set as options for the specific encoder
     GifEncoderDurationFix fixGif(isForTwitter);

--- a/src/app/ui/export_file_window.cpp
+++ b/src/app/ui/export_file_window.cpp
@@ -78,6 +78,7 @@ ExportFileWindow::ExportFileWindow(const Doc* doc)
   forTwitter()->setSelected(m_docPref.saveCopy.forTwitter());
   adjustResize()->setVisible(false);
   playSubtags()->setSelected(m_docPref.saveCopy.playSubtags());
+  ignoreEmpty()->setSelected(m_docPref.saveCopy.ignoreEmpty());
   // Here we don't call updateAniDir() because it's already filled and
   // set by the function fill_anidir_combobox(). So if the user
   // exported a tag with a specific AniDir, we want to keep the option
@@ -114,6 +115,7 @@ void ExportFileWindow::savePref()
   m_docPref.saveCopy.applyPixelRatio(applyPixelRatio());
   m_docPref.saveCopy.forTwitter(isForTwitter());
   m_docPref.saveCopy.playSubtags(isPlaySubtags());
+  m_docPref.saveCopy.ignoreEmpty(isIgnoreEmpty());
 }
 
 double ExportFileWindow::resizeValue() const
@@ -161,6 +163,11 @@ bool ExportFileWindow::applyPixelRatio() const
 bool ExportFileWindow::isForTwitter() const
 {
   return forTwitter()->isSelected();
+}
+
+bool ExportFileWindow::isIgnoreEmpty() const
+{
+  return ignoreEmpty()->isSelected();
 }
 
 void ExportFileWindow::setResizeScale(double scale)

--- a/src/app/ui/export_file_window.h
+++ b/src/app/ui/export_file_window.h
@@ -35,6 +35,7 @@ public:
   bool isPlaySubtags() const;
   bool applyPixelRatio() const;
   bool isForTwitter() const;
+  bool isIgnoreEmpty() const;
 
   void setResizeScale(const double scale);
   void setArea(const std::string& area);


### PR DESCRIPTION
Feature #5452.

This PR adds a toggle to ignore empty frames when using the "Export As..." window. Enabling the setting will prevent all empty frames from being saved/exported.