### PR TITLE
Fix #5673: Saving a sprite with an empty palette corrupts file

### DIFF
--- a/src/dio/aseprite_decoder.cpp
+++ b/src/dio/aseprite_decoder.cpp
@@ -518,6 +518,12 @@ Palette* AsepriteDecoder::readPaletteChunk(Palette* prevPal, frame_t frame)
   int to = read32();
   readPadding(8);
 
+  // If the palette has no colors, resize pal and return early
+  // because there are no colors to be read
+  if (newSize == 0) {
+    pal->resize(newSize);
+    return pal;
+  }
   if (newSize > 0)
     pal->resize(newSize);
 

--- a/src/dio/aseprite_encoder.cpp
+++ b/src/dio/aseprite_encoder.cpp
@@ -42,7 +42,7 @@ bool AsepriteEncoder::encode()
   const Sprite* sprite = delegate()->sprite();
   bool require_new_palette_chunk = false;
   for (Palette* pal : sprite->getPalettes()) {
-    if (pal->size() > 256 || pal->hasAlpha()) {
+    if (pal->size() == 0 || pal->size() > 256 || pal->hasAlpha()) {
       require_new_palette_chunk = true;
       break;
     }
@@ -70,11 +70,18 @@ bool AsepriteEncoder::encode()
 
     // is the first frame or did the palette change?
     Palette* pal = sprite->palette(frame);
-    int palFrom = 0, palTo = pal->size() - 1;
-    if ( // First frame or..
-      (frame == delegate()->fromFrame() ||
-       // This palette is different from the previous frame palette
-       sprite->palette(frame - 1)->countDiff(pal, &palFrom, &palTo) > 0)) {
+    const int paletteSize = pal->size();
+    int palFrom = 0, palTo = paletteSize - 1;
+
+    // Current frame is the first frame
+    const bool isFirstFrame = (frame == delegate()->fromFrame());
+    // Frame's palette is different from the previous frame palette
+    // Check if it's not first frame first so an invalid frame number
+    // (-1) isn't passed into palette()
+    const bool paletteChanged = (!isFirstFrame &&
+                                 sprite->palette(frame - 1)->countDiff(pal, &palFrom, &palTo) > 0);
+
+    if ((isFirstFrame || paletteChanged) && paletteSize != 0) {
       // Write new palette chunk
       if (require_new_palette_chunk) {
         writePaletteChunk(&frame_header, pal, palFrom, palTo);
@@ -85,6 +92,10 @@ bool AsepriteEncoder::encode()
         // is smaller than the new palette chunk).
         writeColor2Chunk(&frame_header, pal);
       }
+    }
+    else if (paletteChanged && paletteSize == 0) {
+      // Write new palette chunk with ncolors = 0 and ignore from and to
+      writePaletteChunk(&frame_header, pal, 0, 0);
     }
 
     // Write extra chunks in the first frame
@@ -402,6 +413,9 @@ void AsepriteEncoder::writePaletteChunk(AsepriteFrameHeader* frame_header,
   write32(from);
   write32(to);
   writePadding(8);
+
+  if (pal->size() == 0)
+    return;
 
   for (int c = from; c <= to; ++c) {
     const color_t color = pal->getEntry(c);

--- a/tests/scripts/sprite.lua
+++ b/tests/scripts/sprite.lua
@@ -305,3 +305,27 @@ do
 
   assert(a.isValid == false)
 end
+
+-- Save and reload a sprite with an empty palette (0 colors)
+-- Related to https://github.com/aseprite/aseprite/issues/5673
+do
+  local spr = Sprite(32, 32)
+  local cel = spr.cels[1]
+
+  local emptyPal = Palette(1)
+  emptyPal:resize(0)
+  assert(#emptyPal == 0)
+  spr:setPalette(emptyPal)
+
+  local filename = "_test_empty_palette.aseprite"
+  spr:saveAs(filename)
+
+  -- File must open without corruption
+  local spr2 = app.open(filename)
+  assert(spr2 ~= nil)
+  assert(spr2.width == 32)
+  assert(spr2.height == 32)
+  assert(#spr2.cels == 1)
+
+  spr2:close()
+end


### PR DESCRIPTION
This PR is in continuation to #5707.

Before, when loading an empty palette and saving the file, the file would become corrupted upon opening it again.

This fixes it by handling the case where the palette size is 0 when saving the file, so it no longer causes underflow in the encoder.

Also fixed the decoder, as before it would only resize palettes with newSize > 0, which would not work for loading empty palettes.

Finally, added a new test to verify if the file doesn't break.


I declare that my contributions are not co-authored using a generative AI technology.

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing
