### PR TITLE
Add safe save (atomic file write) (fix #5770)

### DIFF
--- a/data/pref.xml
+++ b/data/pref.xml
@@ -260,6 +260,7 @@
       <option id="nonactive_layers_opacity" type="int" default="255" />
       <option id="nonactive_layers_opacity_preview" type="int" default="255" />
       <option id="tooltip_delay" type="int" default="300" />
+      <option id="safe_save" type="bool" default="false" />
     </section>
     <section id="developer">
       <option id="debug_paint_messages" type="bool" default="false" />

--- a/data/strings/en.ini
+++ b/data/strings/en.ini
@@ -1680,6 +1680,7 @@ set_cursor_fix_tooltip = Sets the mouse position to the pen location when\nyou h
 wintab_more_info = (More Information)
 flash_selected_layer = Flash layer when it is selected
 use_selection_tool_loop = New selection tools implementation
+safe_save = Safe save (saves to a temp file first)
 non_active_layer_opacity = Opacity for non-active layers:
 cel_content_format = Cel content format:
 cel_format_compressed = Compressed

--- a/data/widgets/options.xml
+++ b/data/widgets/options.xml
@@ -651,6 +651,8 @@
                  pref="experimental.flash_layer" />
           <check id="use_selection_tool_loop" text="@.use_selection_tool_loop"
                  pref="experimental.use_selection_tool_loop" />
+          <check id="safe_save" text="@.safe_save"
+                 pref="experimental.safe_save" />
           <hbox>
             <label for="tooltip_delay" text="@.tooltip_delay" />
             <expr id="tooltip_delay" suffix="@.tooltip_delay_unit" />

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -97,6 +97,7 @@ add_library(app-lib ${generated_files})
 # These specific-platform files should be in an external library
 # (e.g. "base" or "os").
 if(WIN32)
+  target_compile_options(app-lib PRIVATE -DNOMINMAX)
   target_sources(app-lib PRIVATE fonts/font_path_win.cpp)
 elseif(APPLE)
   target_sources(app-lib PRIVATE fonts/font_path_osx.mm)

--- a/src/app/file/file.cpp
+++ b/src/app/file/file.cpp
@@ -51,9 +51,91 @@
 #include <cstdarg>
 #include <cstring>
 
+#if LAF_LINUX || LAF_MACOS
+  #include <sys/stat.h>
+  #include <unistd.h>
+#elif LAF_WINDOWS
+  #include <windows.h>
+#endif
+
 namespace app {
 
 using namespace base;
+
+class SafeSave {
+public:
+  SafeSave(std::string& filename, FileOp* fop, bool enabled)
+    : m_filename(filename)
+    , m_fop(fop)
+    , m_enabled(enabled)
+  {
+    if (!m_enabled)
+      return;
+
+#if LAF_LINUX || LAF_MACOS
+    if (base::is_file(m_filename)) {
+      struct stat sts;
+      if (stat(m_filename.c_str(), &sts) == 0) {
+        m_restoreAttrs = true;
+        m_mode = sts.st_mode;
+      }
+    }
+#elif LAF_WINDOWS
+    if (base::is_file(m_filename))
+      m_fileAttributes = ::GetFileAttributes(base::from_utf8(m_filename).c_str());
+#endif
+
+    auto now = std::chrono::steady_clock::now().time_since_epoch().count();
+    m_tempFilename = base::join_path(
+      base::get_file_path(m_filename),
+      fmt::format("{}_{}.tmp", base::get_file_name(m_filename), now));
+    std::swap(m_filename, m_tempFilename);
+  }
+
+  ~SafeSave()
+  {
+    if (!m_enabled)
+      return;
+    std::swap(m_filename, m_tempFilename);
+    if (!m_fop->hasError() && !m_fop->isStop()) {
+      try {
+        base::move_file(m_tempFilename, m_filename, true);
+#if LAF_LINUX || LAF_MACOS
+        if (m_restoreAttrs)
+          chmod(m_filename.c_str(), m_mode);
+#elif LAF_WINDOWS
+        if (m_fileAttributes != INVALID_FILE_ATTRIBUTES)
+          ::SetFileAttributes(base::from_utf8(m_filename).c_str(), m_fileAttributes);
+#endif
+      }
+      catch (const std::exception& e) {
+        m_fop->setError("Error overwriting file: %s\n", e.what());
+      }
+    }
+    else {
+      if (base::is_file(m_tempFilename)) {
+        try {
+          base::delete_file(m_tempFilename);
+        }
+        catch (const std::exception& e) {
+          m_fop->setError("Error deleting temporary file: %s\n", e.what());
+        }
+      }
+    }
+  }
+
+private:
+  std::string& m_filename;
+  std::string m_tempFilename;
+  FileOp* m_fop;
+  bool m_enabled;
+#if LAF_LINUX || LAF_MACOS
+  bool m_restoreAttrs = false;
+  mode_t m_mode = 0;
+#elif LAF_WINDOWS
+  DWORD m_fileAttributes = INVALID_FILE_ATTRIBUTES;
+#endif
+};
 
 class FileOp::FileAbstractImageImpl : public FileAbstractImage {
 public:
@@ -996,6 +1078,8 @@ void FileOp::operate(IFileOpProgress* progress)
           // Make directories
           makeDirectories();
 
+          SafeSave safeSave(m_filename, this, m_config.safeSave);
+
           // Call the "save" procedure... did it fail?
           if (!m_format->save(this)) {
             setError("Error saving frame %d in the file \"%s\"\n",
@@ -1021,6 +1105,8 @@ void FileOp::operate(IFileOpProgress* progress)
       if (m_abstractImage) {
         m_abstractImage->setSpecSize(m_roi.fileCanvasSize(), m_roi.fileCanvasSize());
       }
+
+      SafeSave safeSave(m_filename, this, m_config.safeSave);
 
       // Call the "save" procedure.
       if (!m_format->save(this)) {

--- a/src/app/file/file_op_config.cpp
+++ b/src/app/file/file_op_config.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2024  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -28,6 +28,7 @@ void FileOpConfig::fillFromPreferences()
   fitCriteria = pref.quantization.fitCriteria();
   cacheCompressedTilesets = pref.tileset.cacheCompressedTilesets();
   composeGroups = pref.experimental.composeGroups();
+  safeSave = pref.experimental.safeSave();
 }
 
 } // namespace app

--- a/src/app/file/file_op_config.h
+++ b/src/app/file/file_op_config.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2024  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -51,6 +51,12 @@ struct FileOpConfig {
   // and then composed with the rest of the sprite. In this case
   // blend mode and opacity fields are valid for groups too.
   bool composeGroups = false;
+
+  // True if the save process first writes to a temporary file
+  // and then renames it to replace the original file.
+  // This method should be much safer than overwriting the
+  // original file directly.
+  bool safeSave = false;
 
   void fillFromPreferences();
 };


### PR DESCRIPTION
Original issue name: "Cancelling Save action overwrites original .aseprite file with partially empty file, causing data loss"

Example of how it works:
<img width="480" height="496" alt="output" src="https://github.com/user-attachments/assets/fd7af2b1-187f-4769-af3b-2b926012a88a" />

fix #5770