### PR TITLE
Fix problem of quick tool shortcut not working when in select tool

### DIFF
--- a/src/app/ui/editor/editor.cpp
+++ b/src/app/ui/editor/editor.cpp
@@ -1779,12 +1779,9 @@ void Editor::updateQuicktool(const ui::Message* msg)
     const tools::Tool* selectedTool = atm->selectedTool();
 
     // Don't change quicktools if we are in a selection tool and using
-    // the selection modifiers (or Ctrl key to start a copy of the
-    // selection).
+    // the selection modifiers (or msg is not a key message, so we are using the mouse buttons).
     if (selectedTool->getInk(0)->isSelection()) {
-      if ((int(m_customizationDelegate->getPressedKeyAction(KeyContext::SelectionTool)) != 0) ||
-          (int(m_customizationDelegate->getPressedKeyAction(KeyContext::TranslatingSelection)) &
-           int(KeyAction::CopySelection))) {
+      if ((int(m_customizationDelegate->getPressedKeyAction(KeyContext::SelectionTool)) != 0) || msg->type() > 11) {
         if (atm->quickTool())
           atm->newQuickToolSelectedFromEditor(nullptr);
         return;


### PR DESCRIPTION
<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the Individual Contributor License Agreement V4.0. -->
<!-- If you're a first-time contributor, please sign the CLA
     as indicated in https://github.com/igarastudio/cla#signing
     and acknowledge it by leaving the statement below. -->

fixes #5743 

I declare that my contributions are not co-authored using a generative AI technology.

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing


Before: 

https://github.com/user-attachments/assets/28793184-4ee1-4066-9f51-b0cd07c4b99c


After:

https://github.com/user-attachments/assets/42cc632f-13e1-47a4-b40c-fb739dc7fa1d


Also this if the PR #5590 that introduced this bug, with this fix it doesnt regress on that 

https://github.com/user-attachments/assets/c4aca290-36ee-4cd8-abcf-0fa769f28f33

