### PR TITLE
Add command search by its keyboard shortcut

### DIFF
--- a/src/app/commands/cmd_keyboard_shortcuts.cpp
+++ b/src/app/commands/cmd_keyboard_shortcuts.cpp
@@ -639,7 +639,6 @@ private:
     int sectionIdx = 0; // index 0 is menus
     for (auto listBox : m_listBoxes) {
       Separator* group = nullptr;
-      ui::Shortcut searchShortcut;
 
       for (auto item : listBox->children()) {
         if (KeyItem* keyItem = dynamic_cast<KeyItem*>(item)) {


### PR DESCRIPTION
This is my first time contributing to this project.
I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md
I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing

Added the ability to search for a command based on the keyboard shortcut in the shortcuts window search. Previously the user would only be able to search for the name of the command.

This fixes issue #5465 