### PR TITLE
Allow the CliProcessor to attempt to install extensions (fix #5744)

### DIFF
--- a/src/app/cli/cli_processor.cpp
+++ b/src/app/cli/cli_processor.cpp
@@ -595,8 +595,15 @@ int CliProcessor::process(Context* ctx)
         cof.document = nullptr;
         cof.filename = base::normalize_path(value.value());
 
-        if ( // Check that the filename wasn't used loading a sequence
-             // of images as one sprite
+        if (ctx->isUIAvailable() &&
+            base::string_to_lower(base::get_file_extension(cof.filename)) == "aseprite-extension") {
+          Params params = {
+            { "installExtension", cof.filename }
+          };
+          ctx->executeCommand(Commands::instance()->byId(CommandId::Options()), params);
+        }
+        else if ( // Check that the filename wasn't used loading a sequence
+                  // of images as one sprite
           m_usedFiles.find(cof.filename) == m_usedFiles.end() &&
           // Open sprite
           openFile(ctx, cof)) {


### PR DESCRIPTION
Fixes #5744, also useful for portable installs so the user can just drag and drop an extension file onto the executable.