### PR TITLE
Fix Shift no longer adding to selection when bound as shortcut (fix #5686)

### DIFF
--- a/src/app/ui/key.cpp
+++ b/src/app/ui/key.cpp
@@ -529,6 +529,13 @@ const AppShortcut* Key::isPressed(const Message* msg, const KeyContext keyContex
       const auto pressedMouseButton = (pressed ? mouseMsg->button() : kButtonNone);
 
       for (const AppShortcut& shortcut : shortcuts()) {
+        // Command shortcuts that are keyboard-only (e.g. Shift) must
+        // not match mouse events; otherwise they can consume
+        // interactions that rely on modifier actions in specific
+        // contexts (e.g. Shift+drag in selection tools).
+        if (m_type == KeyType::Command && shortcut.mouseButton() == kButtonNone)
+          continue;
+
         if ((shortcut.modifiers() == mouseMsg->modifiers()) &&
             ((shortcut.scancode() == kKeyNil && shortcut.unicodeChar() == 0) ||
              (shortcut.modifiers() == kKeySpaceModifier && shortcut.scancode() == kKeySpace &&

--- a/src/app/ui/keyboard_shortcuts_tests.cpp
+++ b/src/app/ui/keyboard_shortcuts_tests.cpp
@@ -168,6 +168,38 @@ TEST(KeyboardShortcuts, FramesSelection)
   EXPECT_COMMAND_FOR_KEY(SetLoopSection, kKeyF2, KeyContext::FramesSelection);
 }
 
+TEST(KeyboardShortcuts, KeyboardOnlyCommandDoesNotWinOnMouseDown)
+{
+  ks->clear();
+
+  // Define a keyboard-only shortcut (Shift with no key/button):
+  // This should NOT trigger on mouse events.
+  KeyPtr keyboardOnlyCommand = ks->command(CommandId::Zoom(), {}, KeyContext::Any);
+  keyboardOnlyCommand->add(ui::Shortcut(kKeyShiftModifier, kKeyNil, 0),
+                           KeySource::UserDefined,
+                           *ks);
+
+  // Define a mouse shortcut (Shift + Left Mouse Button):
+  // This should trigger on mouse events with Shift pressed.
+  KeyPtr mouseCommand = ks->command(CommandId::Undo(), {}, KeyContext::Any);
+  mouseCommand->add(ui::Shortcut(kKeyShiftModifier, kButtonLeft), KeySource::UserDefined, *ks);
+
+  // Simulate a mouse down event with Shift pressed.
+  MouseMessage mouseMsg(kMouseDownMessage,
+                        PointerType::Unknown,
+                        kButtonLeft,
+                        kKeyShiftModifier,
+                        gfx::Point(0, 0));
+
+  // The keyboard-only shortcut must NOT be selected for this mouse event.
+  // Only the mouse shortcut should match.
+  KeyPtr bestCommand =
+    ks->findBestKeyFromMessage(&mouseMsg, KeyContext::Any, std::make_optional(KeyType::Command));
+  ASSERT_TRUE(bestCommand != nullptr);
+  EXPECT_EQ(KeyType::Command, bestCommand->type());
+  EXPECT_EQ(CommandId::Undo(), bestCommand->command()->id());
+}
+
 int app_main(int argc, char* argv[])
 {
   os::SystemRef system = os::System::make();


### PR DESCRIPTION
Previously, if the Shift key was assigned to a command shortcut, pressing Shift while making a selection (e.g. Shift+drag) would not add to the selection as expected. This happened because Shift-only shortcuts could consume mouse-down events, preventing additive selection.

After some testing, I came to the conclusion that the issue itself wasn't only related to Shift shortcuts, but also affected any keyboard-only shortcut (such as shortcuts bound to modifier keys like Ctrl, Alt, or combinations of them) when they were assigned to commands. In these cases, pressing the modifier key could swallow mouse-down events, breaking expected behaviors such as additive selection or other mouse interactions that rely on modifiers.

This patch adds a guard to ignore keyboard-only shortcuts (with no mouse button) on mouse-down events. This ensures Shift+mouse actions continue to work for additive selection, even if Shift is bound to a command, for example. Mouse-button shortcuts are unaffected.

The commit also includes a regression test to verify correct handling of this issue. The test was implemented in C++ because the bug involves low-level GUI event processing and shortcut handling logic that is only accessible and verifiable within the C++ application layer.


I declare that my contributions are not co-authored using a generative AI technology.

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing