### PR TITLE
Fixes issue #5635 fixed a crash when doing 'Export As' for animation and the target file is read-only

### DIFF
--- a/src/app/commands/cmd_save_file.cpp
+++ b/src/app/commands/cmd_save_file.cpp
@@ -219,7 +219,7 @@ void SaveFileBaseCommand::saveDocumentInBackground(const Context* context,
   if (!fop)
     return;
 
-  if (resizeOnTheFly == ResizeOnTheFly::On)
+  if (!fop->hasError() && resizeOnTheFly == ResizeOnTheFly::On)
     fop->setOnTheFlyScale(scale);
 
   SaveFileJob job(fop.get(), params().ui());


### PR DESCRIPTION
I am fairly new to the codebase and this is my first pull request so I am not certain if the fix is this simple or there is more to it. But it seems to have fixed the crash for me and I am getting the appropriate message saying the file is read-only.
Fixes [aseprite/aseprite#5635](https://github.com/aseprite/aseprite/issues/5635)

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing
