### PR TITLE
Fix tips for thin filled ellipses

### DIFF
--- a/src/doc/algo.cpp
+++ b/src/doc/algo.cpp
@@ -500,11 +500,11 @@ void algo_ellipsefill(int x0,
     } // x step
   } while (x0 <= x1);
 
-  while (y0 + vPixels - y1 + 1 < h) {           // too early stop of flat ellipses a=1
-    proc(x0 - 1, ++y0 + vPixels, x0 - 1, data); // -> finish tip of ellipse
-    proc(x1 + 1 + hPixels, y0 + vPixels, x1 + 1 + hPixels, data);
-    proc(x0 - 1, --y1, x0 - 1, data);
-    proc(x1 + 1 + hPixels, y1, x1 + 1 + hPixels, data);
+  while (y0 + vPixels - y1 + 1 <= h) {        // too early stop of flat ellipses a=1
+    proc(x0 - 1, y0 + vPixels, x0 - 1, data); // -> finish tip of ellipse
+    proc(x1 + 1 + hPixels, y0++ + vPixels, x1 + 1 + hPixels, data);
+    proc(x0 - 1, y1, x0 - 1, data);
+    proc(x1 + 1 + hPixels, y1--, x1 + 1 + hPixels, data);
   }
 
   if (vPixels > 0) {


### PR DESCRIPTION
<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the Individual Contributor License Agreement V4.0. -->
<!-- If you're a first-time contributor, please sign the CLA
     as indicated in https://github.com/igarastudio/cla#signing
     and acknowledge it by leaving the statement below. -->

I declare that my contributions are not co-authored using a generative AI technology.

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing

---

Using the filled ellipse tool to draw very tall thin ellipses results in an incorrect & inconsistent result:

<img width="1088" height="1076" alt="Filled Ellipse with holes 1px inside the top and bottom edge" src="https://github.com/user-attachments/assets/993a865f-1d88-4743-a90b-ead53a3ec38f" />

---

Before Fix Video: <video alt="Drawing a Filled Ellipse with holes 1px inside the top and bottom edge" src="https://github.com/user-attachments/assets/3f897f44-7978-47b8-908d-64a38850615d"/>

After Fix Video (Expected Behavior): <video alt="Drawing a Filled Ellipse" src="https://github.com/user-attachments/assets/2cd73065-4bdb-4e78-99d3-14842e903f5a"/>

---

The fix made aligns the `algo_ellipsefill` algorithm with the `algo_ellipse` algorithm, which was correct.