### PR TITLE
Continue with some extra dockable UI features (#5327)

### DIFF
--- a/src/app/ui/dock.cpp
+++ b/src/app/ui/dock.cpp
@@ -19,6 +19,7 @@
 #include "app/ui/layout_selector.h"
 #include "app/ui/main_window.h"
 #include "app/ui/skin/skin_theme.h"
+#include "gfx/path.h"
 #include "os/system.h"
 #include "ui/cursor_type.h"
 #include "ui/label.h"
@@ -68,83 +69,161 @@ int side_from_index(int index)
 static constexpr auto kLegacyLayoutMainWindowSection = "layout:main_window";
 static constexpr auto kLegacyLayoutTimelineSplitter = "timeline_splitter";
 
-Dock::DropzonePlaceholder::DropzonePlaceholder(Widget* dragWidget, const gfx::Point& mousePosition)
-  : Widget(kGenericWidget)
+//////////////////////////////////////////////////////////////////////
+// Dock::Hit
+
+gfx::Rect Dock::Hit::bounds() const
 {
-  setExpansive(true);
-  setSizeHint(dragWidget->sizeHint());
-  setMinSize(dragWidget->size());
+  if (widget)
+    return widget->bounds();
+  return {};
+}
 
-  m_mouseOffset = mousePosition - dragWidget->bounds().origin();
+//////////////////////////////////////////////////////////////////////
+// Dock::DraggingFeedback
 
-  const os::SurfaceRef surface = os::System::instance()->makeRgbaSurface(dragWidget->size().w,
-                                                                         dragWidget->size().h);
+Dock::DraggingFeedback::DraggingFeedback(Display* display,
+                                         const Hit& hit,
+                                         const gfx::Point& mousePosition)
+  : m_display(display)
+  , m_dragWidget(hit.widget)
+  , m_mouseOffset(mousePosition - hit.widget->origin())
+{
+  const os::SurfaceRef surface = os::System::instance()->makeRgbaSurface(m_dragWidget->size().w,
+                                                                         m_dragWidget->size().h);
   {
     const os::SurfaceLock lock(surface.get());
     Paint paint;
     paint.color(gfx::rgba(0, 0, 0, 0));
     paint.style(os::Paint::Fill);
-    surface->drawRect(gfx::Rect(0, 0, surface->width(), surface->height()), paint);
+    surface->drawRect(surface->bounds(), paint);
   }
 
   {
-    Graphics g(display(), surface, 0, 0);
-    g.setFont(font());
-
-    Paint paint;
-    paint.color(gfx::rgba(0, 0, 0, 200));
-
-    // TODO: This will render any open things, especially the preview editor, need to close or hide
-    // that for a frame or paint the widget itself to a surface instead of croppping the backLayer.
-    auto backLayerSurface = display()->backLayer()->surface();
-    g.drawSurface(backLayerSurface.get(),
-                  dragWidget->bounds(),
-                  gfx::Rect(0, 0, surface->width(), surface->height()),
-                  os::Sampling(),
-                  &paint);
+    Graphics g(surface);
+    g.setFont(m_dragWidget->font());
+    m_dragWidget->paint(&g, gfx::Region(m_dragWidget->bounds()), true, (DrawableRegionFlags)0);
   }
 
   m_floatingUILayer = UILayer::Make();
   m_floatingUILayer->setSurface(surface);
-  m_floatingUILayer->setPosition(dragWidget->bounds().origin());
-  display()->addLayer(m_floatingUILayer);
+  m_floatingUILayer->setPosition(m_dragWidget->origin());
+
+  os::Paint p;
+  p.color(gfx::rgba(0, 0, 0, 200));
+  m_floatingUILayer->setPaint(p);
+
+  m_display->addLayer(m_floatingUILayer);
 }
 
-Dock::DropzonePlaceholder::~DropzonePlaceholder()
+Dock::DraggingFeedback::~DraggingFeedback()
 {
-  display()->removeLayer(m_floatingUILayer);
+  m_display->removeLayer(m_floatingUILayer);
+
+  if (m_dropUILayer)
+    m_display->removeLayer(m_dropUILayer);
 }
 
-void Dock::DropzonePlaceholder::setGhostPosition(const gfx::Point& position) const
+void Dock::DraggingFeedback::setHit(const Hit& hit)
+{
+  m_hit = hit;
+
+  if (m_hit.widget && m_hit.targetSide) {
+    if (!m_dropUILayer) {
+      m_dropUILayer = UILayer::Make();
+      m_display->addLayer(m_dropUILayer);
+      if (m_floatingUILayer) {
+        m_display->removeLayer(m_floatingUILayer);
+        m_display->addLayer(m_floatingUILayer);
+      }
+    }
+
+    gfx::Rect dropBounds = hit.bounds();
+    if (dropBounds.isEmpty())
+      return;
+
+    dropBounds.enlarge(2 * guiscale());
+
+    m_display->dirtyRect(m_dropUILayer->bounds());
+
+    os::SurfaceRef surface = os::System::instance()->makeRgbaSurface(dropBounds.w, dropBounds.h);
+    m_dropUILayer->setSurface(surface);
+    m_dropUILayer->setPosition(dropBounds.origin());
+    m_display->dirtyRect(m_dropUILayer->bounds());
+
+    os::Paint p;
+    p.color(gfx::rgba(0, 0, 0, 128));
+    p.blendMode(os::BlendMode::Difference);
+    m_dropUILayer->setPaint(p);
+
+    Graphics g(surface);
+    paint(&g, gfx::Rect(dropBounds.size()));
+  }
+  else if (m_dropUILayer) {
+    m_display->dirtyRect(m_dropUILayer->bounds());
+    m_display->removeLayer(m_dropUILayer);
+    m_dropUILayer.reset();
+  }
+}
+
+void Dock::DraggingFeedback::setFloatingPosition(const gfx::Point& position) const
 {
   ASSERT(m_floatingUILayer);
 
-  display()->dirtyRect(m_floatingUILayer->bounds());
+  m_display->dirtyRect(m_floatingUILayer->bounds());
   m_floatingUILayer->setPosition(position - m_mouseOffset);
-  display()->dirtyRect(m_floatingUILayer->bounds());
+  m_display->dirtyRect(m_floatingUILayer->bounds());
 }
 
-void Dock::DropzonePlaceholder::onPaint(PaintEvent& ev)
+void Dock::DraggingFeedback::paint(Graphics* g, gfx::Rect bounds) const
 {
-  Graphics* g = ev.graphics();
-  gfx::Rect bounds = clientBounds();
+  bounds.shrink(4 * guiscale());
 
-  g->fillRect(bgColor(), bounds);
+  const gfx::Point pts[4] = {
+    bounds.origin(),
+    gfx::Point(bounds.x2() - 1, bounds.y),
+    gfx::Point(bounds.x, bounds.y2() - 1),
+    bounds.point2(),
+  };
 
-  bounds.shrink(2 * guiscale());
+  if (!m_hit.targetSide)
+    return;
 
-  const auto* theme = SkinTheme::get(this);
-  const gfx::Color color = theme->colors.workspaceText();
+  gfx::Path path;
+  path.moveTo(bounds.center());
+  switch (m_hit.targetSide) {
+    case TOP:
+      path.lineTo(pts[0]);
+      path.lineTo(pts[1]);
+      break;
+    case LEFT:
+      path.lineTo(pts[0]);
+      path.lineTo(pts[2]);
+      break;
+    case RIGHT:
+      path.lineTo(pts[1]);
+      path.lineTo(pts[3]);
+      break;
+    case BOTTOM:
+      path.lineTo(pts[2]);
+      path.lineTo(pts[3]);
+      break;
+  }
+  path.close();
 
-  g->drawRect(color, bounds);
-  g->drawLine(color, bounds.center(), bounds.origin());
-  g->drawLine(color, bounds.center(), bounds.point2());
-  g->drawLine(color, bounds.center(), bounds.point2() - gfx::Point(bounds.w, 0));
-  g->drawLine(color, bounds.center(), bounds.origin() + gfx::Point(bounds.w, 0));
-  g->drawRect(
-    color,
-    gfx::Rect(bounds.center() - gfx::Point(2, 2) * guiscale(), gfx::Size(4, 4) * guiscale()));
+  os::Paint paint;
+  paint.color(gfx::rgba(255, 255, 255, 128));
+  paint.style(Paint::StrokeAndFill);
+  paint.strokeWidth(4.0f * guiscale());
+#if LAF_SKIA
+  paint.skPaint().setStrokeCap(SkPaint::kRound_Cap);
+  paint.skPaint().setStrokeJoin(SkPaint::kRound_Join);
+#endif
+  g->drawPath(path, paint);
 }
+
+//////////////////////////////////////////////////////////////////////
+// Dock
 
 Dock::Dock()
 {
@@ -204,8 +283,8 @@ void Dock::dock(int side, ui::Widget* widget, const gfx::Size& prefSize)
     if (prefSize != gfx::Size(0, 0))
       m_sizes[i] = prefSize;
   }
-  else if (auto subdock = dynamic_cast<Dock*>(m_sides[i])) {
-    subdock->dock(CENTER, widget, prefSize);
+  else if (Dock* subdock = this->subdock(side)) {
+    subdock->dock(side, widget, prefSize);
   }
   else {
     ASSERT(false); // Docking failure!
@@ -257,8 +336,11 @@ void Dock::undock(Widget* widget)
       }
     }
 
-    if (parentDock != this && parentDock->children().empty()) {
-      undock(parentDock);
+    if (parentDock->m_autoDelete) {
+      if (parentDock->children().empty()) {
+        undock(parentDock);
+        parentDock->deferDelete();
+      }
     }
   }
   else {
@@ -418,30 +500,29 @@ void Dock::onPaint(ui::PaintEvent& ev)
                           const int index) {
                   gfx::Rect rc = widgetBounds;
                   auto th = textHeight();
-                  if (isCustomizing()) {
-                    auto* theme = SkinTheme::get(this);
-                    const gfx::Color color = theme->colors.workspaceText();
-                    int handleSide = 0;
-                    if (auto* dockable = dynamic_cast<Dockable*>(widget))
-                      handleSide = dockable->dockHandleSide();
-                    switch (handleSide) {
-                      case ui::TOP:
-                        rc.h = th;
-                        for (int y = rc.y; y + 1 < rc.y2(); y += 2)
-                          g->drawHLine(color,
-                                       rc.x + widget->border().left(),
-                                       y,
-                                       rc.w - widget->border().width());
-                        break;
-                      case ui::LEFT:
-                        rc.w = th;
-                        for (int x = rc.x; x + 1 < rc.x2(); x += 2)
-                          g->drawVLine(color,
-                                       x,
-                                       rc.y + widget->border().top(),
-                                       rc.h - widget->border().height());
-                        break;
-                    }
+
+                  auto* theme = SkinTheme::get(this);
+                  const gfx::Color color = theme->colors.workspaceText();
+                  int handleSide = 0;
+                  if (auto* dockable = dynamic_cast<Dockable*>(widget))
+                    handleSide = dockable->dockHandleSide();
+                  switch (handleSide) {
+                    case ui::TOP:
+                      rc.h = th;
+                      for (int y = rc.y; y + 1 < rc.y2(); y += 2)
+                        g->drawHLine(color,
+                                     rc.x + widget->border().left(),
+                                     y,
+                                     rc.w - widget->border().width());
+                      break;
+                    case ui::LEFT:
+                      rc.w = th;
+                      for (int x = rc.x; x + 1 < rc.x2(); x += 2)
+                        g->drawVLine(color,
+                                     x,
+                                     rc.y + widget->border().top(),
+                                     rc.h - widget->border().height());
+                      break;
                   }
                 });
   }
@@ -486,10 +567,12 @@ bool Dock::onProcessMessage(ui::Message* msg)
 
     case kMouseMoveMessage: {
       if (hasCapture()) {
-        const gfx::Point& pos = static_cast<MouseMessage*>(msg)->position();
+        const ui::MouseMessage* mouseMsg = static_cast<ui::MouseMessage*>(msg);
+        const gfx::Point pos = mouseMsg->position();
+        const gfx::Point screenPos = mouseMsg->screenPosition();
 
-        if (m_dropzonePlaceholder)
-          m_dropzonePlaceholder->setGhostPosition(pos);
+        if (m_draggingFeedback)
+          m_draggingFeedback->setFloatingPosition(pos);
 
         if (m_hit.sideIndex >= 0) {
           if (!display()->bounds().contains(pos) ||
@@ -521,63 +604,64 @@ bool Dock::onProcessMessage(ui::Message* msg)
           layout();
           Resize();
         }
-        else if (m_hit.dockable && m_dragging) {
-          invalidate();
+        else if (m_hit.widget && m_hit.dockable && m_dragging) {
+          const Dockable* draggingDockable = m_hit.dockable;
+          const int dockableAt = draggingDockable->dockableAt();
 
-          auto* parentDock = dynamic_cast<Dock*>(m_hit.widget->parent());
-          ASSERT(parentDock);
+          if (!m_draggingFeedback)
+            m_draggingFeedback = std::make_unique<DraggingFeedback>(display(), m_hit, pos);
 
-          if (!parentDock)
+          Widget* pick = manager()->pickFromScreenPos(screenPos);
+
+          Widget* iter = pick;
+          Dockable* targetDockable = nullptr;
+          Dock* targetDock = nullptr;
+          while (iter) {
+            if (auto* dockable = dynamic_cast<Dockable*>(iter)) {
+              if (!targetDockable)
+                targetDockable = dockable;
+            }
+            if (auto* dock = dynamic_cast<Dock*>(iter)) {
+              if (!targetDock && dock->isCustomizing())
+                targetDock = dock;
+            }
+            iter = iter->parent();
+          }
+
+          if (!pick || !targetDockable || !targetDock)
             break;
 
-          if (!m_dropzonePlaceholder)
-            m_dropzonePlaceholder.reset(new DropzonePlaceholder(m_hit.widget, pos));
-
-          auto dockedAt = parentDock->whichSideChildIsDocked(m_hit.widget);
-          const auto& bounds = parentDock->bounds();
-
-          if (!bounds.contains(pos))
-            break; // Do not handle anything outside the bounds of the dock.
-
-          const int kBufferZone =
-            std::max(12 * guiscale(), std::min(m_hit.widget->size().w, m_hit.widget->size().h));
-
-          int newTargetSide = -1;
-          if (m_hit.dockable->dockableAt() & LEFT && !(dockedAt & LEFT) &&
-              pos.x < bounds.x + kBufferZone) {
-            newTargetSide = LEFT;
-          }
-          else if (m_hit.dockable->dockableAt() & RIGHT && !(dockedAt & RIGHT) &&
-                   pos.x > (bounds.w - kBufferZone)) {
-            newTargetSide = RIGHT;
-          }
-          else if (m_hit.dockable->dockableAt() & TOP && !(dockedAt & TOP) &&
-                   pos.y < bounds.y + kBufferZone) {
-            newTargetSide = TOP;
-          }
-          else if (m_hit.dockable->dockableAt() & BOTTOM && !(dockedAt & BOTTOM) &&
-                   pos.y > (bounds.h - kBufferZone)) {
-            newTargetSide = BOTTOM;
+          Hit target;
+          if (targetDockable != draggingDockable) {
+            target.widget = dynamic_cast<Widget*>(targetDockable);
+            target.dockable = targetDockable;
+            target.dock = targetDock;
           }
 
-          if (m_hit.targetSide == newTargetSide)
-            break;
+          gfx::Rect dropBounds = target.bounds();
+          if (!dropBounds.isEmpty()) {
+            gfx::PointF diff(pos - dropBounds.center());
+            if (dropBounds.w / 2.0)
+              diff.x /= dropBounds.w / 2.0f;
+            if (dropBounds.h / 2.0)
+              diff.y /= dropBounds.h / 2.0f;
 
-          m_hit.targetSide = newTargetSide;
-
-          // Always undock the placeholder
-          if (m_dropzonePlaceholder && m_dropzonePlaceholder->parent()) {
-            auto* placeholderCurrentDock = dynamic_cast<Dock*>(m_dropzonePlaceholder->parent());
-            placeholderCurrentDock->undock(m_dropzonePlaceholder.get());
+            if ((dockableAt & LEFT) && diff.x < 0 && (ABS(diff.x) > ABS(diff.y))) {
+              target.targetSide = LEFT;
+            }
+            else if ((dockableAt & RIGHT) && diff.x > 0 && (ABS(diff.x) > ABS(diff.y))) {
+              target.targetSide = RIGHT;
+            }
+            else if ((dockableAt & TOP) && diff.y < 0 && (ABS(diff.x) < ABS(diff.y))) {
+              target.targetSide = TOP;
+            }
+            else if ((dockableAt & BOTTOM) && diff.y > 0 && (ABS(diff.x) < ABS(diff.y))) {
+              target.targetSide = BOTTOM;
+            }
           }
 
-          if (m_dropzonePlaceholder && m_hit.targetSide != -1) {
-            parentDock->dock(m_hit.targetSide,
-                             m_dropzonePlaceholder.get(),
-                             m_hit.widget->sizeHint());
-          }
-
-          layout();
+          if (m_draggingFeedback->hit() != target)
+            m_draggingFeedback->setHit(target);
         }
       }
       break;
@@ -587,67 +671,72 @@ bool Dock::onProcessMessage(ui::Message* msg)
       if (hasCapture()) {
         releaseMouse();
 
-        if (m_dropzonePlaceholder && m_dropzonePlaceholder->parent()) {
-          // Always undock the dropzone placeholder to avoid dangling sizes.
-          auto* placeholderCurrentDock = dynamic_cast<Dock*>(m_dropzonePlaceholder->parent());
-          placeholderCurrentDock->undock(m_dropzonePlaceholder.get());
-        }
+        const auto* mouseMessage = static_cast<MouseMessage*>(msg);
 
-        if (m_hit.dockable) {
+        // Right-click to redock with popup menu.
+        if (mouseMessage->right() && !m_dragging && m_hit.dockable) {
           auto* dockableWidget = dynamic_cast<Widget*>(m_hit.dockable);
           auto* widgetDock = dynamic_cast<Dock*>(dockableWidget->parent());
 
           int currentSide = widgetDock->whichSideChildIsDocked(dockableWidget);
 
-          assert(dockableWidget && widgetDock);
+          ASSERT(dockableWidget && widgetDock);
 
-          const auto* mouseMessage = static_cast<MouseMessage*>(msg);
-          if (mouseMessage->right() && !m_dragging) {
-            Menu menu;
-            MenuItem left(Strings::dock_left());
-            MenuItem right(Strings::dock_right());
-            MenuItem top(Strings::dock_top());
-            MenuItem bottom(Strings::dock_bottom());
+          Menu menu;
+          MenuItem left(Strings::dock_left());
+          MenuItem right(Strings::dock_right());
+          MenuItem top(Strings::dock_top());
+          MenuItem bottom(Strings::dock_bottom());
 
-            if (m_hit.dockable->dockableAt() & ui::LEFT) {
-              menu.addChild(&left);
-            }
-            if (m_hit.dockable->dockableAt() & ui::RIGHT) {
-              menu.addChild(&right);
-            }
-            if (m_hit.dockable->dockableAt() & ui::TOP) {
-              menu.addChild(&top);
-            }
-            if (m_hit.dockable->dockableAt() & ui::BOTTOM) {
-              menu.addChild(&bottom);
-            }
-
-            switch (currentSide) {
-              case ui::LEFT:   left.setEnabled(false); break;
-              case ui::RIGHT:  right.setEnabled(false); break;
-              case ui::TOP:    top.setEnabled(false); break;
-              case ui::BOTTOM: bottom.setEnabled(false); break;
-            }
-
-            left.Click.connect([&] { redockWidget(widgetDock, dockableWidget, ui::LEFT); });
-            right.Click.connect([&] { redockWidget(widgetDock, dockableWidget, ui::RIGHT); });
-            top.Click.connect([&] { redockWidget(widgetDock, dockableWidget, ui::TOP); });
-            bottom.Click.connect([&] { redockWidget(widgetDock, dockableWidget, ui::BOTTOM); });
-
-            menu.showPopup(mouseMessage->position(), display());
-            return false;
+          if (m_hit.dockable->dockableAt() & ui::LEFT) {
+            menu.addChild(&left);
           }
-          else if (m_hit.targetSide > 0 && m_dragging) {
-            ASSERT(m_hit.dockable->dockableAt() & m_hit.targetSide);
-            redockWidget(widgetDock, dockableWidget, m_hit.targetSide);
-            m_dropzonePlaceholder = nullptr;
+          if (m_hit.dockable->dockableAt() & ui::RIGHT) {
+            menu.addChild(&right);
+          }
+          if (m_hit.dockable->dockableAt() & ui::TOP) {
+            menu.addChild(&top);
+          }
+          if (m_hit.dockable->dockableAt() & ui::BOTTOM) {
+            menu.addChild(&bottom);
+          }
+
+          switch (currentSide) {
+            case ui::LEFT:   left.setEnabled(false); break;
+            case ui::RIGHT:  right.setEnabled(false); break;
+            case ui::TOP:    top.setEnabled(false); break;
+            case ui::BOTTOM: bottom.setEnabled(false); break;
+          }
+
+          left.Click.connect([&] { redockWidget(widgetDock, dockableWidget, ui::LEFT); });
+          right.Click.connect([&] { redockWidget(widgetDock, dockableWidget, ui::RIGHT); });
+          top.Click.connect([&] { redockWidget(widgetDock, dockableWidget, ui::TOP); });
+          bottom.Click.connect([&] { redockWidget(widgetDock, dockableWidget, ui::BOTTOM); });
+
+          menu.showPopup(mouseMessage->position(), display());
+          return true;
+        }
+
+        // Drop the widget to a new dock
+        if (m_dragging && m_draggingFeedback) {
+          const Hit target = m_draggingFeedback->hit();
+          const Dockable* dockable = m_hit.dockable;
+          Widget* widget = m_hit.widget;
+          Dock* dock = target.dock;
+
+          if (dock && dockable && widget && target.targetSide) {
+            ASSERT(dockable->dockableAt() & target.targetSide);
+
+            redockWidget(dock, widget, target.targetSide);
+
+            m_draggingFeedback.reset();
             m_dragging = false;
             m_hit = Hit();
-            return false;
+            return true;
           }
         }
 
-        m_dropzonePlaceholder = nullptr;
+        m_draggingFeedback.reset();
         m_dragging = false;
 
         // Call UserResizedDock signal after resizing a Dock splitter
@@ -674,7 +763,7 @@ bool Dock::onProcessMessage(ui::Message* msg)
           case kRightIndex:  cursor = ui::kSizeWECursor; break;
         }
       }
-      else if (m_hit.dockable && m_hit.targetSide == -1) {
+      else if (m_hit.dockable && m_hit.targetSide == 0) {
         cursor = ui::kMoveCursor;
       }
 
@@ -810,12 +899,12 @@ void Dock::forEachSide(gfx::Rect bounds,
   }
 }
 
-void Dock::redockWidget(app::Dock* widgetDock, ui::Widget* dockableWidget, const int side)
+void Dock::redockWidget(app::Dock* newDock, ui::Widget* dockableWidget, const int side)
 {
   gfx::Size size;
 
   if (dockableWidget->id() == "timeline") {
-    const gfx::Rect workspaceBounds = widgetDock->bounds();
+    const gfx::Rect workspaceBounds = newDock->bounds();
 
     size.w = 64;
     size.h = 64;
@@ -836,12 +925,26 @@ void Dock::redockWidget(app::Dock* widgetDock, ui::Widget* dockableWidget, const
     Preferences::instance().general.timelinePosition(pos);
   }
 
-  widgetDock->undock(dockableWidget);
-  widgetDock->dock(side, dockableWidget, size);
+  undock(dockableWidget);
+  newDock->dock(side, dockableWidget, size);
 
-  App::instance()->mainWindow()->invalidate();
-  layout();
+  if (Dock* root = rootDock())
+    root->layout();
   onUserResizedDock();
+}
+
+Dock* Dock::rootDock()
+{
+  Dock* root = this;
+  Widget* iter = this->parent();
+  while (iter) {
+    if (auto* dock = dynamic_cast<Dock*>(iter)) {
+      if (dock->isCustomizing())
+        root = dock;
+    }
+    iter = iter->parent();
+  }
+  return root;
 }
 
 Dock::Hit Dock::calcHit(const gfx::Point& pos)

--- a/src/app/ui/dock.cpp
+++ b/src/app/ui/dock.cpp
@@ -39,26 +39,24 @@ using namespace ui;
 
 namespace {
 
-enum { kTopIndex, kBottomIndex, kLeftIndex, kRightIndex, kCenterIndex };
-
-int side_index(int side)
+Dock::SideIndex side_index(int sideFlag)
 {
-  switch (side) {
-    case ui::TOP:    return kTopIndex;
-    case ui::BOTTOM: return kBottomIndex;
-    case ui::LEFT:   return kLeftIndex;
-    case ui::RIGHT:  return kRightIndex;
+  switch (sideFlag) {
+    case ui::TOP:    return Dock::kTopIndex;
+    case ui::BOTTOM: return Dock::kBottomIndex;
+    case ui::LEFT:   return Dock::kLeftIndex;
+    case ui::RIGHT:  return Dock::kRightIndex;
   }
-  return kCenterIndex; // ui::CENTER
+  return Dock::kCenterIndex; // ui::CENTER
 }
 
-int side_from_index(int index)
+int side_from_index(const Dock::SideIndex sideIndex)
 {
-  switch (index) {
-    case kTopIndex:    return ui::TOP;
-    case kBottomIndex: return ui::BOTTOM;
-    case kLeftIndex:   return ui::LEFT;
-    case kRightIndex:  return ui::RIGHT;
+  switch (sideIndex) {
+    case Dock::kTopIndex:    return ui::TOP;
+    case Dock::kBottomIndex: return ui::BOTTOM;
+    case Dock::kLeftIndex:   return ui::LEFT;
+    case Dock::kRightIndex:  return ui::RIGHT;
   }
   return ui::CENTER; // kCenterIndex
 }
@@ -271,11 +269,11 @@ void Dock::resetDocks()
   removeAllChildren();
 }
 
-void Dock::dock(int side, ui::Widget* widget, const gfx::Size& prefSize)
+void Dock::dock(const int sideFlag, ui::Widget* widget, const gfx::Size& prefSize)
 {
   ASSERT(widget);
 
-  const int i = side_index(side);
+  const SideIndex i = side_index(sideFlag);
   if (!m_sides[i]) {
     setSide(i, widget);
     addChild(widget);
@@ -283,8 +281,8 @@ void Dock::dock(int side, ui::Widget* widget, const gfx::Size& prefSize)
     if (prefSize != gfx::Size(0, 0))
       m_sizes[i] = prefSize;
   }
-  else if (Dock* subdock = this->subdock(side)) {
-    subdock->dock(side, widget, prefSize);
+  else if (Dock* subdock = this->subdock(sideFlag)) {
+    subdock->dock(sideFlag, widget, prefSize);
   }
   else {
     ASSERT(false); // Docking failure!
@@ -352,13 +350,13 @@ int Dock::whichSideChildIsDocked(const ui::Widget* widget) const
 {
   for (int i = 0; i < kSides; ++i)
     if (m_sides[i] == widget)
-      return side_from_index(i);
+      return side_from_index(SideIndex(i));
   return 0;
 }
 
-const gfx::Size Dock::getUserDefinedSizeAtSide(int side) const
+const gfx::Size Dock::getUserDefinedSizeAtSide(const int sideFlag) const
 {
-  int i = side_index(side);
+  SideIndex i = side_index(sideFlag);
   // Only EXPANSIVE sides can be user-defined (has a splitter so the
   // user can expand or shrink it)
   if (m_aligns[i] & EXPANSIVE)
@@ -839,7 +837,7 @@ void Dock::forEachSide(gfx::Rect bounds,
                        std::function<void(ui::Widget* widget,
                                           const gfx::Rect& widgetBounds,
                                           const gfx::Rect& separator,
-                                          const int index)> f)
+                                          const SideIndex index)> f)
 {
   for (int i = 0; i < kSides; ++i) {
     auto* widget = m_sides[i];
@@ -851,7 +849,7 @@ void Dock::forEachSide(gfx::Rect bounds,
     const gfx::Size sz = (m_aligns[i] & EXPANSIVE ? m_sizes[i] : widget->sizeHint(bounds.size()));
 
     gfx::Rect rc, separator;
-    switch (i) {
+    switch (SideIndex(i)) {
       case kTopIndex:
         rc = gfx::Rect(bounds.x, bounds.y, bounds.w, sz.h);
         bounds.y += rc.h;
@@ -895,7 +893,7 @@ void Dock::forEachSide(gfx::Rect bounds,
       case kCenterIndex: rc = bounds; break;
     }
 
-    f(widget, rc, separator, i);
+    f(widget, rc, separator, SideIndex(i));
   }
 }
 

--- a/src/app/ui/dock.h
+++ b/src/app/ui/dock.h
@@ -24,7 +24,7 @@ class Dockable;
 
 class Dock : public ui::Widget {
 public:
-  static constexpr const int kSides = 5;
+  enum SideIndex { kTopIndex, kBottomIndex, kLeftIndex, kRightIndex, kCenterIndex, kSides };
 
   Dock();
 
@@ -34,7 +34,7 @@ public:
   void resetDocks();
 
   // side = ui::LEFT, or ui::RIGHT, etc.
-  void dock(int side, ui::Widget* widget, const gfx::Size& prefSize = gfx::Size());
+  void dock(int sideFlag, ui::Widget* widget, const gfx::Size& prefSize = gfx::Size());
 
   void dockRelativeTo(ui::Widget* relative,
                       int side,
@@ -53,7 +53,7 @@ public:
 
   // Functions useful to query/save the dock layout.
   int whichSideChildIsDocked(const ui::Widget* widget) const;
-  const gfx::Size getUserDefinedSizeAtSide(int side) const;
+  const gfx::Size getUserDefinedSizeAtSide(int sideFlag) const;
 
   static int GetSide(Widget* widget);
   static void SetSide(Widget* widget, int side);
@@ -114,7 +114,7 @@ private:
                    std::function<void(ui::Widget* widget,
                                       const gfx::Rect& widgetBounds,
                                       const gfx::Rect& separator,
-                                      const int index)> f);
+                                      const SideIndex index)> f);
 
   bool hasVisibleSide(const int i) const { return (m_sides[i] && m_sides[i]->isVisible()); }
   void redockWidget(app::Dock* newDock, ui::Widget* dockableWidget, int side);

--- a/src/app/ui/dock.h
+++ b/src/app/ui/dock.h
@@ -26,22 +26,6 @@ class Dock : public ui::Widget {
 public:
   static constexpr const int kSides = 5;
 
-  class DropzonePlaceholder final : public Widget,
-                                    public Dockable {
-  public:
-    DropzonePlaceholder(Widget* dragWidget, const gfx::Point& mousePosition);
-    ~DropzonePlaceholder() override;
-
-    void setGhostPosition(const gfx::Point& position) const;
-
-  private:
-    void onPaint(ui::PaintEvent& ev) override;
-    int dockHandleSide() const override { return 0; }
-
-    gfx::Point m_mouseOffset;
-    ui::UILayerRef m_floatingUILayer;
-  };
-
   Dock();
 
   bool isCustomizing() const { return m_customizing; }
@@ -86,6 +70,43 @@ protected:
   void onUserResizedDock();
 
 private:
+  struct Hit {
+    ui::Widget* widget = nullptr;
+    Dockable* dockable = nullptr;
+    Dock* dock = nullptr;
+    int sideIndex = -1;
+    int targetSide = 0;
+
+    gfx::Rect bounds() const;
+
+    bool operator==(const Hit& other) const
+    {
+      return (widget == other.widget && dockable == other.dockable && dock == other.dock &&
+              sideIndex == other.sideIndex && targetSide == other.targetSide);
+    }
+    bool operator!=(const Hit& other) const { return !operator==(other); }
+  };
+
+  class DraggingFeedback final {
+  public:
+    DraggingFeedback(ui::Display* display, const Hit& hit, const gfx::Point& mousePosition);
+    ~DraggingFeedback();
+
+    const Hit& hit() const { return m_hit; }
+
+    void setHit(const Hit& hit);
+    void setFloatingPosition(const gfx::Point& position) const;
+    void paint(ui::Graphics* g, gfx::Rect bounds) const;
+
+  private:
+    Hit m_hit;
+    ui::Display* m_display;
+    ui::Widget* m_dragWidget;
+    gfx::Point m_mouseOffset;
+    ui::UILayerRef m_floatingUILayer;
+    ui::UILayerRef m_dropUILayer;
+  };
+
   void setSide(int i, ui::Widget* newWidget);
   int calcAlign(int i);
   void updateDockVisibility();
@@ -96,14 +117,8 @@ private:
                                       const int index)> f);
 
   bool hasVisibleSide(const int i) const { return (m_sides[i] && m_sides[i]->isVisible()); }
-  void redockWidget(app::Dock* widgetDock, ui::Widget* dockableWidget, const int side);
-
-  struct Hit {
-    ui::Widget* widget = nullptr;
-    Dockable* dockable = nullptr;
-    int sideIndex = -1;
-    int targetSide = -1;
-  };
+  void redockWidget(app::Dock* newDock, ui::Widget* dockableWidget, int side);
+  Dock* rootDock();
 
   Hit calcHit(const gfx::Point& pos);
 
@@ -124,7 +139,7 @@ private:
 
   // True when we're dragging a widget to attempt to dock it somewhere else.
   bool m_dragging = false;
-  std::unique_ptr<DropzonePlaceholder> m_dropzonePlaceholder;
+  std::unique_ptr<DraggingFeedback> m_draggingFeedback;
 };
 
 } // namespace app

--- a/src/app/ui/main_window.cpp
+++ b/src/app/ui/main_window.cpp
@@ -733,11 +733,10 @@ void MainWindow::configureWorkspaceLayout()
   m_statusBar->setVisible(normal);
   m_contextBar->setVisible(isDoc && (m_mode == NormalMode || m_mode == ContextBarAndTimelineMode));
 
-  // Configure timeline
-  if (m_timeline && m_timeline->parent()) {
-    m_timelineResizeConn = dynamic_cast<Dock*>(m_timeline->parent())
-                             ->Resize.connect(&MainWindow::saveTimelineConfiguration, this);
-  }
+  // After the timeline is resized we save the timeline configuration
+  // for backward compatibility
+  if (m_timeline)
+    m_timelineResizeConn = m_timeline->Resize.connect(&MainWindow::saveTimelineConfiguration, this);
 
   m_timeline->setVisible(isDoc && (m_mode == NormalMode || m_mode == ContextBarAndTimelineMode) &&
                          pref.general.visibleTimeline());

--- a/src/app/ui/timeline/timeline.cpp
+++ b/src/app/ui/timeline/timeline.cpp
@@ -1644,6 +1644,7 @@ void Timeline::onResize(ui::ResizeEvent& ev)
     oneTagHeight()));
 
   updateScrollBars();
+  Resize();
 }
 
 void Timeline::onPaint(ui::PaintEvent& ev)

--- a/src/app/ui/timeline/timeline.h
+++ b/src/app/ui/timeline/timeline.h
@@ -165,6 +165,8 @@ public:
     return ui::TOP | ui::BOTTOM | ui::LEFT | ui::RIGHT | ui::EXPANSIVE;
   }
 
+  obs::signal<void()> Resize;
+
 protected:
   bool onProcessMessage(ui::Message* msg) override;
   void onInitTheme(ui::InitThemeEvent& ev) override;

--- a/src/ui/widget.cpp
+++ b/src/ui/widget.cpp
@@ -1188,15 +1188,16 @@ void Widget::flushMessages() const
   manager->flushMessages();
 }
 
-void Widget::paint(Graphics* graphics, const gfx::Region& drawRegion, const bool isBg)
+void Widget::paint(Graphics* graphics,
+                   const gfx::Region& drawRegion,
+                   const bool isBg,
+                   const DrawableRegionFlags flags)
 {
   if (drawRegion.isEmpty())
     return;
 
   std::queue<Widget*> processing;
   processing.push(this);
-
-  Display* display = this->display();
 
   while (!processing.empty()) {
     Widget* widget = processing.front();
@@ -1211,15 +1212,18 @@ void Widget::paint(Graphics* graphics, const gfx::Region& drawRegion, const bool
     for (auto child : widget->children())
       processing.push(child);
 
-    // Intersect drawRegion with widget's drawable region.
+    // Intersect "drawRegion" with widget's drawable region. Both
+    // regions are in the bounds() coordinates.
     Region region;
-    widget->getDrawableRegion(region, kCutTopWindows);
-    region.createIntersection(region, drawRegion);
+    widget->getDrawableRegion(region, flags);
+    region &= drawRegion;
 
-    Graphics graphics2(display,
-                       base::AddRef(graphics->getInternalSurface()),
-                       widget->bounds().x,
-                       widget->bounds().y);
+    // Create a Graphics to paint the widget relative to the same
+    // widget coordinate (bounds.x/bounds.y as origin = position 0,0).
+    Graphics graphics2(graphics->display(),
+                       AddRef(graphics->getInternalSurface()),
+                       graphics->getInternalDeltaX() + widget->bounds().x - bounds().x,
+                       graphics->getInternalDeltaY() + widget->bounds().y - bounds().y);
     graphics2.setFont(widget->font());
 
     for (const gfx::Rect& rc : region) {
@@ -1266,9 +1270,16 @@ bool Widget::paintEvent(Graphics* graphics, const bool isBg)
     }
     if (parentWidget) {
       gfx::Region rgn(parentWidget->bounds());
+      Graphics graphics2(parentWidget->display(),
+                         AddRef(graphics->getInternalSurface()),
+                         graphics->getInternalDeltaX() + parentWidget->bounds().x - bounds().x,
+                         graphics->getInternalDeltaY() + parentWidget->bounds().y - bounds().y);
+      graphics2.setFont(parentWidget->font());
+
       rgn &= gfx::Region(graphics->getClipBounds().offset(graphics->getInternalDeltaX(),
                                                           graphics->getInternalDeltaY()));
-      parentWidget->paint(graphics, rgn, true);
+
+      parentWidget->paint(&graphics2, rgn, true, kCutTopWindows);
     }
     else {
       // Clear surface with transparent color

--- a/src/ui/widget.h
+++ b/src/ui/widget.h
@@ -327,6 +327,13 @@ public:
 
   GraphicsPtr getGraphics(const gfx::Rect& clip);
 
+  // Paint the widget in the give graphics. The "drawRegion" must be
+  // in the same coordinates as the bounds() field.
+  void paint(Graphics* graphics,
+             const gfx::Region& drawRegion,
+             bool isBg,
+             DrawableRegionFlags flags);
+
   // ===============================================================
   // GUI MANAGER
   // ===============================================================
@@ -461,7 +468,6 @@ protected:
 
 private:
   void removeChild(const WidgetsList::iterator& it);
-  void paint(Graphics* graphics, const gfx::Region& drawRegion, const bool isBg);
   bool paintEvent(Graphics* graphics, const bool isBg);
   void setDirtyFlag();
 


### PR DESCRIPTION
From #5327 we'll try to implement the possibility to dock any widget in any dock. And to make floating windows from docks (even the "preview window" should be dockable).

We want to fix #2299 too adding a notch for completely collapsed widgets in splitters.
