### PR TITLE
fix #5391: Pixel grid options are not grayed out when disabled

### DIFF
--- a/data/widgets/options.xml
+++ b/data/widgets/options.xml
@@ -402,23 +402,23 @@
           </hbox>
 
           <grid columns="5">
-            <label text="@.grid_x" for="grid_x" />
+            <label text="@.grid_x" id="grid_x_label" for="grid_x" />
             <expr id="grid_x" text="" />
-            <label text="@.grid_y" for="grid_y" />
+            <label text="@.grid_y" id="grid_y_label" for="grid_y" />
             <expr id="grid_y" text="" />
             <hbox />
 
-            <label text="@.grid_width" for="grid_w" />
+            <label text="@.grid_width" id="grid_w_label" for="grid_w" />
             <expr id="grid_w" text="" />
-            <label text="@.grid_height" for="grid_h" />
+            <label text="@.grid_height" id="grid_h_label" for="grid_h" />
             <expr id="grid_h" text="" />
             <hbox />
 
-            <label text="@.grid_color" for="grid_color" />
+            <label text="@.grid_color" id="grid_color_label" for="grid_color" />
             <colorpicker id="grid_color" rgba="true" cell_hspan="3" />
             <hbox />
 
-            <label text="@.grid_opacity" for="grid_opacity_row" />
+            <label text="@.grid_opacity" id="grid_opacity_label" for="grid_opacity_row" />
             <hbox id="grid_opacity_row" cell_hspan="3">
               <slider id="grid_opacity" min="1" max="255" width="128" />
               <check id="grid_auto_opacity" text="@.grid_auto" />
@@ -430,10 +430,10 @@
             <separator horizontal="true" expansive="true" />
           </hbox>
           <grid columns="2">
-            <label text="@.grid_color" for="pixel_grid_color" />
+            <label text="@.grid_color" id="pixel_grid_color_label" for="pixel_grid_color" />
             <colorpicker id="pixel_grid_color" rgba="true" />
 
-            <label text="@.grid_opacity" for="pixel_grid_opacity_row" />
+            <label text="@.grid_opacity" id="pixel_grid_opacity_label" for="pixel_grid_opacity_row" />
             <hbox id="pixel_grid_opacity_row">
               <slider id="pixel_grid_opacity" min="1" max="255" width="128" />
               <check id="pixel_grid_auto_opacity" text="@.grid_auto" />

--- a/src/app/commands/cmd_options.cpp
+++ b/src/app/commands/cmd_options.cpp
@@ -384,7 +384,7 @@ public:
 
     // Pixel Grid
     pixelGridVisible()->Click.connect([this] { onPixelGridVisible(); });
-    
+
     // Timeline
     resetTimelineSel()->Click.connect([this] { onResetTimelineSel(); });
 

--- a/src/app/commands/cmd_options.cpp
+++ b/src/app/commands/cmd_options.cpp
@@ -370,6 +370,7 @@ public:
       [this] { showAsepriteFileDialog()->setSelected(!nativeFileDialog()->isSelected()); });
 
     // Grid
+    gridVisible()->Click.connect([this] { onGridVisible(); });
     gridW()->Leave.connect([this] {
       // Prevent entering a width lesser than 1
       if (gridW()->textInt() <= 0)
@@ -381,6 +382,9 @@ public:
         gridH()->setText("1");
     });
 
+    // Pixel Grid
+    pixelGridVisible()->Click.connect([this] { onPixelGridVisible(); });
+    
     // Timeline
     resetTimelineSel()->Click.connect([this] { onResetTimelineSel(); });
 
@@ -1678,6 +1682,9 @@ private:
     pixelGridColor()->setColor(m_curPref->pixelGrid.color());
     pixelGridOpacity()->setValue(m_curPref->pixelGrid.opacity());
     pixelGridAutoOpacity()->setSelected(m_curPref->pixelGrid.autoOpacity());
+
+    onGridVisible();
+    onPixelGridVisible();
   }
 
   void onResetBg()
@@ -1700,6 +1707,33 @@ private:
       checkeredBgColor1()->setColor(pref.bg.color1());
       checkeredBgColor2()->setColor(pref.bg.color2());
     }
+  }
+
+  void onGridVisible(){
+    const bool state = gridVisible()->isSelected();
+    gridXLabel()->setEnabled(state);
+    gridX()->setEnabled(state);
+    gridYLabel()->setEnabled(state);
+    gridY()->setEnabled(state);
+    gridWLabel()->setEnabled(state);
+    gridW()->setEnabled(state);
+    gridHLabel()->setEnabled(state);
+    gridH()->setEnabled(state);
+    gridColorLabel()->setEnabled(state);
+    gridColor()->setEnabled(state);
+    gridOpacityLabel()->setEnabled(state);
+    gridOpacity()->setEnabled(state);
+    gridAutoOpacity()->setEnabled(state);
+  }
+
+  void onPixelGridVisible()
+  {
+    const bool state = pixelGridVisible()->isSelected();
+    pixelGridColorLabel()->setEnabled(state);
+    pixelGridColor()->setEnabled(state);
+    pixelGridOpacityLabel()->setEnabled(state);
+    pixelGridOpacity()->setEnabled(state);
+    pixelGridAutoOpacity()->setEnabled(state);
   }
 
   void onResetGrid()
@@ -1742,6 +1776,9 @@ private:
       pixelGridOpacity()->setValue(pref.pixelGrid.opacity());
       pixelGridAutoOpacity()->setSelected(pref.pixelGrid.autoOpacity());
     }
+
+    onGridVisible();
+    onPixelGridVisible();
   }
 
   void onLocateCrashFolder()


### PR DESCRIPTION
Cause:
Previously, you were able to modify "Visible Pixel Grid" options in the Preferences menu even when the setting is turned off. 

Fix
Implemented onPixelGridVisible() function that ensures that the "Visible Pixel Grid" options in the Preferences menu are grayed out and disabled when the "Visible Pixel Grid" setting is turned off.

I declare that my contributions are not co-authored using a generative AI technology.

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing