### PR TITLE
fix: the webp image parser copies pixel row data usi... in...

### DIFF
--- a/src/app/file/webp_format.cpp
+++ b/src/app/file/webp_format.cpp
@@ -144,6 +144,11 @@ bool WebPFormat::onLoad(FileOp* fop)
   const int w = anim_info.canvas_width;
   const int h = anim_info.canvas_height;
 
+  if (w <= 0 || h <= 0 || w > WEBP_MAX_DIMENSION || h > WEBP_MAX_DIMENSION) {
+    fop->setError("Invalid WebP canvas dimensions (%dx%d)\n", w, h);
+    return false;
+  }
+
   Sprite* sprite = new Sprite(ImageSpec(ColorMode::RGB, w, h), 256);
   LayerImage* layer = new LayerImage(sprite);
   sprite->root()->addLayer(layer);
@@ -170,7 +175,7 @@ bool WebPFormat::onLoad(FileOp* fop)
     if (cel) {
       const uint32_t* src = (const uint32_t*)frame_rgba;
       for (int y = 0; y < h; ++y, src += w) {
-        memcpy(cel->image()->getPixelAddress(0, y), src, w * sizeof(uint32_t));
+        memcpy(cel->image()->getPixelAddress(0, y), src, cel->image()->width() * sizeof(uint32_t));
       }
 
       if (!has_alpha) {


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `src/app/file/webp_format.cpp`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `src/app/file/webp_format.cpp:173` |

**Description**: The WebP image parser copies pixel row data using a width value ('w') sourced directly from the WebP file header without validating it against the actual allocated pixel buffer size. A crafted WebP file with an inflated width value causes memcpy to write beyond the heap allocation, corrupting adjacent memory structures.

## Changes
- `src/app/file/webp_format.cpp`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
