### PR TITLE
Fix #5545: Update status bar on zoom change

### DIFF
--- a/src/app/ui/doc_view.cpp
+++ b/src/app/ui/doc_view.cpp
@@ -112,6 +112,12 @@ public:
       StatusBar::instance()->updateFromEditor(this);
   }
 
+  void onZoomChanged(Editor* editor) override
+  {
+    if (isActive())
+      StatusBar::instance()->updateFromEditor(this);
+  }
+
   void onAfterFrameChanged(Editor* editor) override
   {
     m_previewDelegate->onPreviewOtherEditor(this);


### PR DESCRIPTION
Cause:
Previously, the StatusBar did not receive a signal when the editor's zoom level was modified, via mouse wheel. This resulted in the zoom percentage displayed in the status bar becoming desynchronized from the actual zoom state.

Fix:
Implemented an override for the "onZoomChanged" function in doc_view.cpp. This ensures that whenever a zoom event is triggered, we check if the editor isActive() and force a StatusBar update via updateFromEditor(this).

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the Individual Contributor License Agreement V4.0. -->
<!-- If you're a first-time contributor, please sign the CLA
     as indicated in https://github.com/igarastudio/cla#signing
     and acknowledge it by leaving the statement below. -->

I declare that my contributions are not co-authored using a generative AI technology.

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing
