### PR TITLE
 [lua] Improve Dialog labels and buddy enabled handling (fix #5117) 

### DIFF
--- a/src/ui/label.cpp
+++ b/src/ui/label.cpp
@@ -21,7 +21,7 @@
 
 namespace ui {
 
-Label::Label(const std::string& text) : Widget(kLabelWidget), m_buddy(nullptr)
+Label::Label(const std::string& text) : Widget(kLabelWidget), m_buddy(nullptr), m_buddySync(false)
 {
   enableFlags(IGNORE_MOUSE);
   setAlign(LEFT | MIDDLE);
@@ -48,6 +48,8 @@ void Label::setBuddy(Widget* buddy)
 
   if (m_buddy)
     disableFlags(IGNORE_MOUSE);
+
+  refreshBuddySync();
 }
 
 void Label::setBuddy(const std::string& buddyId)
@@ -82,6 +84,22 @@ bool Label::onProcessMessage(Message* msg)
   }
 
   return Widget::onProcessMessage(msg);
+}
+
+void Label::onEnable(bool enabled)
+{
+  if (m_buddy && m_buddySync)
+    m_buddy->setEnabled(enabled);
+
+  Widget::onEnable(enabled);
+}
+
+void Label::refreshBuddySync()
+{
+  if (m_buddy && m_buddySync)
+    m_buddyEnabledConn = m_buddy->EnabledChange.connect([this](bool state) { setEnabled(state); });
+  else
+    m_buddyEnabledConn.disconnect();
 }
 
 } // namespace ui

--- a/src/ui/label.h
+++ b/src/ui/label.h
@@ -21,12 +21,27 @@ public:
   void setBuddy(Widget* buddy);
   void setBuddy(const std::string& buddyId);
 
+  // Keeps the label's enabled state synchronized with the buddy
+  void setBuddySyncEnabled(bool sync)
+  {
+    if (m_buddySync != sync) {
+      m_buddySync = sync;
+      refreshBuddySync();
+    }
+  }
+  bool buddySyncEnabled() const { return m_buddySync; }
+
 protected:
   bool onProcessMessage(Message* msg) override;
+  void onEnable(bool enabled) override;
 
 private:
+  void refreshBuddySync();
+
   Widget* m_buddy;
+  bool m_buddySync;
   std::string m_buddyId;
+  obs::scoped_connection m_buddyEnabledConn;
 };
 
 } // namespace ui

--- a/src/ui/widget.cpp
+++ b/src/ui/widget.cpp
@@ -1859,7 +1859,7 @@ void Widget::onVisible(bool visible)
 
 void Widget::onEnable(bool enabled)
 {
-  // Do nothing
+  EnabledChange(enabled);
 }
 
 void Widget::onSelect(bool selected)

--- a/src/ui/widget.h
+++ b/src/ui/widget.h
@@ -412,6 +412,7 @@ public:
 
   // Signals
   obs::signal<void()> InitTheme;
+  obs::signal<void(bool)> EnabledChange;
 
 protected:
   // ===============================================================


### PR DESCRIPTION
Fixes #5117, and makes some changes to default behaviors.

Marking as draft because of `Widget` changes, decided to go for the "simple but disruptive" approach of just adding a new signal to Widget and modifying the default `onEnabled`, it's definitely the simplest approach but it does have ripple effects on the entire app.

Decided to leave the "buddy enabled sync" feature disabled by default behind a flag, but we could easily just simplify it and make this the default behavior and void having an extra bool - in fact I think that's probably the way to go before the merge, but I figured I'd first validate this is what we want without any side-effects.

Added the `placeholder` and `labelalign` propertes to `Dialog_add_widget`, the former is self-explanatory, the latter is because I noticed all of the labels were aligned to the top-right and it looks kinda bad, but maybe some things rely on the old behavior so I changed the default to `ui::LEFT | ui::CENTER` and added a way to change the alignment if desired to go back to the previous default or any other.

Here's a little test script:

```lua
local d = Dialog()
local b = true

d:entry{ id="entry_1", label="Entry 1", text="", placeholder="Placeholder" }
:entry{ id="entry_2", label="Entry 2", text="rrrrr" }
:entry{ id="entry_3", label="Entry 3", labelalign=Align.TOP | Align.LEFT, text="old align default" }
:entry{ id="entry_4", label="Entry 4", text="bbbbb" }
:button{ id="button_1", label="Button 1", labelalign=Align.BOTTOM, text="aligned bottom" }
:button{ id="button_2", label="Button 2", labelalign=Align.RIGHT, text="aligned right" }
:button{ id="button_3", text="3" }
:button{ id="button_4", text="4" }

:button{ id="button_5", label="Button 5", text="5" }
:button{ id="button_6", text="6" }
:button{ id="button_7", text="7" }

:separator()

:button{ id="disable", text="Toggle Disabled", onclick=function()
    b = not b
    d:modify{ id="entry_2", enabled=b }
    :modify{ id="entry_4", enabled=b }
    :modify{ id="button_1", enabled=b }
    :modify{ id="button_3", enabled=b }
    --
    :modify{ id="button_5", enabled=b }
    :modify{ id="button_6", enabled=b }
    :modify{ id="button_7", enabled=b }
    --
end}
:button{ id="ok", text="Close" }

d:show()
```
