### PR TITLE
Fix #5659: Square constraint doesn't consider the aspect ratio

### DIFF
--- a/src/app/script/app_object.cpp
+++ b/src/app/script/app_object.cpp
@@ -448,6 +448,14 @@ int App_useTool(lua_State* L)
     }
   }
 
+  // Square aspect (SHIFT key constraint)
+  type = lua_getfield(L, 1, "squareAspect");
+  if (type != LUA_TNIL && lua_toboolean(L, -1))
+    params.modifiers = static_cast<tools::ToolLoopModifiers>(
+      static_cast<int>(params.modifiers) |
+      static_cast<int>(tools::ToolLoopModifiers::kSquareAspect));
+  lua_pop(L, 1);
+
   // Do the tool loop
   type = lua_getfield(L, 1, "points");
   if (type == LUA_TTABLE) {

--- a/src/app/script/app_object.cpp
+++ b/src/app/script/app_object.cpp
@@ -452,6 +452,16 @@ int App_useTool(lua_State* L)
 
   // Get the list of points for the tool
   std::vector<gfx::Point> points;
+
+  // Square aspect (SHIFT key constraint)
+  type = lua_getfield(L, 1, "squareAspect");
+  if (type != LUA_TNIL && lua_toboolean(L, -1))
+    params.modifiers = static_cast<tools::ToolLoopModifiers>(
+      static_cast<int>(params.modifiers) |
+      static_cast<int>(tools::ToolLoopModifiers::kSquareAspect));
+  lua_pop(L, 1);
+
+  // Do the tool loop
   type = lua_getfield(L, 1, "points");
   if (type == LUA_TTABLE) {
     lua_pushnil(L);

--- a/src/app/tools/controllers.h
+++ b/src/app/tools/controllers.h
@@ -247,8 +247,10 @@ public:
     if ((int(loop->getModifiers()) & int(ToolLoopModifiers::kSquareAspect))) {
       int dx = stroke[1].x - m_first.x;
       int dy = stroke[1].y - m_first.y;
-      int minsize = std::min(ABS(dx), ABS(dy));
       int maxsize = std::max(ABS(dx), ABS(dy));
+
+      // Get pixel ratio, for calculations
+      const auto& pixelRatio = loop->sprite()->pixelRatio();
 
       // Lines
       if (loop->getIntertwine()->snapByAngle()) {
@@ -267,8 +269,15 @@ public:
         }
         // Snap at 45
         else if (angle < 54.0) {
-          stroke[1].x = m_first.x + SGN(dx) * minsize;
-          stroke[1].y = m_first.y + SGN(dy) * minsize;
+          const double visualWidth = ABS(dx) * pixelRatio.w;
+          const double visualHeight = ABS(dy) * pixelRatio.h;
+          double minVisualSize = std::min(visualWidth, visualHeight);
+
+          const int pixelDx = (int)(minVisualSize / pixelRatio.w);
+          const int pixelDy = (int)(minVisualSize / pixelRatio.h);
+
+          stroke[1].x = m_first.x + SGN(dx) * pixelDx;
+          stroke[1].y = m_first.y + SGN(dy) * pixelDy;
         }
         // Snap at 63.435
         else if (angle < 72.0) {
@@ -283,8 +292,15 @@ public:
       }
       // Rectangles and ellipses
       else {
-        stroke[1].x = m_first.x + SGN(dx) * minsize;
-        stroke[1].y = m_first.y + SGN(dy) * minsize;
+        const double visualWidth = ABS(dx) * pixelRatio.w;
+        const double visualHeight = ABS(dy) * pixelRatio.h;
+        double minVisualSize = std::min(visualWidth, visualHeight);
+
+        const int pixelDx = (int)(minVisualSize / pixelRatio.w);
+        const int pixelDy = (int)(minVisualSize / pixelRatio.h);
+
+        stroke[1].x = m_first.x + SGN(dx) * pixelDx;
+        stroke[1].y = m_first.y + SGN(dy) * pixelDy;
       }
     }
 

--- a/src/app/tools/controllers.h
+++ b/src/app/tools/controllers.h
@@ -247,8 +247,10 @@ public:
     if ((int(loop->getModifiers()) & int(ToolLoopModifiers::kSquareAspect))) {
       int dx = stroke[1].x - m_first.x;
       int dy = stroke[1].y - m_first.y;
-      int minsize = std::min(ABS(dx), ABS(dy));
       int maxsize = std::max(ABS(dx), ABS(dy));
+
+      // Get pixel ratio, for calculations
+      const auto& pixelRatio = loop->sprite()->pixelRatio();
 
       // Lines
       if (loop->getIntertwine()->snapByAngle()) {
@@ -267,8 +269,15 @@ public:
         }
         // Snap at 45
         else if (angle < 54.0) {
-          stroke[1].x = m_first.x + SGN(dx) * minsize;
-          stroke[1].y = m_first.y + SGN(dy) * minsize;
+          double visualWidth = ABS(dx) * pixelRatio.w;
+          double visualHeight = ABS(dy) * pixelRatio.h;
+          double minVisualSize = std::min(visualWidth, visualHeight);
+
+          int pixelDx = (int)(minVisualSize / pixelRatio.w);
+          int pixelDy = (int)(minVisualSize / pixelRatio.h);
+
+          stroke[1].x = m_first.x + SGN(dx) * pixelDx;
+          stroke[1].y = m_first.y + SGN(dy) * pixelDy;
         }
         // Snap at 63.435
         else if (angle < 72.0) {
@@ -283,8 +292,15 @@ public:
       }
       // Rectangles and ellipses
       else {
-        stroke[1].x = m_first.x + SGN(dx) * minsize;
-        stroke[1].y = m_first.y + SGN(dy) * minsize;
+        double visualWidth = ABS(dx) * pixelRatio.w;
+        double visualHeight = ABS(dy) * pixelRatio.h;
+        double minVisualSize = std::min(visualWidth, visualHeight);
+
+        int pixelDx = (int)(minVisualSize / pixelRatio.w + 0.5);
+        int pixelDy = (int)(minVisualSize / pixelRatio.h + 0.5);
+
+        stroke[1].x = m_first.x + SGN(dx) * pixelDx;
+        stroke[1].y = m_first.y + SGN(dy) * pixelDy;
       }
     }
 

--- a/tests/scripts/tools.lua
+++ b/tests/scripts/tools.lua
@@ -913,3 +913,94 @@ do
   app.preferences.tool("paint_bucket").floodfill.stop_at_grid = 0
   app.preferences.tool("paint_bucket").floodfill.refer_to = 0
 end
+
+----------------------------------------------------------------------
+-- square aspect constraint with non-square pixel ratios
+-- test for: https://github.com/aseprite/aseprite/issues/5659
+----------------------------------------------------------------------
+
+do
+  local function run_square_aspect_test(tc)
+    local spr = Sprite(20, 20)
+    local cel = spr.cels[1]
+    local ratio = Size{ w=tc.pixelRatioW, h=tc.pixelRatioH }
+    spr.pixelRatio = ratio
+
+    app.useTool{
+      tool=tc.tool,
+      color=tc.color,
+      squareAspect=true,
+      points={ Point(0, 0), Point(6, 6) }
+    }
+
+    assert(cel.bounds.width > 1 and cel.bounds.height > 1,
+           "shape was not drawn")
+
+    local pixelDx = cel.bounds.width-1
+    local pixelDy = cel.bounds.height-1
+    expect_eq(pixelDx, tc.expectedPixelDx)
+    expect_eq(pixelDy, tc.expectedPixelDy)
+
+    local visualW = pixelDx * ratio.w
+    local visualH = pixelDy * ratio.h
+    expect_eq(visualW, visualH)
+
+    if tc.expectedImage == "rect_frame_4x7" then
+      local c = tc.color.rgbaPixel
+      expect_img(cel.image,
+                 { c, c, c, c,
+                   c, 0, 0, c,
+                   c, 0, 0, c,
+                   c, 0, 0, c,
+                   c, 0, 0, c,
+                   c, 0, 0, c,
+                   c, c, c, c })
+    end
+
+    app.undo()
+  end
+
+  local cases = {
+    {
+      name = "rectangle 2:1",
+      tool = 'rectangle',
+      pixelRatioW = 2,
+      pixelRatioH = 1,
+      expectedPixelDx = 3,
+      expectedPixelDy = 6,
+      color = Color{ r=255, g=0, b=0 },
+      expectedImage = "rect_frame_4x7"
+    },
+    {
+      name = "ellipse 2:1",
+      tool = 'ellipse',
+      pixelRatioW = 2,
+      pixelRatioH = 1,
+      expectedPixelDx = 3,
+      expectedPixelDy = 6,
+      color = Color{ r=0, g=0, b=255 }
+    },
+    {
+      name = "rectangle 1:2",
+      tool = 'rectangle',
+      pixelRatioW = 1,
+      pixelRatioH = 2,
+      expectedPixelDx = 6,
+      expectedPixelDy = 3,
+      color = Color{ r=255, g=255, b=0 }
+    },
+    {
+      name = "line 45deg 2:1",
+      tool = 'line',
+      pixelRatioW = 2,
+      pixelRatioH = 1,
+      expectedPixelDx = 3,
+      expectedPixelDy = 6,
+      color = Color{ r=0, g=255, b=0 }
+    }
+  }
+
+  for _, tc in ipairs(cases) do
+    run_square_aspect_test(tc)
+  end
+end


### PR DESCRIPTION
When choosing a different aspect ratio than 1:1, when holding the shift key while trying to draw a shape like a circle,for example, it draws an ellipse instead. This behaviour happens since it doesn't take in account the aspect ratio of the sprite.

What I did to fix was using the ratio on the calculations, fixing the error. I also implemented this on the 45º snap of the line tool, since it showed the same problem. I also added tests to prevent this bug to happen again.

I declare that my contributions are not co-authored using a generative AI technology.

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing