### PR TITLE
Draw the Entry background in the delegate (fix #5520)

### DIFF
--- a/src/app/ui/skin/skin_theme.cpp
+++ b/src/app/ui/skin/skin_theme.cpp
@@ -1445,12 +1445,11 @@ public:
 
     if (charBounds.x2() - m_widget->bounds().x < m_widget->clientBounds().x2()) {
       if (m_bg != ColorNone) {
-        // Fill background e.g. needed for selected/highlighted
-        // regions with TTF fonts where the char is smaller than the
-        // text bounds [m_y,m_y+m_h)
-        gfx::Rect fillThisRect(m_lastX - m_widget->bounds().x, m_y, charBounds.x2() - m_lastX, m_h);
-        if (charBounds != fillThisRect)
-          m_graphics->fillRect(m_bg, fillThisRect);
+        // Fill the background here, accounts for regions with TTF fonts where the char is smaller
+        // than the text bounds [m_y,m_y+m_h)
+        m_graphics->fillRect(
+          m_bg,
+          gfx::Rect(m_lastX - m_widget->bounds().x, m_y, charBounds.x2() - m_lastX, m_h));
       }
       m_lastX = charBounds.x2();
       return true;

--- a/src/app/ui/skin/skin_theme.cpp
+++ b/src/app/ui/skin/skin_theme.cpp
@@ -1402,36 +1402,17 @@ public:
   bool caretDrawn() const { return m_caretDrawn; }
   const gfx::Rect& textBounds() const { return m_textBounds; }
 
-  bool isSelectedChar(const int index) override
-  {
-    return ((index >= m_range.from) && (index < m_range.to));
-  }
-
-  void drawSelectionBg(const gfx::RectF& bounds) override
-  {
-    auto* theme = SkinTheme::get(m_widget);
-    auto& colors = theme->colors;
-    gfx::Color bg = ColorNone;
-
-    if (m_widget->hasFocus())
-      bg = colors.selected();
-    else
-      bg = colors.disabled();
-
-    if (bg != ColorNone)
-      m_graphics->fillRect(bg, gfx::Rect(bounds.x - m_widget->bounds().x, m_y, bounds.w, m_h));
-  }
-
   void preProcessChar(const int index,
                       const base::codepoint_t codepoint,
                       gfx::Color& fg,
                       gfx::Color& bg,
                       const gfx::Rect& charBounds) override
   {
-    auto* theme = SkinTheme::get(m_widget);
+    auto theme = SkinTheme::get(m_widget);
 
     // Normal text
     auto& colors = theme->colors;
+    bg = ColorNone;
     fg = colors.text();
 
     // Suffix text
@@ -1440,14 +1421,21 @@ public:
     }
 
     // Selected
-    if (isSelectedChar(m_index)) {
+    if ((m_index >= m_range.from) && (m_index < m_range.to)) {
+      if (m_widget->hasFocus())
+        bg = colors.selected();
+      else
+        bg = colors.disabled();
       fg = colors.selectedText();
     }
 
     // Disabled
     if (!m_widget->isEnabled()) {
+      bg = ColorNone;
       fg = colors.disabled();
     }
+
+    m_bg = bg;
   }
 
   bool preDrawChar(const gfx::Rect& charBounds) override
@@ -1456,6 +1444,14 @@ public:
     m_charStartX = charBounds.x;
 
     if (charBounds.x2() - m_widget->bounds().x < m_widget->clientBounds().x2()) {
+      if (m_bg != ColorNone) {
+        // Fill background e.g. needed for selected/highlighted
+        // regions with TTF fonts where the char is smaller than the
+        // text bounds [m_y,m_y+m_h)
+        gfx::Rect fillThisRect(m_lastX - m_widget->bounds().x, m_y, charBounds.x2() - m_lastX, m_h);
+        if (charBounds != fillThisRect)
+          m_graphics->fillRect(m_bg, fillThisRect);
+      }
       m_lastX = charBounds.x2();
       return true;
     }
@@ -1484,6 +1480,7 @@ private:
   Entry::Range m_range;
   gfx::Rect m_textBounds;
   bool m_caretDrawn;
+  gfx::Color m_bg;
   int m_lastX; // Last position used to fill the background
   int m_y, m_h;
   int m_charStartX;


### PR DESCRIPTION
Changes the approach to fixing #5520 and avoid #5628, depends on [laf#170](https://github.com/aseprite/laf/pull/170).

The cause of the bug was the double drawing of the background, once in the LAF side and once here but only when using TTF fonts with different bounds. I've moved the entirety of the drawing of the selection rect to this code, so it'll draw the right bounds in the delegate.