### PR TITLE
Fix ButtonSet mouse events propagating incorrectly (fix #5547)

### DIFF
--- a/src/app/ui/button_set.cpp
+++ b/src/app/ui/button_set.cpp
@@ -124,6 +124,7 @@ bool ButtonSet::Item::onProcessMessage(ui::Message* msg)
 
       if (static_cast<MouseMessage*>(msg)->left() && !buttonSet()->m_triggerOnMouseUp) {
         onClick();
+        return true;
       }
       break;
 
@@ -136,11 +137,14 @@ bool ButtonSet::Item::onProcessMessage(ui::Message* msg)
         invalidate();
 
         if (static_cast<MouseMessage*>(msg)->left()) {
-          if (buttonSet()->m_triggerOnMouseUp)
+          if (buttonSet()->m_triggerOnMouseUp) {
             onClick();
+            return true;
+          }
         }
         else if (static_cast<MouseMessage*>(msg)->right()) {
           onRightClick();
+          return true;
         }
       }
       break;

--- a/src/ui/link_label.cpp
+++ b/src/ui/link_label.cpp
@@ -77,8 +77,10 @@ bool LinkLabel::onProcessMessage(Message* msg)
         setSelected(false);
         invalidate(); // TODO theme specific
 
-        if (hasMouse())
+        if (hasMouse()) {
           onClick();
+          return true;
+        }
       }
       break;
   }


### PR DESCRIPTION
Also fixes a potential case of this happening in LinkLabel.

The event pausing with the popupMenu was making things extra weird here I think, hopefully nothing relies in this behavior, I tested all the buttonsets I remembered existing and they were fine.


Edit: I always forget I can't make multi-line commit messages 🥲, I miss 'em