### PR TITLE
Fix eyedropper behavior without a reference layer (fix #5685)

### DIFF
--- a/src/app/color_picker.cpp
+++ b/src/app/color_picker.cpp
@@ -82,7 +82,7 @@ ColorPicker::ColorPicker() : m_tile(doc::notile), m_alpha(0), m_layer(nullptr)
 void ColorPicker::pickColor(const Site& site,
                             const gfx::PointF& _pos,
                             const render::Projection& proj,
-                            const Mode mode)
+                            Mode mode)
 {
   const doc::Sprite* sprite = site.sprite();
   gfx::PointF pos = _pos;
@@ -99,6 +99,9 @@ void ColorPicker::pickColor(const Site& site,
 
     pos = wrap_pointF(docPref.tiled.mode(), site.sprite()->size(), pos);
   }
+
+  if (mode == FromFirstReferenceLayer && sprite && !sprite->hasVisibleReferenceLayers())
+    mode = FromComposition;
 
   // Get the color from the image
   switch (mode) {


### PR DESCRIPTION
Fixes #5685 with the simplest possible method. I experimented with adding a warning to the context bar or changing the status of the combobox in some way (disabling the item widget when it's not available) but it all resulted in a bunch of code that had to run for a lot of state changes since everything is global and I ended up dropping it. I think it would still be good to at least a tooltip explaining exactly what "sample" does and the three options though.
