### PR TITLE
Fix color picker selecting below alpha bar

### DIFF
--- a/src/app/ui/color_selector.cpp
+++ b/src/app/ui/color_selector.cpp
@@ -273,9 +273,6 @@ app::Color ColorSelector::getColorByPosition(const gfx::Point& pos)
   if (rc.isEmpty())
     return app::Color::fromMask();
 
-  if (!hasCapture() && pos.y >= rc.y2())
-    return app::Color::fromMask();
-
   const int u = pos.x - rc.x;
   const int umax = std::max(1, rc.w - 1);
 
@@ -286,6 +283,12 @@ app::Color ColorSelector::getColorByPosition(const gfx::Point& pos)
   const gfx::Rect alphaBarBounds = this->alphaBarBounds();
   if ((hasCapture() && m_capturedInAlpha) || (!hasCapture() && alphaBarBounds.contains(pos)))
     return getAlphaBarColor(u, umax);
+
+  // border color extends bottom/alpha bar if visible
+  if (!hasCapture() && pos.y >= rc.y2()) {
+    if (!bottomBarBounds.isEmpty())
+      return alphaBarBounds.isEmpty() ? getBottomBarColor(u, umax) : getAlphaBarColor(u, umax);
+  }
 
   const int v = pos.y - rc.y;
   const int vmax = std::max(1, rc.h - bottomBarBounds.h - alphaBarBounds.h - 1);


### PR DESCRIPTION
Fixes #2006 

I added a check in the color selector, making sure the user can't select from below the alpha bar. The outside border of the ui elements are included in the widget, but the alpha bar and bottom bar bounds are contained strictly inside of the color selector's border. One check makes sure the user isn't selecting the boundary underneath of the alpha bar bounds, and the other prevents the eyedropper tool from previewing colors beneath the alpha bar.

This fixes the issue in the parent `ColorSelector` class rather than in each subclass individually, which also covers the RGB and RYB wheels not addressed in #2522 


I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md
I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing
