### PR TITLE
Fix gradient tool doesn't work when used inside a selection (fix #5750)

### DIFF
--- a/src/app/tools/ink_processing.h
+++ b/src/app/tools/ink_processing.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2024  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -1044,10 +1044,16 @@ public:
   {
   }
 
-  void processScanline(int x1, int y, int x2, ToolLoop* loop) override
+  void initIterators(ToolLoop* loop, int x1, int y)
   {
+    base::initIterators(loop, x1, y);
     m_tmpAddress = (RgbTraits::address_t)m_tmpImage->getPixelAddress(x1, y);
-    base::processScanline(x1, y, x2, loop);
+  }
+
+  void moveIterators()
+  {
+    base::moveIterators();
+    ++m_tmpAddress;
   }
 
   void prepareForStrokes(ToolLoop* loop, Strokes& strokes) override
@@ -1080,7 +1086,6 @@ template<>
 void GradientInkProcessing<RgbTraits>::processPixel(int x, int y)
 {
   *m_dstAddress = rgba_blender_normal(*m_srcAddress, *m_tmpAddress, m_opacity);
-  ++m_tmpAddress;
 }
 
 template<>
@@ -1106,7 +1111,6 @@ void GradientInkProcessing<GrayscaleTraits>::processPixel(int x, int y)
   int v = doc::rgba_getr(c);
 
   *m_dstAddress = graya_blender_normal(*m_srcAddress, doc::graya(v, a), m_opacity);
-  ++m_tmpAddress;
 }
 
 template<>
@@ -1130,8 +1134,6 @@ void GradientInkProcessing<IndexedTraits>::processPixel(int x, int y)
   c = rgba_blender_normal(c0, c, m_opacity);
 
   *m_dstAddress = m_rgbmap->mapColor(c);
-
-  ++m_tmpAddress;
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/src/app/ui/editor/tool_loop_impl.cpp
+++ b/src/app/ui/editor/tool_loop_impl.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2025  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -406,7 +406,9 @@ public:
   render::DitheringMatrix getDitheringMatrix() override
   {
     // TODO add support when UI is not enabled
-    return App::instance()->contextBar()->ditheringMatrix();
+    if (auto* ctx = App::instance()->contextBar())
+      return ctx->ditheringMatrix();
+    return render::DitheringMatrix();
   }
 
   render::DitheringAlgorithmBase* getDitheringAlgorithm() override
@@ -418,7 +420,9 @@ public:
   render::GradientType getGradientType() override
   {
     // TODO add support when UI is not enabled
-    return App::instance()->contextBar()->gradientType();
+    if (auto* ctx = App::instance()->contextBar())
+      return ctx->gradientType();
+    return render::GradientType::Linear;
   }
 
   tools::DynamicsOptions getDynamics() override { return m_dynamics; }

--- a/tests/scripts/gradient.lua
+++ b/tests/scripts/gradient.lua
@@ -1,0 +1,54 @@
+-- Copyright (C) 2026-present  Igara Studio S.A.
+--
+-- This file is released under the terms of the MIT license.
+-- Read LICENSE.txt for more information.
+
+dofile('./test_utils.lua')
+
+local spr = Sprite(4, 4, ColorMode.GRAYSCALE)
+
+app.useTool {
+  tool = 'rectangular_marquee',
+  points = { Point(2, 0), Point(3, 3) }}
+
+app.useTool {
+  tool = 'rectangular_marquee',
+  selection = SelectionMode.ADD,
+  points = { Point(0, 2), Point(1, 3) }}
+
+local gray = app.pixelColor.graya
+local c0 = gray(0)
+local c1 = gray(85)
+local c2 = gray(170)
+local c3 = gray(255)
+
+-- Horizontal Gradient
+app.useTool {
+  tool = 'gradient',
+  color = c0,
+  bgColor = c3,
+  contiguous = false,
+  points = { Point(3, 3), Point(0, 3) }}
+
+local img = app.cel.image
+print(img.width)
+print(img.height)
+expect_img(img, {  0,  0, c1, c0,
+                   0,  0, c1, c0,
+                  c3, c2, c1, c0,
+                  c3, c2, c1, c0 })
+
+app.undo()
+
+-- Vertical Gradient
+app.useTool {
+  tool = 'gradient',
+  color = c0,
+  bgColor = c3,
+  contiguous = false,
+  points = { Point(3, 3), Point(3, 0) }}
+
+  expect_img(img, {  0,  0, c3, c3,
+                     0,  0, c2, c2,
+                    c1, c1, c1, c1,
+                    c0, c0, c0, c0 })


### PR DESCRIPTION
The wrong gradient results happened because m_tmpAddress was initialized before the clip process of x1 inside the processScan base function which initialices m_srcAddress/m_dstAddress in such clipped coordinates. Finally, m_tmpAddress goes shifted (misaligned) refered to m_srcAddress/m_dstAddress.

fix #5750