### PR TITLE
Fix crash drawing on empty tile layer in manual mode (fix #5620)

### DIFF
--- a/src/app/ui/editor/drawing_state.cpp
+++ b/src/app/ui/editor/drawing_state.cpp
@@ -14,6 +14,7 @@
 #include "app/commands/command.h"
 #include "app/commands/commands.h"
 #include "app/commands/params.h"
+#include "app/modules/gui.h"
 #include "app/tools/controller.h"
 #include "app/tools/ink.h"
 #include "app/tools/tool.h"
@@ -428,8 +429,12 @@ void DrawingState::destroyLoopIfCanceled(Editor* editor)
 
 void DrawingState::destroyLoop(Editor* editor)
 {
-  if (editor)
+  if (editor) {
     editor->renderEngine().removePreviewImage();
+
+    // Updates the screen to make sure no preview tile is left.
+    update_screen_for_document(editor->document());
+  }
 
   if (m_toolLoopManager)
     m_toolLoopManager->end();

--- a/src/app/util/expand_cel_canvas.cpp
+++ b/src/app/util/expand_cel_canvas.cpp
@@ -157,7 +157,7 @@ ExpandCelCanvas::ExpandCelCanvas(Site site,
             m_grid.origin(),
             m_grid.tileSize());
 
-  if (isTilesetPreview()) {
+  if (!m_celCreated && isTilesetPreview()) {
     getDestTileset();
   }
   else if (m_celCreated || (m_layer && m_layer->isTilemap())) {
@@ -220,6 +220,15 @@ void ExpandCelCanvas::commit()
     if (previewSpecificLayerChanges()) {
       // We can temporary remove the cel.
       static_cast<LayerImage*>(m_layer)->removeCel(m_cel);
+
+      // Manual mode doesn't create new cels.
+      if (m_layer->isTilemap() && m_tilemapMode == TilemapMode::Pixels &&
+          m_tilesetMode == TilesetMode::Manual) {
+        delete m_cel;
+        m_cel = nullptr;
+        m_committed = true; // Makes sure rollback() isn't called
+        return;
+      }
 
       gfx::Rect trimBounds = getTrimDstImageBounds();
       if (!trimBounds.isEmpty()) {

--- a/tests/scripts/tilemap.lua
+++ b/tests/scripts/tilemap.lua
@@ -1399,3 +1399,43 @@ do
                      0,   0,     1|d,   (1|x|d),
                      0,   0,     1|y|d, (1|x|y|d) })
 end
+
+-----------------------------------------------------------------------
+-- Test that manual mode cannot create tiles or cels on an empty tilemap
+-----------------------------------------------------------------------
+
+do
+  local spr = Sprite(8, 8, ColorMode.INDEXED)
+  spr.gridBounds = Rectangle(0, 0, 2, 2)
+  app.command.NewLayer{ tilemap=true }
+  local tilemapLay = spr.layers[2]
+  assert(#tilemapLay.cels == 0)
+
+  app.useTool{
+  tool='pencil',
+  color=1,
+  layer=tilemapLay,
+  tilesetMode=TilesetMode.MANUAL,
+  points={ Point(0, 0) }}
+  assert(#tilemapLay.cels == 0) -- MANUAL mode cannot create new tiles or cels
+
+  app.useTool{
+    tool='pencil',
+    color=1,
+    layer=tilemapLay,
+    tilesetMode=TilesetMode.STACK, -- STACK creates a new tile and cel
+    points={ Point(0, 0) }}
+
+  local tileset = tilemapLay.tileset
+  local cel = tilemapLay.cels[1]
+
+  app.useTool{
+    tool='pencil',
+    color=2,
+    cel=cel,
+    tilesetMode=TilesetMode.MANUAL,
+    points={ Point(1, 1) }}
+  assert(#tileset == 2) -- no new tiles created
+  expect_img(tileset:getTile(1), { 1,0,
+                                   0,2 })
+end


### PR DESCRIPTION
Upon investigating the cell-addition logic for tilemap layers, I found that Manual Mode was creating new cels without properly attaching them. While PR #5720 resolved the immediate crash, the first interaction in Manual Mode was still incorrectly committing a tile.

To resolve this, I implemented an early exit within the commit function to bypass the data-writing process when in Manual Mode. However, this initially prevented the preview layer from being cleared.

To ensure a consistent UI state, I updated drawing_state to explicitly clean the preview buffer when the drawing loop is destroyed. This ensures that "ghost" pixels are removed even when a commit is opted out.

I declare that my contributions are not co-authored using a generative AI technology.

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing
