### PR TITLE
Extension installation and command fixes

### DIFF
--- a/src/app/extensions.cpp
+++ b/src/app/extensions.cpp
@@ -1100,7 +1100,7 @@ Extensions::Extensions()
         loadExtension(dir, fullFn, isBuiltinExtension);
       }
       catch (const std::exception& ex) {
-        LOG("EXT: Error loading JSON file: %s\n", ex.what());
+        LOG(ERROR, "EXT: Error loading extension from '%s': %s\n", dir.c_str(), ex.what());
       }
     }
   }
@@ -1368,6 +1368,12 @@ Extension* Extensions::loadExtension(const std::string& path,
     throw base::Exception("Error loading extension '%s', empty name", path.c_str());
   const auto& version = json.value("version", "");
   const auto& displayName = json.value("displayName", name);
+
+  auto it = std::find_if(m_extensions.begin(), m_extensions.end(), [&name](const Extension* ext) {
+    return ext->name() == name;
+  });
+  if (it != m_extensions.end())
+    throw base::Exception("An extension with the name '%s' already exists", name.c_str());
 
   LOG("EXT: Extension '%s' loaded\n", name.c_str());
 

--- a/src/app/extensions.cpp
+++ b/src/app/extensions.cpp
@@ -333,16 +333,17 @@ void Extension::addCommand(const std::string& id)
   m_plugin.items.push_back(item);
 }
 
-void Extension::removeCommand(const std::string& id)
+bool Extension::removeCommand(const std::string& id)
 {
   for (auto it = m_plugin.items.begin(); it != m_plugin.items.end();) {
     if (it->type == PluginItem::Command && it->id == id) {
-      it = m_plugin.items.erase(it);
+      m_plugin.items.erase(it);
+      return true;
     }
-    else {
-      ++it;
-    }
+
+    ++it;
   }
+  return false;
 }
 
 void Extension::addMenuGroup(const std::string& id)
@@ -353,16 +354,17 @@ void Extension::addMenuGroup(const std::string& id)
   m_plugin.items.push_back(item);
 }
 
-void Extension::removeMenuGroup(const std::string& id)
+bool Extension::removeMenuGroup(const std::string& id)
 {
   for (auto it = m_plugin.items.begin(); it != m_plugin.items.end();) {
     if (it->type == PluginItem::MenuGroup && it->id == id) {
-      it = m_plugin.items.erase(it);
+      m_plugin.items.erase(it);
+      return true;
     }
-    else {
-      ++it;
-    }
+
+    ++it;
   }
+  return false;
 }
 
 void Extension::addMenuSeparator(ui::Widget* widget)

--- a/src/app/extensions.cpp
+++ b/src/app/extensions.cpp
@@ -48,9 +48,16 @@
 #endif
 
 #include "archive.h"
+#define WIN32_LEAN_AND_MEAN
 #include "archive_entry.h"
 #include "nlohmann/json.hpp"
 
+#ifdef LAF_WINDOWS
+  // archive_entry.h includes windows.h and this breaks LOG
+  #undef ERROR
+#endif
+
+#include <cctype>
 #include <fstream>
 #include <sstream>
 #include <string>
@@ -1274,7 +1281,7 @@ ExtensionInfo Extensions::getCompressedExtensionInfo(const std::string& zipFn) c
 Extension* Extensions::installCompressedExtension(const std::string& zipFn,
                                                   const ExtensionInfo& info)
 {
-  base::paths installedFiles;
+  std::set<std::string> installedFiles;
 
   // Uncompress zipFn in info.dstPath
   {
@@ -1310,7 +1317,8 @@ Extension* Extensions::installCompressedExtension(const std::string& zipFn,
           continue;
       }
 
-      installedFiles.push_back(fn);
+      installedFiles.emplace(base::get_file_path(fn));
+      installedFiles.emplace(fn);
 
       const std::string fullFn = base::join_path(info.dstPath, fn);
 #if _WIN32

--- a/src/app/extensions.h
+++ b/src/app/extensions.h
@@ -139,10 +139,10 @@ public:
   void addDitheringMatrix(const std::string& id, const std::string& path, const std::string& name);
 #ifdef ENABLE_SCRIPTING
   void addCommand(const std::string& id);
-  void removeCommand(const std::string& id);
+  bool removeCommand(const std::string& id);
 
   void addMenuGroup(const std::string& id);
-  void removeMenuGroup(const std::string& id);
+  bool removeMenuGroup(const std::string& id);
 
   void addMenuSeparator(ui::Widget* widget);
   void addFileFormat(const CustomFormatDefinition& definition);

--- a/src/app/script/plugin_class.cpp
+++ b/src/app/script/plugin_class.cpp
@@ -16,6 +16,7 @@
 #include "app/script/engine.h"
 #include "app/script/luacpp.h"
 #include "app/ui/app_menuitem.h"
+#include "base/exception.h"
 #include "base/version.h"
 
 namespace app { namespace script {
@@ -31,12 +32,14 @@ class PluginCommand : public Command {
 public:
   PluginCommand(const std::string& id,
                 const std::string& title,
+                const std::string& extensionName,
                 script::Engine* engine,
                 int onclickRef,
                 int onenabledRef,
                 int oncheckedRef)
     : Command(id.c_str())
     , m_title(title)
+    , m_extensionName(extensionName)
     , m_engine(engine)
     , m_onclickRef(onclickRef)
     , m_onenabledRef(onenabledRef)
@@ -56,6 +59,8 @@ public:
   }
 
   bool isPlugin() override { return true; }
+
+  const std::string& extensionName() const { return m_extensionName; }
 
 protected:
   std::string onGetFriendlyName() const override { return m_title; }
@@ -108,6 +113,7 @@ private:
   }
 
   std::string m_title;
+  std::string m_extensionName;
   Engine* m_engine;
   int m_onclickRef;
   int m_onenabledRef;
@@ -116,24 +122,35 @@ private:
 
 void deleteCommandIfExistent(Extension* ext, const std::string& id)
 {
-  auto cmd = Commands::instance()->byId(id.c_str());
-  if (cmd) {
-    // Delete the item added by the "group" parameter, if any.
+  auto* cmd = Commands::instance()->byId(id.c_str());
+  if (!cmd)
+    return;
+
+  const auto* pluginCmd = dynamic_cast<PluginCommand*>(cmd);
+
+  // TODO: We need to prefix or tag extension commands in some way so that they can share names.
+  if (!pluginCmd || ext->name() != pluginCmd->extensionName())
+    throw base::Exception(
+      "Extension %s attempted to alter a command (%s) that does not belong to it",
+      ext->name().c_str(),
+      id.c_str());
+
+  if (ext->removeCommand(id)) {
     if (auto* appMenus = AppMenus::instance())
       appMenus->removeMenuItemFromGroup(cmd);
 
     Commands::instance()->remove(cmd);
-    ext->removeCommand(id);
     delete cmd;
   }
 }
 
 void deleteMenuGroupIfExistent(Extension* ext, const std::string& id)
 {
+  if (!ext->removeMenuGroup(id))
+    return;
+
   if (auto* appMenus = AppMenus::instance())
     appMenus->removeMenuGroup(id);
-
-  ext->removeMenuGroup(id);
 }
 
 int Plugin_gc(lua_State* L)
@@ -197,6 +214,7 @@ int Plugin_newCommand(lua_State* L)
 
       auto cmd = new PluginCommand(id,
                                    title,
+                                   plugin->ext->name(),
                                    plugin->ext->scriptEngine(),
                                    onclickRef,
                                    onenabledRef,

--- a/src/app/script/plugin_class.cpp
+++ b/src/app/script/plugin_class.cpp
@@ -118,6 +118,10 @@ void deleteCommandIfExistent(Extension* ext, const std::string& id)
 {
   auto cmd = Commands::instance()->byId(id.c_str());
   if (cmd) {
+    // Delete the item added by the "group" parameter, if any.
+    if (auto* appMenus = AppMenus::instance())
+      appMenus->removeMenuItemFromGroup(cmd);
+
     Commands::instance()->remove(cmd);
     ext->removeCommand(id);
     delete cmd;


### PR DESCRIPTION
Fixes a few assorted extension issues:

 * When an extension with subdirectories was uninstalled, we were leaving the directories behind, since they were never added to installedFiles.
 * [An assert](https://github.com/aseprite/aseprite/blob/793fb6526540b4c6f5cf8381ae189241cb003fdf/src/app/app_menus.cpp#L602) could be triggered when exiting or disabling an extension because a menu item that was created by a command that was deleted lingered.
 * Extension could delete any command either by using deleteCommand or creating a new command with the same name, this includes built-in commands like "About" or... anything else really. Now it checks.
 * Before you could copy paste the extension directory and have a bunch of the same extension with the same name, this is a more "controversial" change since we don't really have an extension `id` per-se, just a "name". Ideally through normal installation this would never happen because the installer checks, but it's IMO good practice to avoid weird cases with extensions registering the same commands, etc.