### PR TITLE
[lua] Fix Image:drawSprite() call when we're in the middle of a ToolLoop (part of #3916)

### DIFF
--- a/src/app/script/image_class.cpp
+++ b/src/app/script/image_class.cpp
@@ -26,6 +26,7 @@
 #include "app/script/security.h"
 #include "app/site.h"
 #include "app/tx.h"
+#include "app/ui/editor/scoped_tool_loop_fix.h"
 #include "app/util/autocrop.h"
 #include "app/util/resize_image.h"
 #include "app/util/shader_helpers.h"
@@ -362,6 +363,8 @@ int Image_drawSprite(lua_State* L)
 
   ASSERT(dst);
   ASSERT(sprite);
+
+  ScopedToolLoopFix fix(sprite);
 
   if (auto cel = obj->cel(L)) {
     Tx tx(cel->sprite());

--- a/src/app/tools/tool_loop.h
+++ b/src/app/tools/tool_loop.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2024  Igara Studio S.A.
+// Copyright (C) 2019-2025  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This program is distributed under the terms of
@@ -48,6 +48,7 @@ class DitheringMatrix;
 namespace app {
 class Context;
 class Doc;
+class ExpandCelCanvas;
 
 namespace tools {
 class Controller;
@@ -269,6 +270,10 @@ public:
   virtual bool isSelectionToolLoop() const = 0;
   virtual void addSelectionToolPoint(const gfx::Rect& rc) = 0;
   virtual void clearSelectionToolMask(const bool finalStep) = 0;
+
+  // Used to restore the sprite status temporarily in case we want to
+  // access its original state in the middle of a ToolLoop.
+  virtual ExpandCelCanvas* expandCelCanvas() const = 0;
 };
 
 } // namespace tools

--- a/src/app/ui/editor/drawing_state.cpp
+++ b/src/app/ui/editor/drawing_state.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2024  Igara Studio S.A.
+// Copyright (C) 2018-2025  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -428,6 +428,11 @@ void DrawingState::destroyLoop(Editor* editor)
   m_toolLoop.reset(nullptr);
 
   app_rebuild_documents_tabs();
+}
+
+ExpandCelCanvas* DrawingState::expandCelCanvas() const
+{
+  return m_toolLoop->expandCelCanvas();
 }
 
 } // namespace app

--- a/src/app/ui/editor/drawing_state.h
+++ b/src/app/ui/editor/drawing_state.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2022  Igara Studio S.A.
+// Copyright (C) 2019-2025  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This program is distributed under the terms of
@@ -24,6 +24,7 @@ class ToolLoopManager;
 } // namespace tools
 
 class CommandExecutionEvent;
+class ExpandCelCanvas;
 
 class DrawingState : public StandbyState,
                      DelayedMouseMoveDelegate {
@@ -65,6 +66,8 @@ public:
   void sendMovementToToolLoop(const tools::Pointer& pointer);
 
   void notifyToolLoopModifiersChange(Editor* editor);
+
+  ExpandCelCanvas* expandCelCanvas() const;
 
 private:
   void handleMouseMovement();

--- a/src/app/ui/editor/scoped_tool_loop_fix.h
+++ b/src/app/ui/editor/scoped_tool_loop_fix.h
@@ -1,0 +1,48 @@
+// Aseprite
+// Copyright (C) 2025  Igara Studio S.A.
+//
+// This program is distributed under the terms of
+// the End-User License Agreement for Aseprite.
+
+#ifndef APP_UI_EDITOR_SCOPED_TOOL_LOOP_FIX_H_INCLUDED
+#define APP_UI_EDITOR_SCOPED_TOOL_LOOP_FIX_H_INCLUDED
+#pragma once
+
+#include "app/ui/editor/drawing_state.h"
+#include "app/ui/editor/editor.h"
+#include "app/util/expand_cel_canvas.h"
+
+namespace app {
+
+// Quite a hack to temporarily fix the Sprite active cel that is being
+// used in a DrawingState/ToolLoop/ExpandCelCanvas, so the sprite can
+// be used in a Image:drawSprite() scripting API call.
+class ScopedToolLoopFix {
+public:
+  ScopedToolLoopFix(doc::Sprite* sprite)
+  {
+    if (Editor* editor = Editor::activeEditor()) {
+      if (editor->sprite() != sprite)
+        return;
+
+      if (auto* state = dynamic_cast<DrawingState*>(editor->getState().get())) {
+        m_expand = state->expandCelCanvas();
+        if (m_expand)
+          m_expand->prepareSpriteForScript();
+      }
+    }
+  }
+
+  ~ScopedToolLoopFix()
+  {
+    if (m_expand)
+      m_expand->restoreSpriteForToolLoop();
+  }
+
+private:
+  ExpandCelCanvas* m_expand = nullptr;
+};
+
+} // namespace app
+
+#endif

--- a/src/app/ui/editor/tool_loop_impl.cpp
+++ b/src/app/ui/editor/tool_loop_impl.cpp
@@ -432,6 +432,8 @@ public:
   void addSelectionToolPoint(const gfx::Rect& rc) override {};
   void clearSelectionToolMask(const bool finalStep) override {};
 
+  ExpandCelCanvas* expandCelCanvas() const override { return nullptr; }
+
 protected:
   void updateAllVisibleRegion()
   {
@@ -754,6 +756,8 @@ public:
   bool getPreviewFilled() override { return m_previewFilled; }
   int getSprayWidth() override { return m_sprayWidth; }
   int getSpraySpeed() override { return m_spraySpeed; }
+
+  ExpandCelCanvas* expandCelCanvas() const override { return m_expandCelCanvas.get(); }
 
 private:
   bool m_filled;

--- a/src/app/util/expand_cel_canvas.cpp
+++ b/src/app/util/expand_cel_canvas.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2023  Igara Studio S.A.
+// Copyright (C) 2019-2025  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -110,18 +110,16 @@ ExpandCelCanvas::ExpandCelCanvas(Site site,
   // Create a new cel
   if (!m_cel) {
     m_celCreated = true;
-    m_cel = new Cel(site.frame(), ImageRef(NULL));
+    m_cel = new Cel(site.frame(), ImageRef(nullptr));
   }
 
   m_origCelPos = m_cel->position();
 
   // Region to draw
   gfx::Rect celBounds = (m_celCreated ? m_sprite->bounds() : m_cel->bounds());
-
   gfx::Rect spriteBounds(0, 0, m_sprite->width(), m_sprite->height());
-
   if (tiledMode == TiledMode::NONE) { // Non-tiled
-    m_bounds = celBounds.createUnion(spriteBounds);
+    m_bounds = (celBounds | spriteBounds);
   }
   else { // Tiled
     m_bounds = spriteBounds;
@@ -150,12 +148,6 @@ ExpandCelCanvas::ExpandCelCanvas(Site site,
     }
   }
 
-  // We have to adjust the cel position to match the m_dstImage
-  // position (the new m_dstImage will be used in RenderEngine to
-  // draw this cel).
-  if (!isTilesetPreview())
-    m_cel->setPosition(m_bounds.origin());
-
   EXP_TRACE("ExpandCelCanvas",
             "m_cel->bounds()=",
             m_cel->bounds(),
@@ -165,27 +157,24 @@ ExpandCelCanvas::ExpandCelCanvas(Site site,
             m_grid.origin(),
             m_grid.tileSize());
 
-  if (m_celCreated) {
+  if (isTilesetPreview()) {
+    getDestTileset();
+  }
+  else if (m_celCreated || (m_layer && m_layer->isTilemap())) {
     // Calling "getDestCanvas()" we create the m_dstImage
     getDestCanvas();
 
+    // We have to adjust the cel position to match the m_dstImage
+    // position (the new m_dstImage will be used in RenderEngine to
+    // draw this cel).
+    m_cel->setPosition(m_bounds.origin());
     m_cel->data()->setImage(m_dstImage, m_layer);
 
-    if (previewSpecificLayerChanges())
+    if (m_celCreated && previewSpecificLayerChanges())
       static_cast<LayerImage*>(m_layer)->addCel(m_cel);
   }
-  else if (m_layer->isTilemap() && m_tilemapMode == TilemapMode::Tiles) {
-    getDestCanvas();
-    m_cel->data()->setImage(m_dstImage, m_layer);
-  }
-  // If we are in a tilemap, we use m_dstImage to draw pixels (instead
-  // of the tilemap image).
-  else if (m_layer->isTilemap() && m_tilemapMode == TilemapMode::Pixels && !isTilesetPreview()) {
-    getDestCanvas();
-    m_cel->data()->setImage(m_dstImage, m_layer);
-  }
-  else if (isTilesetPreview()) {
-    getDestTileset();
+  else {
+    m_cel->setPosition(m_bounds.origin());
   }
 }
 
@@ -727,6 +716,38 @@ void ExpandCelCanvas::copySourceTilestToDestTileset()
     // To rehash the tileset
     m_dstTileset->notifyTileContentChange(i);
   }
+}
+
+void ExpandCelCanvas::prepareSpriteForScript()
+{
+  // If is tileset preview or a selection tool (so m_dstImage is being
+  // used as a top layer preview only, not as part of the sprite):
+  // there is nothing we have to fix for the script Image:drawSprite()
+  // call.
+  if (isTilesetPreview() || !previewSpecificLayerChanges())
+    return;
+
+  m_cel->setPosition(m_origCelPos);
+
+  if (m_celCreated)
+    static_cast<LayerImage*>(m_layer)->removeCel(m_cel);
+  else if (m_layer->isTilemap())
+    m_cel->data()->setImage(m_celImage, m_layer);
+}
+
+void ExpandCelCanvas::restoreSpriteForToolLoop()
+{
+  if (isTilesetPreview() || !previewSpecificLayerChanges())
+    return;
+
+  ASSERT(m_layer); // previewSpecificLayerChanges() filters the nullptr case
+
+  m_cel->setPosition(m_bounds.origin());
+
+  if (m_celCreated)
+    static_cast<LayerImage*>(m_layer)->addCel(m_cel);
+  else if (m_layer->isTilemap())
+    m_cel->data()->setImage(m_dstImage, m_layer);
 }
 
 } // namespace app

--- a/src/app/util/expand_cel_canvas.h
+++ b/src/app/util/expand_cel_canvas.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2021  Igara Studio S.A.
+// Copyright (C) 2019-2025  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -93,6 +93,11 @@ public:
 
   const Cel* getCel() const { return m_cel; }
   const doc::Grid& getGrid() const { return m_grid; }
+
+  // Functions used by ScopedToolLoopFix to temporarily fix the sprite
+  // to being used in Image:drawSprite() function call.
+  void prepareSpriteForScript();
+  void restoreSpriteForToolLoop();
 
 private:
   gfx::Rect getTrimDstImageBounds() const;


### PR DESCRIPTION
Fix part of #3916, allowing using `Image:drawSprite()` correctly if we are in the middle of a `ToolLoop`.

Script to test:

```lua
local dlg
local timer = Timer{ interval=0.25, ontick=function() dlg:repaint() end }
dlg = Dialog { title="Paint every 1/4 sec", onclose=function() timer:stop() end }

local function paintCanvas(ev)
  local spr = app.sprite
  if not spr then return end
  local gc = ev.context
  local img = Image(spr.width, spr.height)
  img:drawSprite(spr, app.frame, 0, 0)
  gc:drawImage(img, img.bounds, Rectangle(0, 0, gc.width, gc.height))
end

dlg:canvas { id="canvas", width=128, height=128, onpaint=paintCanvas }
dlg:show { wait=false }
timer:start()
```