### PR TITLE
Fix #5736: underscore and strike-through not shifted with layer's name

### DIFF
--- a/src/app/ui/timeline/timeline.cpp
+++ b/src/app/ui/timeline/timeline.cpp
@@ -2402,8 +2402,8 @@ void Timeline::drawLayer(ui::Graphics* g, const int layerIdx)
     int s = ui::guiscale();
     g->fillRect(is_active ? skinTheme()->colors.timelineClickedText() :
                             skinTheme()->colors.timelineNormalText(),
-                gfx::Rect(bounds.x + 4 * s,
-                          bounds.y + bounds.h - 2 * s,
+                gfx::Rect(textBounds.x + 4 * s,
+                          textBounds.y + textBounds.h - 2 * s,
                           font()->textLength(layer->name().c_str()),
                           s));
   }
@@ -2411,8 +2411,8 @@ void Timeline::drawLayer(ui::Graphics* g, const int layerIdx)
     int s = ui::guiscale();
     g->fillRect(is_active ? skinTheme()->colors.timelineClickedText() :
                             skinTheme()->colors.timelineNormalText(),
-                gfx::Rect(bounds.x + 4 * s,
-                          bounds.y + bounds.h / 2,
+                gfx::Rect(textBounds.x + 4 * s,
+                          textBounds.y + textBounds.h / 2,
                           font()->textLength(layer->name().c_str()),
                           s));
   }


### PR DESCRIPTION
<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the Individual Contributor License Agreement V4.0. -->
<!-- If you're a first-time contributor, please sign the CLA
     as indicated in https://github.com/igarastudio/cla#signing
     and acknowledge it by leaving the statement below. -->

I declare that my contributions are not co-authored using a generative AI technology.

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing
