### PR TITLE
[win] Use vswhere to support VS2026 and future versions

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -3,7 +3,27 @@
 rem If cl.exe is not available, we try to run the vcvars64.bat
 where cl.exe >nul 2>nul
 if %errorlevel%==1 (
-   @call "%ProgramFiles%\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
+   set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+   if exist "%VSWHERE%" (
+      for /f "usebackq tokens=*" %%i in (`"%VSWHERE%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
+         set "VS_INSTALL_DIR=%%i"
+      )
+   )
+   
+   if defined VS_INSTALL_DIR (
+      if exist "%VS_INSTALL_DIR%\VC\Auxiliary\Build\vcvars64.bat" (
+         @call "%VS_INSTALL_DIR%\VC\Auxiliary\Build\vcvars64.bat"
+      )
+   ) else (
+      rem Fallback options if vswhere fails or is not present
+      if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat" (
+         @call "%ProgramFiles%\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
+      ) else (
+         if exist "%ProgramFiles%\Microsoft Visual Studio\18\Community\VC\Auxiliary\Build\vcvars64.bat" (
+            @call "%ProgramFiles%\Microsoft Visual Studio\18\Community\VC\Auxiliary\Build\vcvars64.bat"
+         )
+      )
+   )
 )
 
 rem Add an extra path element which will be invalidated by Git Bash.


### PR DESCRIPTION
Visual Studio 2026 (v18) installs to a new location not covered by the hardcoded paths. This change implements dynamic detection using 'vswhere.exe' to correctly locate the C++ build tools on VS2026 and other versions.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the Individual Contributor License Agreement V4.0. -->
<!-- If you're a first-time contributor, please sign the CLA
     as indicated in https://github.com/igarastudio/cla#signing
     and acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing
