### PR TITLE
Fix regression crash when removing cel in tool loop (fix #5717)

### DIFF
--- a/src/app/util/expand_cel_canvas.cpp
+++ b/src/app/util/expand_cel_canvas.cpp
@@ -157,7 +157,7 @@ ExpandCelCanvas::ExpandCelCanvas(Site site,
             m_grid.origin(),
             m_grid.tileSize());
 
-  if (isTilesetPreview()) {
+  if (!m_celCreated && isTilesetPreview()) {
     getDestTileset();
   }
   else if (m_celCreated || (m_layer && m_layer->isTilemap())) {


### PR DESCRIPTION
Regression from 05f2a1e75b1d42ae5b6af5e1f83150145e4dd2f2, because of the reworked logic we were calling `getDestTileset()` even when we created a new cel, so the new cel was never attached to a layer and we crashed when [we removed it later](https://github.com/aseprite/aseprite/blob/61ccd144bc6d2d5bf11d87815b8f509bc7177d8a/src/app/util/expand_cel_canvas.cpp#L222).

This logic could probably be simplified a bunch with #5684. Related: #5678