### PR TITLE
Allow installing extensions by dropping them into the preferences dialog

### DIFF
--- a/src/app/commands/cmd_options.cpp
+++ b/src/app/commands/cmd_options.cpp
@@ -1103,6 +1103,21 @@ private:
     miniFontPreview()->setFont(m_miniFont);
   }
 
+  bool onProcessMessage(Message* msg) override
+  {
+    switch (msg->type()) {
+      case kDropFilesMessage:
+        base::paths files = static_cast<DropFilesMessage*>(msg)->files();
+        for (const auto& fn : files) {
+          const auto& extension = base::string_to_lower(base::get_file_extension(fn));
+          if (extension == "aseprite-extension" || extension == "zip")
+            showDialogToInstallExtension(fn);
+        }
+        return true;
+    }
+    return Window::onProcessMessage(msg);
+  }
+
   void fillThemeVariants()
   {
     ButtonSet* list = nullptr;

--- a/src/ui/manager.cpp
+++ b/src/ui/manager.cpp
@@ -483,6 +483,7 @@ void Manager::generateMessagesFromOSEvents()
         Message* msg = new DropFilesMessage(osEvent.files());
         msg->setDisplay(display);
         msg->setRecipient(this);
+        msg->setPropagateToChildren(true);
         enqueueMessage(msg);
         break;
       }


### PR DESCRIPTION
Right now if you double click an extension from the OS, install it, and then attempt to install another one, it does nothing because "dropping" files only works when the foreground window is the main window.

This change allows the event to propagate so we can have modal dialogs that accept file drops, in this case the Preferences dialog accepts `.aseprite-extension` and `.zip` (since if you're dropping something onto here, it'll most likely be an extension).
