### PR TITLE
Fix TextEdit selection clearing on right click menu

### DIFF
--- a/src/app/widget_loader.cpp
+++ b/src/app/widget_loader.cpp
@@ -240,9 +240,12 @@ Widget* WidgetLoader::convertXmlElementToWidget(const XMLElement* elem,
   }
   else if (elem_name == "textedit") {
     widget = new TextEdit();
+    const bool readonly = bool_attr(elem, "readonly", false);
 
     if (elem->Attribute("placeholder"))
       ((TextEdit*)widget)->setPlaceholder(m_xmlTranslator(elem, "placeholder"));
+    if (readonly)
+      ((TextEdit*)widget)->setReadOnly(true);
   }
   else if (elem_name == "grid") {
     const char* columns = elem->Attribute("columns");

--- a/src/ui/textedit.cpp
+++ b/src/ui/textedit.cpp
@@ -18,6 +18,7 @@
 #include "text/font_mgr.h"
 #include "text/text_blob.h"
 #include "ui/display.h"
+#include "ui/manager.h"
 #include "ui/menu.h"
 #include "ui/message.h"
 #include "ui/paint_event.h"
@@ -138,9 +139,13 @@ bool TextEdit::onProcessMessage(Message* msg)
       break;
     }
     case kFocusLeaveMessage: {
+      // Avoids clearing the selection when using the right click menu
+      Manager* manager = Manager::getDefault();
+      if (manager && manager->getFocus() && manager->getFocus()->type() != kMenuBoxWidget)
+        m_selection.clear();
+
       stopTimer();
       m_lockedSelectionStart.clear();
-      m_selection.clear();
       m_drawCaret = false;
       invalidate();
       onCaretPosChange();


### PR DESCRIPTION
Fixes a regression introduced in 02abd73234c94dbeaadf0bdbf4f1b24d8bbffb86 that broke cut/copy/paste from the menu, it also introduces he "readonly" XML property for parity with Entry.