### PR TITLE
Fix CLI --oneframe command

### DIFF
--- a/src/app/cli/cli_processor.cpp
+++ b/src/app/cli/cli_processor.cpp
@@ -584,6 +584,8 @@ int CliProcessor::process(Context* ctx)
         // --oneframe
         else if (opt == &m_options.oneFrame()) {
           cof.oneFrame = true;
+          cof.fromFrame = 0;
+          cof.toFrame = 0;
         }
         // --export-tileset
         else if (opt == &m_options.exportTileset()) {

--- a/src/app/cli/cli_processor.cpp
+++ b/src/app/cli/cli_processor.cpp
@@ -299,6 +299,7 @@ int CliProcessor::process(Context* ctx)
 
           cof.fromFrame = base::convert_to<frame_t>(splitRange[0]);
           cof.toFrame = base::convert_to<frame_t>(splitRange[1]);
+          cof.oneFrame = false;
         }
         // --ignore-empty
         else if (opt == &m_options.ignoreEmpty()) {
@@ -584,6 +585,8 @@ int CliProcessor::process(Context* ctx)
         // --oneframe
         else if (opt == &m_options.oneFrame()) {
           cof.oneFrame = true;
+          cof.fromFrame = 0;
+          cof.toFrame = 0;
         }
         // --export-tileset
         else if (opt == &m_options.exportTileset()) {


### PR DESCRIPTION
Fix #5709 

Get a input.aseprite with multiple frames.
Run aseprite -b --oneframe input.aseprite --save-as thumbnail.png. (as suggested by the wiki)
Check output files.

Results in a single output file thumbnail.png.

Old Behaviour:
<img width="1152" height="376" alt="image" src="https://github.com/user-attachments/assets/6b0dbef5-4d17-418d-bde8-430d712c566b" />

Fixed Behaviour:
<img width="1315" height="327" alt="image" src="https://github.com/user-attachments/assets/9816d8e0-9b60-476e-ae84-d62e744dab0f" />



