### PR TITLE
Fix missing semicolon in build.ps1 PATH

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,5 +1,5 @@
 if (Test-Path "$env:ProgramFiles\Git\bin") {
-    $env:Path = "$env:ProgramFiles\Git\bin;$env:ProgramFiles\Git\mingw64\bin" + $env:Path
+    $env:Path = "$env:ProgramFiles\Git\bin;$env:ProgramFiles\Git\mingw64\bin;" + $env:Path
 }
 elseif (Test-Path "$env:ProgramFiles(x86)\Git\bin") {
     $env:Path = "$env:ProgramFiles(x86)\Git\bin;$env:ProgramFiles(x86)\Git\mingw64\bin;" + $env:Path


### PR DESCRIPTION
Fix missing semicolon in PATH setup, which corrupted the environment variable (e.g., ```...mingw64\binC:\...```).
Adding the semicolon correctly separates the new entries (e.g., ```...mingw64\bin;C:\...```).

*I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md
I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing*
