### PR TITLE
Add ability to make line breaks in Text tool (fix #5606)

### DIFF
--- a/src/app/ui/doc_view.cpp
+++ b/src/app/ui/doc_view.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2025  Igara Studio S.A.
+// Copyright (C) 2018-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -21,18 +21,24 @@
 #include "app/context_access.h"
 #include "app/doc_access.h"
 #include "app/doc_event.h"
+#include "app/fonts/font_info.h"
+#include "app/fonts/fonts.h"
 #include "app/i18n/strings.h"
 #include "app/modules/palettes.h"
 #include "app/pref/preferences.h"
+#include "app/tools/tool_box.h"
 #include "app/tx.h"
+#include "app/ui/context_bar.h"
 #include "app/ui/editor/editor.h"
 #include "app/ui/editor/editor_customization_delegate.h"
 #include "app/ui/editor/editor_view.h"
 #include "app/ui/editor/navigate_state.h"
+#include "app/ui/editor/writing_text_state.h"
 #include "app/ui/keyboard_shortcuts.h"
 #include "app/ui/main_window.h"
 #include "app/ui/status_bar.h"
 #include "app/ui/timeline/timeline.h"
+#include "app/ui/toolbar.h"
 #include "app/ui/workspace.h"
 #include "app/ui_context.h"
 #include "app/util/clipboard.h"
@@ -51,6 +57,7 @@
 #include "ui/system.h"
 #include "ui/view.h"
 
+#include <cmath>
 #include <typeinfo>
 
 namespace app {
@@ -541,11 +548,9 @@ bool DocView::onCanPaste(Context* ctx)
                       ContextFlags::ActiveLayerIsEditable | ContextFlags::ActiveLayerIsImage) &&
       !ctx->checkFlags(ContextFlags::ActiveLayerIsReference)) {
     auto format = ctx->clipboard()->format();
-    if (format == ClipboardFormat::Image) {
-      return true;
-    }
-    else if (format == ClipboardFormat::Tilemap &&
-             ctx->checkFlags(ContextFlags::ActiveLayerIsTilemap)) {
+    if (format == ClipboardFormat::Image || format == ClipboardFormat::Text ||
+        (format == ClipboardFormat::Tilemap &&
+         ctx->checkFlags(ContextFlags::ActiveLayerIsTilemap))) {
       return true;
     }
   }
@@ -605,8 +610,55 @@ bool DocView::onPaste(Context* ctx, const gfx::Point* position)
     clipboard->paste(ctx, true, position);
     return true;
   }
-  else
-    return false;
+  else if (clipboard->format() == ClipboardFormat::Text) {
+    std::string text;
+    if (!clipboard->getClipboardText(text) || text.empty())
+      return false;
+    Editor* editor = m_editor;
+    if (!editor)
+      return false;
+    doc::Sprite* sprite = editor->sprite();
+    if (!sprite)
+      return false;
+    tools::Tool* textTool = App::instance()->toolBox()->getToolById("text");
+    if (textTool)
+      ToolBar::instance()->selectTool(textTool);
+
+    // Calculate text bounds based on font size, considering multiline text
+    const FontInfo fontInfo = App::instance()->contextBar()->fontInfo();
+    int textWidth = sprite->width() / 2;
+    int textHeight = 16;
+    if (auto font = Fonts::instance()->fontFromInfo(fontInfo)) {
+      float maxLineWidth = 0;
+      int lineCount = 1;
+      int start = 0;
+      int pos = 0;
+      while ((pos = text.find('\n', start)) != std::string::npos) {
+        const std::string line = text.substr(start, pos - start);
+        maxLineWidth = std::max(maxLineWidth, font->textLength(line));
+        ++lineCount;
+        start = pos + 1;
+      }
+      std::string lastLine = text.substr(start);
+      textWidth = int(std::max(maxLineWidth, font->textLength(lastLine)));
+      textHeight = int(font->lineHeight() * lineCount);
+    }
+
+    // Center the text on the visible sprite area
+    gfx::Rect bounds(0, 0, textWidth, textHeight);
+    const gfx::Rect visibleSpriteBounds = editor->getVisibleSpriteBounds();
+    bounds.x = std::max(
+      0,
+      std::min(visibleSpriteBounds.center().x - textWidth / 2, sprite->width() - textWidth));
+    bounds.y = std::max(
+      0,
+      std::min(visibleSpriteBounds.center().y - textHeight / 2, sprite->height() - textHeight));
+
+    EditorStatePtr newState = std::make_shared<WritingTextState>(editor, bounds, text);
+    editor->setState(newState);
+    return true;
+  }
+  return false;
 }
 
 bool DocView::onClear(Context* ctx)

--- a/src/app/ui/editor/writing_text_state.cpp
+++ b/src/app/ui/editor/writing_text_state.cpp
@@ -82,7 +82,10 @@ public:
     Final,        // Final to be rendered in the cel
   };
 
-  TextEditor(Editor* editor, const Site& site, const gfx::Rect& bounds)
+  TextEditor(Editor* editor,
+             const Site& site,
+             const gfx::Rect& bounds,
+             const std::string& initialText = std::string())
     : m_editor(editor)
     , m_doc(site.document())
     , m_extraCel(new ExtraCel)
@@ -96,6 +99,10 @@ public:
     FontInfo fontInfo = App::instance()->contextBar()->fontInfo();
     if (auto font = Fonts::instance()->fontFromInfo(fontInfo))
       setFont(font);
+
+    if (!initialText.empty()) {
+      setText(initialText);
+    }
   }
 
   ~TextEditor()
@@ -558,11 +565,13 @@ private:
   bool m_textDirty = true;
 };
 
-WritingTextState::WritingTextState(Editor* editor, const gfx::Rect& bounds)
+WritingTextState::WritingTextState(Editor* editor,
+                                   const gfx::Rect& bounds,
+                                   const std::string& initialText)
   : m_delayedMouseMove(this, editor, 5)
   , m_editor(editor)
   , m_bounds(bounds)
-  , m_textEdit(new TextEditor(editor, editor->getSite(), bounds))
+  , m_textEdit(new TextEditor(editor, editor->getSite(), bounds, initialText))
 {
   m_beforeCmdConn = UIContext::instance()->BeforeCommandExecution.connect(
     &WritingTextState::onBeforeCommandExecution,

--- a/src/app/ui/editor/writing_text_state.cpp
+++ b/src/app/ui/editor/writing_text_state.cpp
@@ -164,6 +164,18 @@ private:
         }
         break;
       }
+      case kMouseWheelMessage: {
+        auto* mouseMsg = static_cast<MouseMessage*>(msg);
+        if (m_editor->getState()->onMouseWheel(m_editor, mouseMsg))
+          return true;
+        break;
+      }
+      case kTouchMagnifyMessage: {
+        auto* touchMsg = static_cast<TouchMessage*>(msg);
+        if (m_editor->getState()->onTouchMagnify(m_editor, touchMsg))
+          return true;
+        break;
+      }
     }
     return TextEdit::onProcessMessage(msg);
   }

--- a/src/app/ui/editor/writing_text_state.cpp
+++ b/src/app/ui/editor/writing_text_state.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2022-2025  Igara Studio S.A.
+// Copyright (C) 2022-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -32,11 +32,12 @@
 #include "render/dithering.h"
 #include "render/quantization.h"
 #include "render/render.h"
+#include "text/draw_text.h"
 #include "text/font_metrics.h"
-#include "ui/entry.h"
 #include "ui/message.h"
 #include "ui/paint_event.h"
 #include "ui/system.h"
+#include "ui/textedit.h"
 
 #ifdef LAF_SKIA
   #include "app/util/shader_helpers.h"
@@ -45,6 +46,7 @@
 #endif
 
 #include <cmath>
+#include <limits>
 
 namespace app {
 
@@ -73,7 +75,7 @@ static gfx::RectF calc_blob_bounds(const text::TextBlobRef& blob)
   return bounds;
 }
 
-class WritingTextState::TextEditor : public Entry {
+class WritingTextState::TextEditor : public TextEdit {
 public:
   enum TextPreview {
     Intermediate, // With selection preview / user interface
@@ -81,15 +83,12 @@ public:
   };
 
   TextEditor(Editor* editor, const Site& site, const gfx::Rect& bounds)
-    : Entry(4096)
-    , m_editor(editor)
+    : m_editor(editor)
     , m_doc(site.document())
     , m_extraCel(new ExtraCel)
   {
-    // We have to draw the editor as background of this ui::Entry.
+    // We have to draw the editor as background of this ui::TextEdit.
     setTransparent(true);
-
-    setPersistSelection(true);
 
     createExtraCel(site, bounds);
     renderExtraCel(TextPreview::Intermediate);
@@ -129,6 +128,8 @@ public:
 
   obs::signal<void(const gfx::RectF&)> NewRequiredBounds;
 
+  void invalidateTextCache() { m_textDirty = true; }
+
 private:
   void createExtraCel(const Site& site, const gfx::Rect& bounds)
   {
@@ -164,7 +165,7 @@ private:
         break;
       }
     }
-    return Entry::onProcessMessage(msg);
+    return TextEdit::onProcessMessage(msg);
   }
 
   float onGetTextBaseline() const override
@@ -176,19 +177,28 @@ private:
 
   void onInitTheme(InitThemeEvent& ev) override
   {
-    Entry::onInitTheme(ev);
+    TextEdit::onInitTheme(ev);
     setBgColor(gfx::ColorNone);
   }
 
   void onSetText() override
   {
-    Entry::onSetText();
+    TextEdit::onSetText();
+    invalidateTextCache();
     onNewTextBlob();
   }
 
   void onSetFont() override
   {
-    Entry::onSetFont();
+    TextEdit::onSetFont();
+    invalidateTextCache();
+    onNewTextBlob();
+  }
+
+  void onTextChanged() override
+  {
+    TextEdit::onTextChanged();
+    invalidateTextCache();
     onNewTextBlob();
   }
 
@@ -202,21 +212,92 @@ private:
 
   void onNewTextBlob()
   {
-    text::TextBlobRef blob = textBlob();
-    if (!blob)
+    if (lines().empty())
       return;
 
     // Notify that we could make the text editor bigger to show this
-    // text blob.
-    NewRequiredBounds(calc_blob_bounds(blob));
+    // multi-line text.
+    const gfx::RectF bounds = calcMultiLineBounds();
+    if (!bounds.isEmpty())
+      NewRequiredBounds(bounds);
+  }
+
+  Caret caretFromPosition(const gfx::Point& position) override
+  {
+    if (lines().empty())
+      return Caret(&lines(), 0, 0);
+
+    // Check if position is within widget bounds (screen coordinates)
+    if (!bounds().contains(position)) {
+      if (position.y < bounds().y)
+        return Caret(&lines(), 0, 0);
+      if (position.y > bounds().y2())
+        return Caret(&lines(), lines().size() - 1, lines().back().glyphCount);
+      return Caret();
+    }
+
+    gfx::PointF localPos(position - bounds().origin());
+    gfx::PointF offsetPosition(localPos.x / scale().x, localPos.y / scale().y);
+    Caret newCaret(&lines());
+
+    // Check if the position is below all lines
+    if (offsetPosition.y >= maxHeight()) {
+      newCaret.setLine(lines().size() - 1);
+      newCaret.setPos(
+        (offsetPosition.x > newCaret.lineObj().width / 2) ? newCaret.lineObj().glyphCount : 0);
+      return newCaret;
+    }
+
+    int lineStartY = 0;
+    for (const Line& line : lines()) {
+      const int lineEndY = lineStartY + line.height;
+      if (offsetPosition.y < lineStartY || offsetPosition.y >= lineEndY) {
+        lineStartY = lineEndY;
+        continue;
+      }
+      newCaret.setLine(line.i);
+      if (!line.blob)
+        break;
+      if (offsetPosition.x > line.width) {
+        newCaret.setPos(line.glyphCount);
+        break;
+      }
+
+      int advance = 0;
+      int best = 0;
+      float bestDiff = std::numeric_limits<float>::max();
+      float bestGlyphCenterX = 0;
+      line.blob->visitRuns([&](text::TextBlob::RunInfo& run) {
+        for (size_t i = 0; i < run.glyphCount; ++i) {
+          gfx::RectF glyphBounds = run.getGlyphBounds(i);
+          const float centerX = glyphBounds.center().x;
+          const float diff = std::fabs(centerX - offsetPosition.x);
+          if (diff < bestDiff) {
+            best = advance;
+            bestDiff = diff;
+            bestGlyphCenterX = centerX;
+          }
+          ++advance;
+        }
+      });
+
+      // Round the caret position according the glyph center
+      if (offsetPosition.x > bestGlyphCenterX)
+        newCaret.setPos(best + 1);
+      else
+        newCaret.setPos(best);
+      break;
+    }
+
+    return newCaret;
   }
 
   void onPaint(PaintEvent& ev) override
   {
     Graphics* g = ev.graphics();
 
-    // Don't paint the base Entry borders
-    // Entry::onPaint(ev);
+    // Don't paint the base TextEdit
+    // TextEdit::onPaint(ev);
 
     if (!hasText())
       return;
@@ -242,10 +323,7 @@ private:
 
       // Paint caret
       if (isCaretVisible()) {
-        int scroll, caret;
-        getEntryThemeInfo(&scroll, &caret, nullptr, nullptr);
-
-        gfx::RectF caretBounds = getCharBoxBounds(caret);
+        gfx::RectF caretBounds = getCaretBoundsForPaint();
         caretBounds *= gfx::SizeF(scale());
         caretBounds.w = 1;
         g->fillRect(gfx::rgba(0, 0, 0), caretBounds);
@@ -258,6 +336,69 @@ private:
     }
   }
 
+  gfx::RectF getCaretBoundsForPaint() const
+  {
+    if (lines().empty())
+      return gfx::RectF();
+
+    const Line& line = caret().lineObj();
+    float x = 0;
+
+    if (caret().inEol())
+      x = line.width;
+    else if (caret().pos() > 0)
+      x = line.getBounds(caret().pos()).x;
+
+    // Calculate y position by summing heights of previous lines
+    float y = 0;
+    for (const auto& l : lines()) {
+      if (l.i >= caret().line())
+        break;
+      y += l.height;
+    }
+
+    return gfx::RectF(x, y, 1, line.height);
+  }
+
+  void drawSelectionRects(os::Surface* surface, const os::Paint& paint) const
+  {
+    if (selection().isEmpty() || lines().empty())
+      return;
+
+    const Caret& start = selection().start();
+    const Caret& end = selection().end();
+    float yOffset = 0;
+    for (const auto& l : lines()) {
+      if (l.i >= start.line())
+        break;
+      yOffset += l.height;
+    }
+    for (int lineIdx = start.line(); lineIdx <= end.line(); ++lineIdx) {
+      const Line& line = lines()[lineIdx];
+
+      float startX = 0;
+      float endX = line.width;
+
+      if (lineIdx == start.line() && start.pos() > 0)
+        startX = line.getBounds(start.pos()).x;
+
+      if (lineIdx == end.line()) {
+        if (end.inEol())
+          endX = line.width;
+        else if (end.pos() > 0)
+          endX = line.getBounds(end.pos()).x;
+        else
+          endX = 0;
+      }
+
+      const gfx::RectF lineRect(startX, yOffset, endX - startX, line.height);
+      if (!lineRect.isEmpty())
+        surface->drawRect(lineRect, paint);
+
+      yOffset += line.height;
+    }
+  }
+
   void renderExtraCel(const TextPreview textPreview)
   {
     doc::Image* extraImg = m_extraCel->image();
@@ -267,46 +408,22 @@ private:
 
     extraImg->clear(extraImg->maskColor());
 
-    text::TextBlobRef blob = textBlob();
-    doc::ImageRef blobImage;
-    gfx::RectF bounds;
-    if (blob) {
-      const ui::Paint paint = get_paint_for_text();
-      bounds = calc_blob_bounds(blob);
-      blobImage = render_text_blob(blob, bounds, get_paint_for_text());
-      if (!blobImage)
-        return;
-
-      // Invert selected range in the image
-      if (textPreview == TextPreview::Intermediate) {
-        Range range;
-        getEntryThemeInfo(nullptr, nullptr, nullptr, &range);
-        if (!range.isEmpty()) {
-          gfx::RectF selectedBounds = getCharBoxBounds(range.from) | getCharBoxBounds(range.to - 1);
-
-          if (!selectedBounds.isEmpty()) {
-            selectedBounds.offset(-bounds.origin());
-
-#ifdef LAF_SKIA
-            sk_sp<SkSurface> skSurface = wrap_docimage_in_sksurface(blobImage.get());
-            os::SurfaceRef surface = base::make_ref<os::SkiaSurface>(skSurface);
-
-            os::Paint paint2 = paint;
-            paint2.blendMode(os::BlendMode::Xor);
-            paint2.style(os::Paint::Style::Fill);
-            surface->drawRect(selectedBounds, paint2);
-#endif // LAF_SKIA
-          }
-        }
-      }
+    if (lines().empty() || !hasText()) {
+      m_cachedTextImage.reset();
+      return;
     }
+    if (m_textDirty || !m_cachedTextImage)
+      renderTextToCache();
+    if (!m_cachedTextImage)
+      return;
 
     doc::Cel* extraCel = m_extraCel->cel();
     ASSERT(extraCel);
     if (!extraCel)
       return;
 
-    extraCel->setPosition(m_baseBounds.x + bounds.x, m_baseBounds.y + bounds.y);
+    extraCel->setPosition(m_baseBounds.x + m_cachedTextBounds.x,
+                          m_baseBounds.y + m_cachedTextBounds.y);
 
     render::Render().renderLayer(extraImg,
                                  m_editor->layer(),
@@ -314,14 +431,104 @@ private:
                                  gfx::Clip(0, 0, extraCel->bounds()),
                                  doc::BlendMode::SRC);
 
-    if (blobImage) {
+    if (textPreview == TextPreview::Intermediate && !selection().isEmpty()) {
+      doc::ImageRef finalImage(doc::Image::createCopy(m_cachedTextImage.get()));
+#ifdef LAF_SKIA
+      sk_sp<SkSurface> skSurface = wrap_docimage_in_sksurface(finalImage.get());
+      os::SurfaceRef surface = base::make_ref<os::SkiaSurface>(skSurface);
+
+      os::Paint paint2 = get_paint_for_text();
+      paint2.blendMode(os::BlendMode::Xor);
+      paint2.style(os::Paint::Style::Fill);
+      drawSelectionRects(surface.get(), paint2);
+#endif
       doc::blend_image(extraImg,
-                       blobImage.get(),
-                       gfx::Clip(blobImage->bounds().size()),
+                       finalImage.get(),
+                       gfx::Clip(finalImage->bounds().size()),
                        m_doc->sprite()->palette(m_editor->frame()),
                        255,
                        doc::BlendMode::NORMAL);
     }
+    else {
+      doc::blend_image(extraImg,
+                       m_cachedTextImage.get(),
+                       gfx::Clip(m_cachedTextImage->bounds().size()),
+                       m_doc->sprite()->palette(m_editor->frame()),
+                       255,
+                       doc::BlendMode::NORMAL);
+    }
+  }
+
+  // Render text to cached image (called only when text content changes)
+  void renderTextToCache()
+  {
+    m_cachedTextBounds = calcMultiLineBounds();
+    if (m_cachedTextBounds.isEmpty()) {
+      m_cachedTextImage.reset();
+      return;
+    }
+
+    m_cachedTextImage.reset(doc::Image::create(doc::IMAGE_RGB,
+                                               std::ceil(m_cachedTextBounds.w),
+                                               std::ceil(m_cachedTextBounds.h)));
+    m_cachedTextImage->clear(m_cachedTextImage->maskColor());
+
+#ifdef LAF_SKIA
+    sk_sp<SkSurface> skSurface = wrap_docimage_in_sksurface(m_cachedTextImage.get());
+    os::SurfaceRef surface = base::make_ref<os::SkiaSurface>(skSurface);
+
+    const ui::Paint paint = get_paint_for_text();
+
+    float yOffset = 0;
+    for (const auto& line : lines()) {
+      if (line.blob) {
+        gfx::RectF lineBlobBounds = calc_blob_bounds(line.blob);
+        gfx::PointF drawPos(-lineBlobBounds.x, yOffset - lineBlobBounds.y);
+        text::draw_text(surface.get(), line.blob, drawPos, &paint);
+      }
+      yOffset += line.height;
+    }
+#endif // LAF_SKIA
+
+    m_textDirty = false;
+  }
+
+  gfx::RectF calcMultiLineBounds() const
+  {
+    if (lines().empty())
+      return gfx::RectF();
+
+    float maxWidth = 0;
+    float totalHeight = 0;
+    float minX = 0;
+    float minY = 0;
+    bool first = true;
+
+    for (const auto& line : lines()) {
+      if (line.blob) {
+        gfx::RectF lineBounds = calc_blob_bounds(line.blob);
+        if (first) {
+          minX = lineBounds.x;
+          minY = lineBounds.y;
+          first = false;
+        }
+        else {
+          minX = std::min(minX, lineBounds.x);
+        }
+        maxWidth = std::max(maxWidth, lineBounds.w);
+      }
+      else {
+        maxWidth = std::max(maxWidth, 1.0f);
+      }
+      totalHeight += line.height;
+    }
+
+    if (maxWidth < 1)
+      maxWidth = 1;
+    if (totalHeight < 1)
+      totalHeight = 1;
+
+    return gfx::RectF(minX, minY, maxWidth, totalHeight);
   }
 
   Editor* m_editor;
@@ -332,13 +539,18 @@ private:
   // render the text in case some initial letter/glyph needs some
   // extra room at the left side.
   gfx::Rect m_baseBounds;
+
+  // Cached rendered text image to avoid re-rendering on position changes
+  doc::ImageRef m_cachedTextImage;
+  gfx::RectF m_cachedTextBounds;
+  bool m_textDirty = true;
 };
 
 WritingTextState::WritingTextState(Editor* editor, const gfx::Rect& bounds)
   : m_delayedMouseMove(this, editor, 5)
   , m_editor(editor)
   , m_bounds(bounds)
-  , m_entry(new TextEditor(editor, editor->getSite(), bounds))
+  , m_textEdit(new TextEditor(editor, editor->getSite(), bounds))
 {
   m_beforeCmdConn = UIContext::instance()->BeforeCommandExecution.connect(
     &WritingTextState::onBeforeCommandExecution,
@@ -347,12 +559,18 @@ WritingTextState::WritingTextState(Editor* editor, const gfx::Rect& bounds)
   m_fontChangeConn =
     App::instance()->contextBar()->FontChange.connect(&WritingTextState::onFontChange, this);
 
-  m_entry->NewRequiredBounds.connect([this](const gfx::RectF& blobBounds) {
+  m_fgColorConn = Preferences::instance().colorBar.fgColor.AfterChange.connect([this] {
+    m_textEdit->invalidateTextCache();
+    m_textEdit->invalidate();
+    m_editor->invalidate();
+  });
+
+  m_textEdit->NewRequiredBounds.connect([this](const gfx::RectF& blobBounds) {
     if (m_bounds.w < blobBounds.w || m_bounds.h < blobBounds.h) {
       m_bounds.w = std::max(m_bounds.w, blobBounds.w);
       m_bounds.h = std::max(m_bounds.h, blobBounds.h);
-      m_entry->setExtraCelBounds(m_bounds);
-      m_entry->setBounds(calcEntryBounds());
+      m_textEdit->setExtraCelBounds(m_bounds);
+      m_textEdit->setBounds(calcEntryBounds());
     }
   });
 
@@ -380,6 +598,8 @@ bool WritingTextState::onMouseDown(Editor* editor, MouseMessage* msg)
       editor->captureMouse();
       return true;
     }
+    if (m_hit == Hit::Inside)
+      return false;
 
     // On mouse down with the left button, we just drop the text
     // directly when we click outside the edges.
@@ -402,8 +622,9 @@ bool WritingTextState::onMouseUp(Editor* editor, MouseMessage* msg)
   if (m_movingBounds)
     m_movingBounds = false;
 
-  // Drop if the user just clicked (so other text box is created)
-  if (m_delayedMouseMove.canInterpretMouseMovementAsJustOneClick()) {
+  // Drop if the user just clicked outside the text area (so other text box is created)
+  // Don't drop if clicked inside - that's for caret positioning
+  if (m_hit != Hit::Inside && m_delayedMouseMove.canInterpretMouseMovementAsJustOneClick()) {
     drop();
   }
 
@@ -428,8 +649,8 @@ void WritingTextState::onCommitMouseMove(Editor* editor, const gfx::PointF& spri
     return;
 
   m_bounds.setOrigin(delta + m_boundsOrigin);
-  m_entry->setExtraCelBounds(m_bounds);
-  m_entry->setBounds(calcEntryBounds());
+  m_textEdit->setExtraCelBounds(m_bounds);
+  m_textEdit->setBounds(calcEntryBounds());
 }
 
 bool WritingTextState::onSetCursor(Editor* editor, const gfx::Point& mouseScreenPos)
@@ -448,10 +669,6 @@ bool WritingTextState::onKeyDown(Editor*, KeyMessage* msg)
   // Cancel loop pressing Esc key
   if (msg->scancode() == ui::kKeyEsc) {
     cancel();
-  }
-  // Drop text pressing Enter key
-  else if (msg->scancode() == ui::kKeyEnter) {
-    drop();
     return true;
   }
   return false;
@@ -471,15 +688,15 @@ void WritingTextState::onEditorGotFocus(Editor* editor)
   // Focus the entry when we focus the editor, it happens when we
   // change the font settings, so we keep the focus in the entry
   // field.
-  if (m_entry)
-    m_entry->requestFocus();
+  if (m_textEdit)
+    m_textEdit->requestFocus();
 }
 
 void WritingTextState::onEditorResize(Editor* editor)
 {
   const gfx::PointF scale(editor->projection().scaleX(), editor->projection().scaleY());
-  m_entry->setScale(scale);
-  m_entry->setBounds(calcEntryBounds());
+  m_textEdit->setScale(scale);
+  m_textEdit->setBounds(calcEntryBounds());
 }
 
 gfx::Rect WritingTextState::calcEntryBounds()
@@ -504,8 +721,8 @@ void WritingTextState::onEnterState(Editor* editor)
 
   editor->invalidate();
 
-  editor->addChild(m_entry.get());
-  m_entry->requestFocus();
+  editor->addChild(m_textEdit.get());
+  m_textEdit->requestFocus();
 }
 
 EditorState::LeaveAction WritingTextState::onLeaveState(Editor* editor, EditorState* newState)
@@ -515,7 +732,7 @@ EditorState::LeaveAction WritingTextState::onLeaveState(Editor* editor, EditorSt
       // Paints the text in the active layer/sprite creating an
       // undoable transaction.
       Site site = m_editor->getSite();
-      ExtraCelRef extraCel = m_entry->extraCel(TextEditor::Final);
+      ExtraCelRef extraCel = m_textEdit->extraCel(TextEditor::Final);
       Tx tx(site.document(), Strings::tools_text());
       ExpandCelCanvas expand(site, site.layer(), TiledMode::NONE, tx, ExpandCelCanvas::None);
 
@@ -539,7 +756,7 @@ EditorState::LeaveAction WritingTextState::onLeaveState(Editor* editor, EditorSt
 
 void WritingTextState::onBeforePopState(Editor* editor)
 {
-  editor->removeChild(m_entry.get());
+  editor->removeChild(m_textEdit.get());
   m_beforeCmdConn.disconnect();
   m_fontChangeConn.disconnect();
 
@@ -561,17 +778,17 @@ void WritingTextState::onBeforeCommandExecution(CommandExecutionEvent& ev)
 void WritingTextState::onFontChange(const FontInfo& fontInfo, FontEntry::From fromField)
 {
   if (auto font = Fonts::instance()->fontFromInfo(fontInfo)) {
-    m_entry->setFont(font);
-    m_entry->invalidate();
+    m_textEdit->setFont(font);
+    m_textEdit->invalidate();
     m_editor->invalidate();
 
     // This is useful to show changes to the anti-alias option
     // immediately.
-    auto dummy = m_entry->extraCel(TextEditor::Intermediate);
+    auto dummy = m_textEdit->extraCel(TextEditor::Intermediate);
 
     if (fromField == FontEntry::From::Popup) {
-      if (m_entry)
-        m_entry->requestFocus();
+      if (m_textEdit)
+        m_textEdit->requestFocus();
     }
   }
 }
@@ -593,11 +810,11 @@ void WritingTextState::drop()
 WritingTextState::Hit WritingTextState::calcHit(Editor* editor, const gfx::Point& mouseScreenPos)
 {
   auto edges = editor->editorToScreen(m_bounds);
-  if (!edges.contains(mouseScreenPos) && edges.enlarge(32 * guiscale()).contains(mouseScreenPos)) {
+  if (edges.contains(mouseScreenPos))
+    return Hit::Inside;
+  if (edges.enlarge(32 * guiscale()).contains(mouseScreenPos))
     return Hit::Edges;
-  }
-
-  return Hit::Normal;
+  return Hit::Outside;
 }
 
 } // namespace app

--- a/src/app/ui/editor/writing_text_state.h
+++ b/src/app/ui/editor/writing_text_state.h
@@ -13,6 +13,7 @@
 #include "app/ui/font_entry.h"
 
 #include <memory>
+#include <string>
 
 namespace app {
 class CommandExecutionEvent;
@@ -21,7 +22,9 @@ class FontInfo;
 class WritingTextState : public StandbyState,
                          DelayedMouseMoveDelegate {
 public:
-  WritingTextState(Editor* editor, const gfx::Rect& bounds);
+  WritingTextState(Editor* editor,
+                   const gfx::Rect& bounds,
+                   const std::string& initialText = std::string());
   ~WritingTextState();
 
   LeaveAction onLeaveState(Editor* editor, EditorState* newState) override;

--- a/src/app/ui/editor/writing_text_state.h
+++ b/src/app/ui/editor/writing_text_state.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (c) 2022-2025  Igara Studio S.A.
+// Copyright (c) 2022-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -38,7 +38,8 @@ public:
 
 private:
   enum class Hit {
-    Normal,
+    Outside,
+    Inside,
     Edges,
   };
 
@@ -60,14 +61,14 @@ private:
   DelayedMouseMove m_delayedMouseMove;
   Editor* m_editor;
   gfx::RectF m_bounds;
-  std::unique_ptr<TextEditor> m_entry;
+  std::unique_ptr<TextEditor> m_textEdit;
 
   // True if the text was discarded.
   bool m_discarded = false;
 
   // To move text entry bounds when we drag the mouse from the edges
   // of the TextEditor.
-  Hit m_hit = Hit::Normal;
+  Hit m_hit = Hit::Outside;
   bool m_mouseMoveReceived = false;
   bool m_movingBounds = false;
   gfx::PointF m_cursorStart;
@@ -75,6 +76,7 @@ private:
 
   obs::scoped_connection m_beforeCmdConn;
   obs::scoped_connection m_fontChangeConn;
+  obs::scoped_connection m_fgColorConn;
 };
 
 } // namespace app

--- a/src/app/util/clipboard.cpp
+++ b/src/app/util/clipboard.cpp
@@ -302,13 +302,15 @@ bool Clipboard::copyFromDocument(const Site& site, bool merged)
 
 ClipboardFormat Clipboard::format() const
 {
-  // Check if the native clipboard has an image
-  if (use_native_clipboard() && hasNativeBitmap()) {
-    return ClipboardFormat::Image;
+  if (use_native_clipboard()) {
+    // Check if the native clipboard has an image
+    if (hasNativeBitmap())
+      return ClipboardFormat::Image;
+    // Check if the native clipboard has text
+    if (clip::has(clip::text_format()))
+      return ClipboardFormat::Text;
   }
-  else {
-    return m_data->format();
-  }
+  return m_data->format();
 }
 
 void Clipboard::getDocumentRangeInfo(Doc** document, DocRange* range)

--- a/src/app/util/clipboard.h
+++ b/src/app/util/clipboard.h
@@ -47,6 +47,7 @@ enum class ClipboardFormat {
   Tilemap,
   Tileset,
   Slices,
+  Text,
 };
 
 class Clipboard : public ui::ClipboardDelegate {

--- a/src/ui/textedit.cpp
+++ b/src/ui/textedit.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2024-2025  Igara Studio S.A.
+// Copyright (C) 2024-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -60,15 +60,11 @@ void TextEdit::copy()
   if (m_selection.isEmpty())
     return;
 
-  const int startPos = m_selection.start().absolutePos();
-  set_clipboard_text(text().substr(startPos, m_selection.end().absolutePos() - startPos));
+  set_clipboard_text(selectedText());
 }
 
 void TextEdit::paste()
 {
-  if (!m_caret.isValid())
-    m_caret = Caret(&m_lines, 0, 0); // TODO: Can we just ensure this doesn't happen?
-
   std::string clipboard;
   if (!get_clipboard_text(clipboard) || clipboard.empty())
     return;
@@ -76,31 +72,20 @@ void TextEdit::paste()
   deleteSelection();
   base::replace_string(clipboard, "\r\n", "\n");
 
-  std::string newText = text();
-  newText.insert(m_caret.absolutePos(), clipboard);
-
-  if (!m_lines.empty() && clipboard.find('\n') == std::string::npos) {
-    Line& line = m_caret.lineObj();
-    line.insertText(m_caret.pos(), clipboard);
-    line.buildBlob(this);
-    setTextQuiet(newText);
+  if (insertText(clipboard)) {
+    updateViewSize();
     Change();
+    ensureCaretVisible();
   }
-  else {
-    setText(newText);
-  }
-
-  m_caret.advanceBy(clipboard.size());
-  ensureCaretVisible();
 }
 
 void TextEdit::selectAll()
 {
-  if (text().empty() || m_lines.empty())
+  if (m_textContent.empty() || m_lines.empty())
     return;
 
   const Caret startCaret(&m_lines);
-  Caret endCaret(startCaret);
+  Caret endCaret(&m_lines);
   endCaret.set(m_lines.size() - 1, m_lines.back().glyphCount);
 
   m_selection.set(startCaret, endCaret);
@@ -134,9 +119,9 @@ bool TextEdit::onProcessMessage(Message* msg)
     }
     case kFocusEnterMessage: {
       startTimer();
-      m_drawCaret = true; // Immediately draw the caret for fast UI feedback.
+      m_drawCaret = true;
       invalidate();
-      onCaretPosChange();
+      updateCaretPosOnScreen();
       break;
     }
     case kFocusLeaveMessage: {
@@ -148,8 +133,9 @@ bool TextEdit::onProcessMessage(Message* msg)
       stopTimer();
       m_lockedSelectionStart.clear();
       m_drawCaret = false;
-      invalidate();
-      onCaretPosChange();
+
+      invalidateRect(m_caretRect);
+      updateCaretPosOnScreen();
       break;
     }
     case kKeyDownMessage: {
@@ -243,12 +229,9 @@ bool TextEdit::onKeyDown(const KeyMessage* keymsg)
   const KeyScancode scancode = keymsg->scancode();
   if (scancode == kKeyEnter || scancode == kKeyEnterPad) {
     deleteSelection();
-
-    std::string newText = text();
-    newText.insert(m_caret.absolutePos(), "\n");
-    setText(newText);
-
-    m_caret.set(m_caret.line() + 1, 0);
+    insertText("\n");
+    updateViewSize();
+    ensureCaretVisible();
     return true;
   }
 
@@ -313,7 +296,8 @@ void TextEdit::onPaint(PaintEvent& ev)
     backgroundPaint = m_colors.disabledBackground;
   }
 
-  g->drawRect(g->getClipBounds(), backgroundPaint);
+  const gfx::Rect rect = view->viewportBounds().offset(-bounds().origin());
+  g->drawRect(rect, backgroundPaint);
 
   gfx::PointF point(clientChildrenBounds().origin());
   const gfx::Rect clipBounds = g->getClipBounds();
@@ -440,7 +424,7 @@ void TextEdit::onExecuteCmd(const Cmd cmd,
 
 gfx::Rect TextEdit::caretBounds() const
 {
-  Line& line = m_caret.lineObj();
+  const Line& line = m_caret.lineObj();
 
   gfx::Point origin = clientChildrenBounds().origin();
   gfx::Rect rc(origin, theme()->getCaretSize(const_cast<TextEdit*>(this)));
@@ -453,10 +437,10 @@ gfx::Rect TextEdit::caretBounds() const
   }
 
   gfx::PointF point(origin);
-  for (const auto& line : m_lines) {
-    if (line.i >= m_caret.line())
+  for (const auto& l : m_lines) {
+    if (l.i >= m_caret.line())
       break;
-    point.y += line.height;
+    point.y += l.height;
   }
 
   rc.h = std::max(rc.h, line.height);
@@ -472,7 +456,7 @@ gfx::Point TextEdit::caretPosOnScreen() const
   return nativeWindow->pointToScreen(caretBounds().point2() + bounds().origin());
 }
 
-void TextEdit::onCaretPosChange()
+void TextEdit::updateCaretPosOnScreen()
 {
   if (hasFocus())
     os::System::instance()->setTextInput(true, caretPosOnScreen());
@@ -625,7 +609,8 @@ void TextEdit::insertCharacter(base::codepoint_t character)
 
   if (m_lines.empty()) {
     // Fast path for the first char.
-    setText(unicodeStr);
+    m_textContent = unicodeStr;
+    rebuildLines();
     m_caret.setPos(m_caret.pos() + 1);
     return;
   }
@@ -638,16 +623,14 @@ void TextEdit::insertCharacter(base::codepoint_t character)
   Line& line = m_caret.lineObj();
   const int oldglyphs = line.glyphCount;
   line.insertText(m_caret.pos(), unicodeStr);
-  line.buildBlob(this);
+  buildLineBlob(m_caret.line());
   const int delta = line.glyphCount - oldglyphs;
 
-  std::string newText = text();
-  newText.insert(absPos, unicodeStr);
-  setTextQuiet(newText);
-  Change();
-
+  m_textContent.insert(absPos, unicodeStr);
   m_caret.setPos(m_caret.pos() + delta);
-  onCaretPosChange();
+  updateCaretPosOnScreen();
+  updateViewSize();
+  onTextChanged();
 }
 
 void TextEdit::deleteSelection()
@@ -655,9 +638,8 @@ void TextEdit::deleteSelection()
   if (m_selection.isEmpty() || !m_selection.isValid())
     return;
 
-  std::string newText = text();
-  newText.erase(newText.begin() + m_selection.start().absolutePos(),
-                newText.begin() + m_selection.end().absolutePos());
+  m_textContent.erase(m_textContent.begin() + m_selection.start().absolutePos(),
+                      m_textContent.begin() + m_selection.end().absolutePos());
 
   if (m_selection.start().line() == m_selection.end().line()) {
     Line& line = m_selection.start().lineObj();
@@ -669,21 +651,18 @@ void TextEdit::deleteSelection()
 
     line.text.erase(line.text.begin() + line.utfSize[m_selection.start().pos()].begin,
                     line.text.begin() + end);
-    line.buildBlob(this);
-
-    updateViewSize();
-
     // Only rebuilds the one line
-    setTextQuiet(newText);
-    Change();
+    buildLineBlob(m_selection.start().line());
   }
   else {
-    setText(newText);
+    rebuildLines();
   }
 
   m_caret = m_selection.start();
   m_selection.clear();
-  onCaretPosChange();
+  updateCaretPosOnScreen();
+  updateViewSize();
+  onTextChanged();
 }
 
 void TextEdit::ensureCaretVisible()
@@ -719,39 +698,14 @@ void TextEdit::ensureCaretVisible()
     scroll.y = (caret.y - bounds().y - vp.h + caret.h);
 
   view->setViewScroll(scroll);
-  onCaretPosChange();
+  updateCaretPosOnScreen();
 }
 
 void TextEdit::onSetText()
 {
-  std::vector<std::string_view> newLines;
-  newLines.reserve(m_lines.size()); // Assume lines will be around the same size as before, if any
-
-  // Recalculate all the lines based on the widget's text
-  m_lines.clear();
-
-  base::split_string(text(), newLines, "\n");
-  m_lines.reserve(newLines.size());
-
-  for (const auto& lineString : newLines) {
-    Line newLine;
-    newLine.text = lineString;
-    newLine.buildBlob(this);
-    newLine.i = m_lines.size();
-    m_lines.push_back(newLine);
-  }
-
+  setTextContent(text());
   updateViewSize();
-
-  Change();
   Widget::onSetText();
-
-  // Keep the caret in a valid position.
-  if (!m_caret.isValid()) {
-    int line = std::clamp(m_caret.line(), 0, int(m_lines.size()) - 1);
-    m_caret = Caret(&m_lines, line, std::clamp(m_caret.pos(), 0, m_lines[line].glyphCount));
-  }
-  onCaretPosChange();
 }
 
 void TextEdit::onSetFont()
@@ -802,32 +756,85 @@ void TextEdit::updateViewSize()
   }
 }
 
-void TextEdit::Line::buildBlob(const Widget* forWidget)
+void TextEdit::setTextContent(const std::string& text)
 {
-  utfSize.clear();
-
-  if (text.empty()) {
-    blob = nullptr;
-    width = 0;
-    glyphCount = 0;
-    height = forWidget->font()->metrics(nullptr);
-    return;
-  }
-
-  Utf8RangeBuilder rangeBuilder(text.size());
-  blob = text::TextBlob::MakeWithShaper(forWidget->theme()->fontMgr(),
-                                        forWidget->font(),
-                                        text,
-                                        &rangeBuilder);
-
-  utfSize = std::move(rangeBuilder.ranges);
-  glyphCount = utfSize.size();
-
-  width = blob->bounds().w;
-  height = std::max(blob->bounds().h, forWidget->font()->metrics(nullptr));
+  m_textContent = text;
+  rebuildLines();
+  onTextChanged();
 }
 
-// Insert text into this line based on a caret position, taking into account utf8 size.
+std::string TextEdit::selectedText() const
+{
+  if (m_selection.isEmpty() || !m_selection.isValid())
+    return std::string();
+
+  const int startPos = m_selection.start().absolutePos();
+  const int endPos = m_selection.end().absolutePos();
+  return m_textContent.substr(startPos, endPos - startPos);
+}
+
+bool TextEdit::insertText(const std::string& str)
+{
+  if (str.empty())
+    return false;
+
+  if (!m_caret.isValid())
+    m_caret = Caret(&m_lines, 0, 0);
+
+  deleteSelection();
+
+  std::string cleanedStr = str;
+  // Replace \r\n with \n
+  size_t pos = 0;
+  while ((pos = cleanedStr.find("\r\n", pos)) != std::string::npos) {
+    cleanedStr.replace(pos, 2, "\n");
+  }
+
+  const int targetAbsPos = m_caret.absolutePos() + cleanedStr.size();
+
+  m_textContent.insert(m_caret.absolutePos(), cleanedStr);
+
+  if (!m_lines.empty() && cleanedStr.find('\n') == std::string::npos) {
+    // Single line insert - optimize by just rebuilding the current line
+    Line& line = m_caret.lineObj();
+    line.insertText(m_caret.pos(), cleanedStr);
+    buildLineBlob(m_caret.line());
+    onTextChanged();
+    m_caret.advanceBy(cleanedStr.size());
+  }
+  else {
+    // Multi-line insert - rebuild everything
+    rebuildLines();
+
+    // Find the new caret position from the target absolute position
+    int absPos = 0;
+    for (int i = 0; i < m_lines.size(); ++i) {
+      const Line& line = m_lines[i];
+      const int lineTextSize = line.text.size();
+      const int lineEndPos = absPos + lineTextSize;
+
+      if (targetAbsPos <= lineEndPos) {
+        // Caret is on this line - convert byte offset to glyph position
+        const int byteOffset = targetAbsPos - absPos;
+        int glyphPos = 0;
+        for (int j = 0; j < line.glyphCount; ++j) {
+          if (line.utfSize[j].begin >= byteOffset)
+            break;
+          glyphPos = j + 1;
+        }
+        m_caret.set(i, glyphPos);
+        break;
+      }
+
+      absPos = lineEndPos + 1; // +1 for the newline character
+    }
+
+    onTextChanged();
+  }
+
+  return true;
+}
+
 void TextEdit::Line::insertText(int pos, const std::string& str)
 {
   if (pos == 0)
@@ -840,6 +847,9 @@ void TextEdit::Line::insertText(int pos, const std::string& str)
 
 gfx::RectF TextEdit::Line::getBounds(const int glyph) const
 {
+  if (!blob)
+    return gfx::RectF();
+
   int advance = 0;
   gfx::Rect result;
   blob->visitRuns([&advance, &result, glyph](const text::TextBlob::RunInfo& run) {
@@ -854,10 +864,9 @@ gfx::RectF TextEdit::Line::getBounds(const int glyph) const
 
 gfx::RectF TextEdit::Line::getBounds(const int startGlyph, const int endGlyph) const
 {
-  if (startGlyph == endGlyph)
-    return {};
-
   ASSERT(endGlyph > startGlyph);
+  if (startGlyph == endGlyph || !blob)
+    return gfx::RectF();
 
   int advance = 0; // The amount of glyphs we've advanced through.
   gfx::Rect resultBounds;
@@ -1017,7 +1026,7 @@ bool TextEdit::Caret::isWordPart() const
     return false;
 
   const auto& utfPos = lineObj().utfSize[m_pos];
-  const std::string_view word = text().substr(utfPos.begin, utfPos.end - utfPos.begin);
+  const std::string_view word = textView().substr(utfPos.begin, utfPos.end - utfPos.begin);
   return (!word.empty() && std::isspace(word[0]) == 0 && std::ispunct(word[0]) == 0);
 }
 
@@ -1114,6 +1123,70 @@ void TextEdit::Selection::clear()
 {
   m_start.clear();
   m_end.clear();
+}
+
+void TextEdit::rebuildLines()
+{
+  std::vector<std::string_view> newLines;
+  newLines.reserve(m_lines.size());
+  m_lines.clear();
+  base::split_string(m_textContent, newLines, "\n");
+  m_lines.reserve(newLines.size());
+
+  for (const auto& lineString : newLines) {
+    Line newLine;
+    newLine.text = std::string(lineString);
+    newLine.i = m_lines.size();
+    m_lines.push_back(newLine);
+  }
+
+  // At least one line
+  if (m_lines.empty()) {
+    Line emptyLine;
+    emptyLine.i = 0;
+    m_lines.push_back(emptyLine);
+  }
+
+  for (int i = 0; i < m_lines.size(); ++i)
+    buildLineBlob(i);
+
+  // Keep the caret in a valid position
+  if (!m_caret.isValid()) {
+    const int line = std::clamp(m_caret.line(), 0, int(m_lines.size()) - 1);
+    m_caret = Caret(&m_lines, line, std::clamp(m_caret.pos(), 0, m_lines[line].glyphCount));
+  }
+
+  updateCaretPosOnScreen();
+}
+
+void TextEdit::buildLineBlob(int lineIndex)
+{
+  Line& line = m_lines[lineIndex];
+  line.utfSize.clear();
+
+  if (line.text.empty()) {
+    line.blob = nullptr;
+    line.width = 0;
+    line.glyphCount = 0;
+    line.height = font()->metrics(nullptr);
+    return;
+  }
+
+  Utf8RangeBuilder rangeBuilder(line.text.size());
+  line.blob = text::TextBlob::MakeWithShaper(theme()->fontMgr(), font(), line.text, &rangeBuilder);
+
+  line.utfSize = std::move(rangeBuilder.ranges);
+  line.glyphCount = line.utfSize.size();
+
+  line.width = line.blob->bounds().w;
+  line.height = std::max(int(line.blob->bounds().h), int(font()->metrics(nullptr)));
+}
+
+void TextEdit::onTextChanged()
+{
+  // Sync Widget's m_text with our m_textContent
+  setTextQuiet(m_textContent);
+  Change();
 }
 
 } // namespace ui

--- a/src/ui/textedit.h
+++ b/src/ui/textedit.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2024-2025  Igara Studio S.A.
+// Copyright (C) 2024-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -9,12 +9,17 @@
 #define UI_TEXT_EDIT_H_INCLUDED
 #pragma once
 
+#include "base/codepoint.h"
+#include "gfx/rect.h"
 #include "text/text_blob.h"
 #include "ui/textcmd.h"
 #include "ui/theme.h"
 #include "ui/widget.h"
 
 #include <algorithm>
+#include <string>
+#include <string_view>
+#include <vector>
 
 namespace ui {
 using namespace text;
@@ -32,6 +37,11 @@ public:
   bool isReadOnly() const;
   void setPlaceholder(const std::string& placeholder);
 
+  bool isCaretVisible() const { return m_drawCaret; }
+
+  gfx::PointF scale() const { return m_scale; }
+  void setScale(const gfx::PointF& scale) { m_scale = scale; }
+
   obs::signal<void()> Change;
 
 protected:
@@ -45,7 +55,16 @@ protected:
   bool onKeyDown(const KeyMessage* keymsg);
   bool onMouseMove(const MouseMessage* mouseMessage);
 
-private:
+  virtual void onTextChanged();
+
+  std::string& textContent() { return m_textContent; }
+  const std::string& textContent() const { return m_textContent; }
+  void setTextContent(const std::string& text);
+  std::string selectedText() const;
+  bool insertText(const std::string& str);
+  void rebuildLines();
+  void buildLineBlob(int lineIndex);
+
   struct Line {
     std::string text;
     std::vector<TextBlob::Utf8Range> utfSize;
@@ -57,8 +76,6 @@ private:
 
     // Line index for more convenient loops
     int i = 0;
-
-    void buildBlob(const Widget* forWidget);
 
     // Insert text into this line based on a caret position, taking into account utf8 size.
     void insertText(int pos, const std::string& str);
@@ -131,7 +148,7 @@ private:
   private:
     int m_line = 0;
     int m_pos = 0;
-    std::string_view text() const { return (*m_lines)[m_line].text; }
+    std::string_view textView() const { return (*m_lines)[m_line].text; }
     std::vector<Line>* m_lines;
   };
 
@@ -168,6 +185,13 @@ private:
     Caret m_end;
   };
 
+  std::vector<Line>& lines() { return m_lines; }
+  const std::vector<Line>& lines() const { return m_lines; }
+  const Caret& caret() const { return m_caret; }
+  const Selection& selection() const { return m_selection; }
+  int maxHeight() const;
+
+private:
   // TextCmdProcessor impl
   bool onHasValidSelection() override { return !m_selection.isEmpty(); }
   bool onCanModify() override { return isEnabled() && !m_readOnly; }
@@ -175,21 +199,22 @@ private:
 
   gfx::Rect caretBounds() const;
   gfx::Point caretPosOnScreen() const;
-  void onCaretPosChange();
+  void updateCaretPosOnScreen();
 
-  // Get the selection rect for the given line, if any
   gfx::RectF getSelectionRect(const Line& line, const gfx::PointF& offset) const;
-  Caret caretFromPosition(const gfx::Point& position);
+  const Selection& selectionWords() const { return m_selectionWords; }
+  const Caret& lockedSelectionStart() const { return m_lockedSelectionStart; }
+  virtual Caret caretFromPosition(const gfx::Point& position);
   void insertCharacter(base::codepoint_t character);
   void deleteSelection();
   void ensureCaretVisible();
-  int maxHeight() const;
 
   void startTimer();
   void stopTimer();
 
   void updateViewSize();
 
+  std::string m_textContent;
   Selection m_selection;
   Selection m_selectionWords;
   Caret m_caret;
@@ -210,6 +235,7 @@ private:
   // The total size of the complete text, calculated as the longest single line width and the sum of
   // the total line heights
   gfx::Size m_textSize;
+  gfx::PointF m_scale = gfx::PointF(1.0f, 1.0f);
 
   // Color cache
   Theme::TextColors m_colors;


### PR DESCRIPTION
The following features were added:
1. Ability to create line breaks with the Text tool.
2. Zooming within the text box (the lack of this feature was particularly annoying when the text box occupied almost the entire canvas).
3. Bonus: Ability to paste text from the clipboard to the canvas.

fix #5606