### PR TITLE
Fix console re-centering too much (fix ##5349)

### DIFF
--- a/src/app/console.cpp
+++ b/src/app/console.cpp
@@ -302,7 +302,7 @@ void Console::showException(const std::exception& e)
 // static
 void Console::notifyNewDisplayConfiguration()
 {
-  if (m_console)
+  if (m_console && !m_console->hasConsoleText())
     m_console->centerConsole();
 }
 


### PR DESCRIPTION
Makes the code in `notifyNewDisplayConfiguration` be consistent with the one on `addMessages` which checks for text before re-centering the window, so this preserves the original behavior but makes relocating the already visible console stick,