### PR TITLE
Add sprite user data to exported JSON (fixes #4094)

### DIFF
--- a/src/app/doc_exporter.cpp
+++ b/src/app/doc_exporter.cpp
@@ -1505,6 +1505,23 @@ void DocExporter::createDataFile(const Samples& samples, std::ostream& os, doc::
      << "\"h\": " << texture->height() << " },\n"
      << "  \"scale\": \"1\"";
 
+  // meta.data
+  {
+    Sprite* sprite = nullptr;
+    for (const auto& item : m_documents) {
+      if (item.isOneImageOnly())
+        continue;
+      if (!sprite)
+        sprite = item.doc->sprite();
+      else if (item.doc->sprite() != sprite) {
+        sprite = nullptr;
+        break;
+      }
+    }
+    if (sprite && !sprite->userData().isEmpty())
+      os << sprite->userData();
+  }
+
   // meta.frameTags
   if (m_listTags) {
     os << ",\n"

--- a/tests/scripts/userdata_json.lua
+++ b/tests/scripts/userdata_json.lua
@@ -61,7 +61,7 @@ do
   -- Sprite properties
   if meta.properties then
     assert(meta.properties.user_defined_data == true)
-    assert(meta.properties["my_plugin"].foo == "sample data")
+    assert(meta.properties["my_plugin"].extension_defined_data == "sample data")
   end
 
   -- Layer properties


### PR DESCRIPTION
This change adds the UserData for the entire sprite to the "meta" property when exporting the JSON for a sprite

---

I declare that my contributions are not co-authored using a generative AI technology.

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing