### PR TITLE
Fix zoom level 20% distorts layers (fix #5774)

### DIFF
--- a/src/render/render.cpp
+++ b/src/render/render.cpp
@@ -1,5 +1,5 @@
 // Aseprite Render Library
-// Copyright (C) 2019-2025  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -274,8 +274,8 @@ void composite_image_scale_down(Image* dst,
     return;
 
   BlenderHelper<DstTraits, SrcTraits> blender(dst, src, pal, blendMode, newBlend);
-  int step_w = int(1.0 / sx);
-  int step_h = int(1.0 / sy);
+  int step_w = int(std::round(1.0 / sx));
+  int step_h = int(std::round(1.0 / sy));
   if (step_w < 1 || step_h < 1)
     return;
 


### PR DESCRIPTION
The problem was that `sx` was 0.20000000000000001 and then `1.0/sx` gave 5.0 which naturally was truncated to 5. In the other hand, `sy` was 0.20000000000000004 and then `1.0/sy` gave 4.9999999999999991 which was truncated to 4.
https://github.com/aseprite/aseprite/blob/e0536556f4f254c317b44fa47becf7ace5100a37/src/render/render.cpp#L277-L278

It would seem better to remove the multiplication and division of `celBounds.w / double(cel_image->width())` and `celBounds.h / double(cel_image->height())` that resulted in 0.20000000000000004 in the first place:
https://github.com/aseprite/aseprite/blob/e0536556f4f254c317b44fa47becf7ace5100a37/src/render/render.cpp#L1368-L1369
However, if I'm not mistaken, this is intended for reference layers. Therefore, I'll leave it as is.

Fix #5774