### PR TITLE
Add font property to widgets

### DIFF
--- a/src/app/script/dialog_class.cpp
+++ b/src/app/script/dialog_class.cpp
@@ -15,6 +15,7 @@
 #include "app/context.h"
 #include "app/doc.h"
 #include "app/file_selector.h"
+#include "app/fonts/font_info.h"
 #include "app/script/canvas_widget.h"
 #include "app/script/engine.h"
 #include "app/script/graphics_context.h"
@@ -28,6 +29,7 @@
 #include "app/ui/expr_entry.h"
 #include "app/ui/filename_field.h"
 #include "app/ui/main_window.h"
+#include "app/ui/skin/skin_theme.h"
 #include "app/ui/window_with_hand.h"
 #include "base/fs.h"
 #include "base/paths.h"
@@ -111,6 +113,7 @@ struct Dialog {
   std::map<std::string, ui::Widget*> labelWidgets;
   int currentRadioGroup = 0;
   int autofit = kDefaultAutofit;
+  text::FontRef font = nullptr;
 
   // Member used to hold current state about the creation of a tabs
   // widget. After creation it is reset to null to be ready for the
@@ -202,6 +205,12 @@ struct Dialog {
     // Accept both 0 or a valid subset of align parameters.
     if (align == 0 || (align & (ui::LEFT | ui::RIGHT | ui::TOP | ui::BOTTOM)))
       autofit = align;
+  }
+
+  void setFont(const text::FontRef& font)
+  {
+    this->font = font;
+    window.setFont(font);
   }
 
   Display* parentDisplay() const
@@ -323,6 +332,37 @@ struct Dialog {
   }
 };
 
+text::FontRef resolve_font(const ui::Widget* widget,
+                           const std::string& font,
+                           const text::FontRef& defaultFont = nullptr)
+{
+  text::FontRef fontRef = nullptr;
+  auto& pref = Preferences::instance();
+  if (font == "default") {
+    auto fontInfo = base::convert_to<FontInfo>(pref.theme.font());
+    fontRef = Fonts::instance()->fontFromInfo(fontInfo);
+    if (!fontRef)
+      fontRef = skin::SkinTheme::get(widget)->getDefaultFont();
+  }
+  else if (font == "mini") {
+    auto miniFontInfo = base::convert_to<FontInfo>(pref.theme.miniFont());
+    fontRef = Fonts::instance()->fontFromInfo(miniFontInfo);
+    if (!fontRef)
+      fontRef = skin::SkinTheme::get(widget)->getMiniFont();
+  }
+  else if (!font.empty()) {
+    auto fontInfo = base::convert_to<FontInfo>(font);
+    fontRef = Fonts::instance()->fontFromInfo(fontInfo);
+    if (fontRef && fontRef->size() == 0.0f && fontRef->type() != text::FontType::SpriteSheet)
+      fontRef->setSize(10.0);
+  }
+
+  if (!fontRef && defaultFont)
+    fontRef = defaultFont;
+
+  return fontRef;
+}
+
 template<typename... Args, typename Callback>
 void Dialog_connect_signal(lua_State* L,
                            int dlgIdx,
@@ -390,6 +430,7 @@ int Dialog_new(lua_State* L)
   // Get the title and the type of window (with or without title bar)
   ui::Window::Type windowType = ui::Window::WithTitleBar;
   std::string title = "Script";
+  std::string font;
   bool sizeable = true;
   int autofit = kDefaultAutofit;
   if (lua_isstring(L, 1)) {
@@ -416,10 +457,20 @@ int Dialog_new(lua_State* L)
       autofit = lua_tointeger(L, -1);
     }
     lua_pop(L, 1);
+
+    type = lua_getfield(L, 1, "font");
+    if (type == LUA_TSTRING)
+      font = lua_tostring(L, -1);
+    lua_pop(L, 1);
   }
 
   auto dlg = push_new<Dialog>(L, windowType, title, sizeable);
   dlg->setAutofit(autofit);
+
+  if (!font.empty()) {
+    if (auto newFont = resolve_font(&dlg->window, font))
+      dlg->setFont(newFont);
+  }
 
   // The uservalue of the dialog userdata will contain a table that
   // stores all the callbacks to handle events. As these callbacks can
@@ -611,7 +662,7 @@ void set_widget_flags(lua_State* L, int idx, Widget* widget)
   lua_pop(L, 1);
 }
 
-int Dialog_add_widget(lua_State* L, Widget* widget)
+int Dialog_add_widget(lua_State* L, Widget* widget, const std::string& font = std::string())
 {
   auto dlg = get_obj<Dialog>(L, 1);
   const char* label = nullptr;
@@ -620,6 +671,12 @@ int Dialog_add_widget(lua_State* L, Widget* widget)
   bool hexpand = true;
   // Canvas is vertically expansive by default too
   bool vexpand = (widget->type() == Canvas::Type());
+  bool useWidgetFontForLabel = false;
+
+  if (auto newFont = resolve_font(widget, font, dlg->font)) {
+    widget->setFont(newFont);
+    useWidgetFontForLabel = true;
+  }
 
   // This is to separate different kind of widgets without label in
   // different rows. Separator widgets will always create a new row.
@@ -673,6 +730,9 @@ int Dialog_add_widget(lua_State* L, Widget* widget)
       auto labelWidget = new ui::Label(label);
       if (!visible)
         labelWidget->setVisible(false);
+
+      if (useWidgetFontForLabel)
+        labelWidget->setFont(widget->font());
 
       dlg->currentGrid->addChildInCell(labelWidget, 1, 1, ui::LEFT | ui::TOP);
       if (!id.empty())
@@ -730,7 +790,7 @@ int Dialog_separator(lua_State* L)
 {
   auto dlg = get_obj<Dialog>(L, 1);
 
-  std::string id, text;
+  std::string id, text, font;
 
   if (lua_isstring(L, 2)) {
     if (auto p = lua_tostring(L, 2))
@@ -742,6 +802,11 @@ int Dialog_separator(lua_State* L)
       if (auto p = lua_tostring(L, -1))
         text = p;
     }
+    lua_pop(L, 1);
+
+    type = lua_getfield(L, 2, "font");
+    if (type == LUA_TSTRING)
+      font = lua_tostring(L, -1);
     lua_pop(L, 1);
 
     type = lua_getfield(L, 2, "id");
@@ -758,12 +823,13 @@ int Dialog_separator(lua_State* L)
     dlg->dataWidgets[id] = widget;
   }
 
-  return Dialog_add_widget(L, widget);
+  return Dialog_add_widget(L, widget, font);
 }
 
 int Dialog_label(lua_State* L)
 {
-  std::string text;
+  std::string text, font;
+
   if (lua_istable(L, 2)) {
     int type = lua_getfield(L, 2, "text");
     if (type != LUA_TNIL) {
@@ -771,10 +837,15 @@ int Dialog_label(lua_State* L)
         text = p;
     }
     lua_pop(L, 1);
+
+    type = lua_getfield(L, 2, "font");
+    if (type == LUA_TSTRING)
+      font = lua_tostring(L, -1);
+    lua_pop(L, 1);
   }
 
   auto widget = new ui::Label(text.c_str());
-  return Dialog_add_widget(L, widget);
+  return Dialog_add_widget(L, widget, font);
 }
 
 template<typename T>
@@ -782,13 +853,18 @@ int Dialog_button_base(lua_State* L, T** outputWidget = nullptr)
 {
   auto dlg = get_obj<Dialog>(L, 1);
 
-  std::string text;
+  std::string text, font;
   if (lua_istable(L, 2)) {
     int type = lua_getfield(L, 2, "text");
     if (type != LUA_TNIL) {
       if (auto p = lua_tostring(L, -1))
         text = p;
     }
+    lua_pop(L, 1);
+
+    type = lua_getfield(L, 2, "font");
+    if (type == LUA_TSTRING)
+      font = lua_tostring(L, -1);
     lua_pop(L, 1);
   }
 
@@ -823,7 +899,7 @@ int Dialog_button_base(lua_State* L, T** outputWidget = nullptr)
     widget->Click.connect([dlg, widget]() { dlg->lastButton = widget; });
   }
 
-  return Dialog_add_widget(L, widget);
+  return Dialog_add_widget(L, widget, font);
 }
 
 int Dialog_button(lua_State* L)
@@ -867,13 +943,18 @@ int Dialog_menuItem(lua_State* L)
 
 int Dialog_entry(lua_State* L)
 {
-  std::string text;
+  std::string text, font;
   if (lua_istable(L, 2)) {
     int type = lua_getfield(L, 2, "text");
     if (type == LUA_TSTRING) {
       if (auto p = lua_tostring(L, -1))
         text = p;
     }
+    lua_pop(L, 1);
+
+    type = lua_getfield(L, 2, "font");
+    if (type == LUA_TSTRING)
+      font = lua_tostring(L, -1);
     lua_pop(L, 1);
   }
 
@@ -889,12 +970,13 @@ int Dialog_entry(lua_State* L)
     lua_pop(L, 1);
   }
 
-  return Dialog_add_widget(L, widget);
+  return Dialog_add_widget(L, widget, font);
 }
 
 int Dialog_number(lua_State* L)
 {
   auto widget = new ExprEntry;
+  std::string font;
 
   if (lua_istable(L, 2)) {
     int type = lua_getfield(L, 2, "text");
@@ -902,6 +984,11 @@ int Dialog_number(lua_State* L)
       if (auto p = lua_tostring(L, -1))
         widget->setText(p);
     }
+    lua_pop(L, 1);
+
+    type = lua_getfield(L, 2, "font");
+    if (type == LUA_TSTRING)
+      font = lua_tostring(L, -1);
     lua_pop(L, 1);
 
     type = lua_getfield(L, 2, "decimals");
@@ -919,7 +1006,7 @@ int Dialog_number(lua_State* L)
     lua_pop(L, 1);
   }
 
-  return Dialog_add_widget(L, widget);
+  return Dialog_add_widget(L, widget, font);
 }
 
 int Dialog_slider(lua_State* L)
@@ -927,6 +1014,7 @@ int Dialog_slider(lua_State* L)
   int min = 0;
   int max = 100;
   int value = 100;
+  std::string font;
 
   if (lua_istable(L, 2)) {
     int type = lua_getfield(L, 2, "min");
@@ -945,6 +1033,11 @@ int Dialog_slider(lua_State* L)
     if (type != LUA_TNIL) {
       value = lua_tointegerx(L, -1, nullptr);
     }
+    lua_pop(L, 1);
+
+    type = lua_getfield(L, 2, "font");
+    if (type == LUA_TSTRING)
+      font = lua_tostring(L, -1);
     lua_pop(L, 1);
   }
 
@@ -968,12 +1061,13 @@ int Dialog_slider(lua_State* L)
     lua_pop(L, 1);
   }
 
-  return Dialog_add_widget(L, widget);
+  return Dialog_add_widget(L, widget, font);
 }
 
 int Dialog_combobox(lua_State* L)
 {
   auto widget = new ui::ComboBox;
+  std::string font;
 
   if (lua_istable(L, 2)) {
     int type = lua_getfield(L, 2, "options");
@@ -997,6 +1091,11 @@ int Dialog_combobox(lua_State* L)
     }
     lua_pop(L, 1);
 
+    type = lua_getfield(L, 2, "font");
+    if (type == LUA_TSTRING)
+      font = lua_tostring(L, -1);
+    lua_pop(L, 1);
+
     type = lua_getfield(L, 2, "onchange");
     if (type == LUA_TFUNCTION) {
       Dialog_connect_signal(L, 1, widget->Change, [](lua_State* L) {
@@ -1006,15 +1105,21 @@ int Dialog_combobox(lua_State* L)
     lua_pop(L, 1);
   }
 
-  return Dialog_add_widget(L, widget);
+  return Dialog_add_widget(L, widget, font);
 }
 
 int Dialog_color(lua_State* L)
 {
   app::Color color;
+  std::string font;
   if (lua_istable(L, 2)) {
     lua_getfield(L, 2, "color");
     color = convert_args_into_color(L, -1);
+    lua_pop(L, 1);
+
+    int type = lua_getfield(L, 2, "font");
+    if (type == LUA_TSTRING)
+      font = lua_tostring(L, -1);
     lua_pop(L, 1);
   }
 
@@ -1030,7 +1135,7 @@ int Dialog_color(lua_State* L)
     }
   }
 
-  return Dialog_add_widget(L, widget);
+  return Dialog_add_widget(L, widget, font);
 }
 
 int Dialog_shades(lua_State* L)
@@ -1038,6 +1143,7 @@ int Dialog_shades(lua_State* L)
   Shade colors;
   // 'pick' is the default mode anyway
   ColorShades::ClickType mode = ColorShades::ClickEntries;
+  std::string font;
 
   if (lua_istable(L, 2)) {
     int type = lua_getfield(L, 2, "mode");
@@ -1060,6 +1166,11 @@ int Dialog_shades(lua_State* L)
         lua_pop(L, 1);
       }
     }
+    lua_pop(L, 1);
+
+    type = lua_getfield(L, 2, "font");
+    if (type == LUA_TSTRING)
+      font = lua_tostring(L, -1);
     lua_pop(L, 1);
   }
 
@@ -1086,7 +1197,7 @@ int Dialog_shades(lua_State* L)
     lua_pop(L, 1);
   }
 
-  return Dialog_add_widget(L, widget);
+  return Dialog_add_widget(L, widget, font);
 }
 
 int Dialog_file(lua_State* L)
@@ -1094,6 +1205,7 @@ int Dialog_file(lua_State* L)
   std::string title = "Open File";
   std::string path;
   std::string fn;
+  std::string font;
   base::paths exts;
   auto dlgType = FileSelectorType::Open;
   auto fnFieldType = FilenameField::ButtonOnly;
@@ -1138,6 +1250,11 @@ int Dialog_file(lua_State* L)
       path = lua_tostring(L, -1);
     }
     lua_pop(L, 1);
+
+    type = lua_getfield(L, 2, "font");
+    if (type == LUA_TSTRING)
+      font = lua_tostring(L, -1);
+    lua_pop(L, 1);
   }
 
   auto widget = new FilenameField(fnFieldType, fn);
@@ -1180,7 +1297,7 @@ int Dialog_file(lua_State* L)
     else
       return widget->fullFilename();
   });
-  return Dialog_add_widget(L, widget);
+  return Dialog_add_widget(L, widget, font);
 }
 
 // Auxiliary callbacks used in Canvas events
@@ -1283,6 +1400,7 @@ static void fill_touchmessage_values(lua_State* L, const ui::TouchMessage* msg)
 int Dialog_canvas(lua_State* L)
 {
   auto widget = new Canvas;
+  std::string font;
 
   if (lua_istable(L, 2)) {
     gfx::Size sz(0, 0);
@@ -1297,6 +1415,11 @@ int Dialog_canvas(lua_State* L)
     if (type != LUA_TNIL) {
       sz.h = lua_tointegerx(L, -1, nullptr);
     }
+    lua_pop(L, 1);
+
+    type = lua_getfield(L, 2, "font");
+    if (type == LUA_TSTRING)
+      font = lua_tostring(L, -1);
     lua_pop(L, 1);
 
     type = lua_getfield(L, 2, "autoscaling");
@@ -1387,7 +1510,7 @@ int Dialog_canvas(lua_State* L)
       widget->setFocusStop(true);
   }
 
-  return Dialog_add_widget(L, widget);
+  return Dialog_add_widget(L, widget, font);
 }
 
 int Dialog_tab(lua_State* L)
@@ -1396,6 +1519,7 @@ int Dialog_tab(lua_State* L)
 
   std::string text;
   std::string id;
+  std::string font;
   bool hasId = false;
   if (lua_istable(L, 2)) {
     int type = lua_getfield(L, 2, "id");
@@ -1411,6 +1535,11 @@ int Dialog_tab(lua_State* L)
     }
     lua_pop(L, 1);
 
+    type = lua_getfield(L, 2, "font");
+    if (type == LUA_TSTRING)
+      font = lua_tostring(L, -1);
+    lua_pop(L, 1);
+
     // If there was no id set, then use the tab text as the tab id.
     if (!hasId)
       id = text;
@@ -1418,6 +1547,9 @@ int Dialog_tab(lua_State* L)
 
   if (!dlg->wipTab) {
     dlg->wipTab = new app::script::Tabs(ui::CENTER);
+
+    if (auto fontRef = resolve_font(dlg->wipTab, font, dlg->font))
+      dlg->wipTab->setFont(fontRef);
   }
 
   auto tab = dlg->wipTab->addTab(id, text);

--- a/src/ui/combobox.cpp
+++ b/src/ui/combobox.cpp
@@ -112,6 +112,19 @@ ComboBox::~ComboBox()
   deleteAllItems();
 }
 
+void ComboBox::setFont(const text::FontRef& font)
+{
+  Widget::setFont(font);
+  if (m_listbox)
+    m_listbox->setFont(font);
+  if (m_entry)
+    m_entry->setFont(font);
+  for (auto* i : m_items) {
+    if (auto* li = dynamic_cast<ListItem*>(i))
+      li->setFont(font);
+  }
+}
+
 void ComboBox::setEditable(bool state)
 {
   m_editable = state;
@@ -155,7 +168,11 @@ int ComboBox::addItem(Widget* item)
 
 int ComboBox::addItem(const std::string& text)
 {
-  return addItem(new ListItem(text));
+  auto* item = new ListItem(text);
+
+  if (!isCachedFont())
+    item->setFont(font());
+  return addItem(item);
 }
 
 void ComboBox::insertItem(int itemIndex, Widget* item)
@@ -170,7 +187,10 @@ void ComboBox::insertItem(int itemIndex, Widget* item)
 
 void ComboBox::insertItem(int itemIndex, const std::string& text)
 {
-  insertItem(itemIndex, new ListItem(text));
+  auto* item = new ListItem(text);
+  if (!isCachedFont())
+    item->setFont(font());
+  insertItem(itemIndex, item);
 }
 
 void ComboBox::removeItem(Widget* item)

--- a/src/ui/combobox.h
+++ b/src/ui/combobox.h
@@ -36,6 +36,8 @@ public:
   ComboBox();
   ~ComboBox();
 
+  virtual void setFont(const text::FontRef& font) override;
+
   Items::iterator begin() { return m_items.begin(); }
   Items::iterator end() { return m_items.end(); }
 

--- a/src/ui/theme.h
+++ b/src/ui/theme.h
@@ -49,6 +49,7 @@ struct PaintWidgetPartInfo {
   float baseline = 0.0f;
   int mnemonic = 0;
   os::Surface* icon = nullptr;
+  text::FontRef font = nullptr;
 
   PaintWidgetPartInfo();
   PaintWidgetPartInfo(const Widget* widget);
@@ -163,11 +164,7 @@ private:
   void paintLayer(Graphics* g,
                   const Style* style,
                   const Style::Layer& layer,
-                  const std::string& text,
-                  text::TextBlobRef textBlob,
-                  const float baseline,
-                  const int mnemonic,
-                  os::Surface* icon,
+                  const PaintWidgetPartInfo& info,
                   gfx::Rect& rc,
                   gfx::Color& bgColor);
   void measureLayer(const Widget* widget,

--- a/src/ui/widget.cpp
+++ b/src/ui/widget.cpp
@@ -184,14 +184,17 @@ void Widget::setTextQuiet(const std::string& text)
 
 const text::FontRef& Widget::font() const
 {
-  if (!m_font && m_theme)
+  if (!m_font && m_theme) {
     m_font = m_theme->getWidgetFont(this);
+    m_isCachedFont = true;
+  }
   return m_font;
 }
 
 void Widget::setFont(const text::FontRef& font)
 {
   if (m_font != font) {
+    m_isCachedFont = false;
     m_font = font;
     m_blob.reset();
     onSetFont();
@@ -220,7 +223,8 @@ void Widget::setTheme(Theme* theme)
   assert_ui_thread();
 
   m_theme = theme;
-  m_font = nullptr;
+  if (m_isCachedFont)
+    m_font = nullptr;
 
   for (auto child : children())
     child->setTheme(theme);
@@ -1821,7 +1825,8 @@ void Widget::onBroadcastMouseMessage(const gfx::Point& screenPos, WidgetsList& t
 void Widget::onInitTheme(InitThemeEvent& ev)
 {
   // Reset cached font and TextBlob
-  m_font.reset();
+  if (m_isCachedFont)
+    m_font.reset();
   m_blob.reset();
 
   // Create a copy of the children list and iterate it, just in case a

--- a/src/ui/widget.h
+++ b/src/ui/widget.h
@@ -134,7 +134,7 @@ public:
   // ===============================================================
 
   const text::FontRef& font() const;
-  void setFont(const text::FontRef& font);
+  virtual void setFont(const text::FontRef& font);
 
   // Gets the background color of the widget.
   gfx::Color bgColor() const
@@ -414,6 +414,8 @@ public:
   obs::signal<void()> InitTheme;
 
 protected:
+  bool isCachedFont() const { return m_isCachedFont; }
+
   // ===============================================================
   // MESSAGE PROCESSING
   // ===============================================================
@@ -461,8 +463,15 @@ private:
   int m_flags;       // Special boolean properties (see flags in ui/base.h)
   Theme* m_theme;    // Widget's theme
   Style* m_style;
-  std::string m_text;               // Widget text
-  mutable text::FontRef m_font;     // Cached font returned by the theme
+  std::string m_text; // Widget text
+
+  // Cached font returned by the theme OR custom font. Use field m_isCachedFont to
+  // determine how is being used this field.
+  mutable text::FontRef m_font;
+  // Determines how the m_font field is used. If true, it is being used as a cache
+  // for a font provided by the theme. If false, the font is a custom font provided
+  // by the user and must override the theme's font.
+  mutable bool m_isCachedFont = false;
   mutable text::TextBlobRef m_blob; // Cached TextBlob
   gfx::Color m_bgColor;             // Background color
   gfx::Rect m_bounds;


### PR DESCRIPTION
Fix #5372

This PR allows the Lua script author to use the font property in the Dialog and any of the widgets. When set to the Dialog it is used as a default for the widgets added. When set for any particular widget it will overwrite the Dialog's default.
Also, the font property accepts several formats (basically any string that can be converted internally to a FontInfo).
Examples:
- font="default" (sets the font to theme's default font)
- font="mini" (sets the font to theme's mini font)
- font="system=Academy Engraved LET"
- font="Unicode"
- font="file=..."

Example script:
```lua
local dialog = Dialog({ title="Tabs Separator Bug", font="system=Academy Engraved LET"})

dialog
  :separator{text = "Header"}
  :label{label = "Label A", text = "1"}
  :separator{text = "Separator 1", font = "mini"}
  :label{label = "Label B", text = "2"}
  :label{label = "Label C", text = "3", font = "default"}
  :separator{text = "Separator declared within Tab 2"}
  :entry{label = "Some entry", text = "4789"}
  :label{label = "Label D", text = "4", font = "mini"}
  :separator{text = "Separator 2", font="Unicode"}
  :button{text="Button 1", font="mini"}

dialog:show({ wait=false})
```

