### PR TITLE
Check if extension files are present to avoid crashes & issues

### DIFF
--- a/src/app/extensions.cpp
+++ b/src/app/extensions.cpp
@@ -274,6 +274,9 @@ void Extension::executeExitActions()
 
 void Extension::addKeys(const std::string& id, const std::string& path)
 {
+  if (!m_isBuiltinExtension && !base::is_file(path))
+    return;
+
   m_keys[id] = path;
   updateCategory(Category::Keys);
 }
@@ -282,6 +285,9 @@ void Extension::addLanguage(const std::string& id,
                             const std::string& path,
                             const std::string& displayName)
 {
+  if (!m_isBuiltinExtension && !base::is_file(path))
+    return;
+
   m_languages[id] = LangInfo(id, path, displayName);
   updateCategory(Category::Languages);
 }
@@ -296,6 +302,9 @@ void Extension::addTheme(const std::string& id, const std::string& path, const s
 
 void Extension::addPalette(const std::string& id, const std::string& path)
 {
+  if (!m_isBuiltinExtension && !base::is_file(path))
+    return;
+
   m_palettes[id] = path;
   updateCategory(Category::Palettes);
 }
@@ -304,6 +313,9 @@ void Extension::addDitheringMatrix(const std::string& id,
                                    const std::string& path,
                                    const std::string& name)
 {
+  if (!m_isBuiltinExtension && !base::is_file(path))
+    return;
+
   DitheringMatrixInfo info(path, name);
   m_ditheringMatrices[id] = std::move(info);
   updateCategory(Category::DitheringMatrices);

--- a/src/app/ui/keyboard_shortcuts.cpp
+++ b/src/app/ui/keyboard_shortcuts.cpp
@@ -28,6 +28,7 @@
 #include "app/ui_context.h"
 #include "app/xml_document.h"
 #include "app/xml_exception.h"
+#include "base/fs.h"
 #include "fmt/format.h"
 #include "ui/message.h"
 #include "ui/shortcut.h"
@@ -329,6 +330,9 @@ void KeyboardShortcuts::importFile(XMLElement* rootElement, KeySource source)
 
 void KeyboardShortcuts::importFile(const std::string& filename, KeySource source)
 {
+  if (!base::is_file(filename))
+    return;
+
   XMLDocumentRef doc = app::open_xml(filename);
   XMLHandle handle(doc.get());
   XMLElement* xmlKey = handle.FirstChildElement("keyboard").ToElement();


### PR DESCRIPTION
Having an installed extension that refers to a non-existing keys file can cause aseprite to crash on load, as `AppMenu` attempts to load the XML file without checking if it exists. Other non-existing files can also cause annoying issues (like language entries appearing but doing nothing, etc).

This adds some checks to avoid this. The only only _necessary_ one is the `KeyboardShortcuts` one, but I think the others won't hurt and make sense.

Test exception to reproduce it: [test-extension.zip](https://github.com/user-attachments/files/24143216/test-extension.zip)

