### PR TITLE
Fix tilemap layer copy/paste

### DIFF
--- a/src/app/commands/cmd_duplicate_layer.cpp
+++ b/src/app/commands/cmd_duplicate_layer.cpp
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2025  David Capello
 //
 // This program is distributed under the terms of
@@ -46,7 +47,10 @@ void DuplicateLayerCommand::onExecute(Context* context)
     Tx tx(writer, Strings::commands_DuplicateLayer());
     LayerImage* sourceLayer = static_cast<LayerImage*>(writer.layer());
     DocApi api = document->getApi(tx);
-    api.duplicateLayerAfter(sourceLayer, sourceLayer->parent(), sourceLayer);
+    api.duplicateLayerAfter(sourceLayer,
+                            sourceLayer->parent(),
+                            sourceLayer,
+                            DocApi::ShareTilesets::Yes); // TODO configurable
     tx.commit();
   }
 

--- a/src/app/doc.cpp
+++ b/src/app/doc.cpp
@@ -539,7 +539,10 @@ void Doc::resetTransformation()
 //////////////////////////////////////////////////////////////////////
 // Copying
 
-void Doc::copyLayerContent(const Layer* sourceLayer, Doc* destDoc, Layer* destLayer) const
+void Doc::copyOneLayerContent(const Layer* sourceLayer,
+                              Doc* destDoc,
+                              Layer* destLayer,
+                              LayerList& childrenToCopy) const
 {
   LayerFlags dstFlags = sourceLayer->flags();
 
@@ -559,40 +562,7 @@ void Doc::copyLayerContent(const Layer* sourceLayer, Doc* destDoc, Layer* destLa
   destLayer->setOpacity(sourceLayer->opacity());
 
   if (sourceLayer->isGroup() && destLayer->isGroup()) {
-    for (Layer* sourceChild : sourceLayer->layers()) {
-      std::unique_ptr<Layer> destChild(nullptr);
-
-      if (sourceChild->isImage()) {
-        if (sourceChild->isTilemap()) {
-          auto* tilemapLayer = static_cast<LayerTilemap*>(sourceChild);
-          destChild.reset(new LayerTilemap(destLayer->sprite(), tilemapLayer->tilesetIndex()));
-        }
-        else {
-          destChild.reset(new LayerImage(destLayer->sprite()));
-        }
-
-        copyLayerContent(sourceChild, destDoc, destChild.get());
-      }
-      else if (sourceChild->isGroup()) {
-        destChild.reset(new LayerGroup(destLayer->sprite()));
-        copyLayerContent(sourceChild, destDoc, destChild.get());
-      }
-      else {
-        ASSERT(false);
-      }
-
-      ASSERT(destChild != NULL);
-
-      // Add the new layer in the sprite.
-
-      Layer* newLayer = destChild.release();
-      Layer* afterThis = destLayer->lastLayer();
-
-      destLayer->addLayer(newLayer);
-      destChild.release();
-
-      destLayer->stackLayer(newLayer, afterThis);
-    }
+    childrenToCopy = sourceLayer->layers();
   }
   else if (sourceLayer->type() == destLayer->type()) {
     // Copy cels
@@ -628,6 +598,50 @@ void Doc::copyLayerContent(const Layer* sourceLayer, Doc* destDoc, Layer* destLa
   }
   else {
     ASSERT(false && "Trying to copy two incompatible layers");
+  }
+}
+
+void Doc::copyLayerContent(const Layer* sourceLayer, Doc* destDoc, Layer* destLayer) const
+{
+  LayerList childrenToCopy;
+  copyOneLayerContent(sourceLayer, destDoc, destLayer, childrenToCopy);
+
+  for (const Layer* sourceChild : childrenToCopy) {
+    std::unique_ptr<Layer> destChild(nullptr);
+
+    if (sourceChild->isImage()) {
+      if (sourceChild->isTilemap()) {
+        auto* tilemapLayer = static_cast<const LayerTilemap*>(sourceChild);
+        // This works only when we're duplicating a sprite, because
+        // the tileset index is exactly the same.
+        const tileset_index tsi = tilemapLayer->tilesetIndex();
+        destChild.reset(new LayerTilemap(destLayer->sprite(), tsi));
+      }
+      else {
+        destChild.reset(new LayerImage(destLayer->sprite()));
+      }
+
+      copyLayerContent(sourceChild, destDoc, destChild.get());
+    }
+    else if (sourceChild->isGroup()) {
+      destChild.reset(new LayerGroup(destLayer->sprite()));
+      copyLayerContent(sourceChild, destDoc, destChild.get());
+    }
+    else {
+      ASSERT(false);
+    }
+
+    ASSERT(destChild != NULL);
+
+    // Add the new layer in the sprite.
+
+    Layer* newLayer = destChild.release();
+    Layer* afterThis = destLayer->lastLayer();
+
+    destLayer->addLayer(newLayer);
+    destChild.release();
+
+    destLayer->stackLayer(newLayer, afterThis);
   }
 }
 

--- a/src/app/doc.cpp
+++ b/src/app/doc.cpp
@@ -606,42 +606,24 @@ void Doc::copyLayerContent(const Layer* sourceLayer, Doc* destDoc, Layer* destLa
   LayerList childrenToCopy;
   copyOneLayerContent(sourceLayer, destDoc, destLayer, childrenToCopy);
 
+  if (sourceLayer->isTilemap()) {
+    // This works out-of-the-box only because we're duplicating a
+    // sprite, as the tileset index is exactly the same as the
+    // original sprite. In other case we should adjust the cloned
+    // tileset index for tilemap layers.
+    const tileset_index tsi = static_cast<const LayerTilemap*>(sourceLayer)->tilesetIndex();
+    static_cast<LayerTilemap*>(destLayer)->setTilesetIndex(tsi);
+  }
+
+  // Copy the LayerGroup content (children layer)
   for (const Layer* sourceChild : childrenToCopy) {
-    std::unique_ptr<Layer> destChild(nullptr);
+    std::unique_ptr<Layer> destChild(sourceChild->clone(destDoc->sprite()));
 
-    if (sourceChild->isImage()) {
-      if (sourceChild->isTilemap()) {
-        auto* tilemapLayer = static_cast<const LayerTilemap*>(sourceChild);
-        // This works only when we're duplicating a sprite, because
-        // the tileset index is exactly the same.
-        const tileset_index tsi = tilemapLayer->tilesetIndex();
-        destChild.reset(new LayerTilemap(destLayer->sprite(), tsi));
-      }
-      else {
-        destChild.reset(new LayerImage(destLayer->sprite()));
-      }
-
-      copyLayerContent(sourceChild, destDoc, destChild.get());
-    }
-    else if (sourceChild->isGroup()) {
-      destChild.reset(new LayerGroup(destLayer->sprite()));
-      copyLayerContent(sourceChild, destDoc, destChild.get());
-    }
-    else {
-      ASSERT(false);
-    }
-
-    ASSERT(destChild != NULL);
+    copyLayerContent(sourceChild, destDoc, destChild.get());
 
     // Add the new layer in the sprite.
-
-    Layer* newLayer = destChild.release();
-    Layer* afterThis = destLayer->lastLayer();
-
-    destLayer->addLayer(newLayer);
+    destLayer->addLayer(destChild.get());
     destChild.release();
-
-    destLayer->stackLayer(newLayer, afterThis);
   }
 }
 

--- a/src/app/doc.h
+++ b/src/app/doc.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2025  Igara Studio S.A.
+// Copyright (C) 2018-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -251,7 +251,10 @@ public:
   //////////////////////////////////////////////////////////////////////
   // Copying
 
-  void copyLayerContent(const Layer* sourceLayer, Doc* destDoc, Layer* destLayer) const;
+  void copyOneLayerContent(const Layer* sourceLayer,
+                           Doc* destDoc,
+                           Layer* destLayer,
+                           LayerList& childrenToCopy) const;
   Doc* duplicate(DuplicateType type) const;
 
   void close();
@@ -261,6 +264,7 @@ protected:
   virtual void onContextChanged();
 
 private:
+  void copyLayerContent(const Layer* sourceLayer, Doc* destDoc, Layer* destLayer) const;
   void removeFromContext();
   void updateOSColorSpace(bool appWideSignal);
 

--- a/src/app/doc_api.cpp
+++ b/src/app/doc_api.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2025  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -722,7 +722,13 @@ Layer* DocApi::copyLayerWithSprite(doc::Layer* layer, doc::Sprite* sprite)
   }
 
   if (auto* doc = dynamic_cast<app::Doc*>(sprite->document())) {
-    doc->copyLayerContent(layer, doc, clone.get());
+    LayerList children;
+    doc->copyOneLayerContent(layer, doc, clone.get(), children);
+    for (auto child : children) {
+      Layer* childClone = copyLayerWithSprite(child, sprite);
+      if (childClone)
+        clone->addLayer(childClone);
+    }
   }
 
   return clone.release();

--- a/src/app/doc_api.cpp
+++ b/src/app/doc_api.cpp
@@ -86,8 +86,8 @@ DocApi::HandleLinkedCels::HandleLinkedCels(DocApi& api,
   , m_created(false)
 {
   if (Cel* srcCel = srcLayer->cel(srcFrame)) {
-    auto it = m_api.m_linkedCels.find(srcCel->data()->id());
-    if (it != m_api.m_linkedCels.end()) {
+    auto it = m_api.data()->linkedCels.find(srcCel->data()->id());
+    if (it != m_api.data()->linkedCels.end()) {
       Cel* dstRelated = it->second;
       if (dstRelated && dstRelated->layer() == dstLayer) {
         // Create a link
@@ -112,7 +112,7 @@ DocApi::HandleLinkedCels::~HandleLinkedCels()
 {
   if (m_srcDataId != doc::NullId) {
     if (Cel* dstCel = m_dstLayer->cel(m_dstFrame))
-      m_api.m_linkedCels[m_srcDataId] = dstCel;
+      m_api.data()->linkedCels[m_srcDataId] = dstCel;
   }
 }
 
@@ -120,6 +120,13 @@ DocApi::DocApi(Doc* document, Transaction& transaction)
   : m_document(document)
   , m_transaction(transaction)
 {
+}
+
+DocApi::Data* DocApi::data()
+{
+  if (!m_data)
+    m_data = std::make_unique<Data>();
+  return m_data.get();
 }
 
 void DocApi::setSpriteSize(Sprite* sprite, int w, int h)
@@ -708,11 +715,32 @@ Layer* DocApi::copyLayerForSprite(doc::Layer* layer,
       // different sprite as its owner, then we must copy the tilesets of the
       // given tilemap layer into the new owner.
       if (sprite != srcTilemap->sprite() || (shareTilesets == ShareTilesets::No)) {
-        auto* srcTilesetCopy = Tileset::MakeCopyCopyingImagesForSprite(srcTilemap->tileset(),
-                                                                       sprite);
-        auto* addTileset = new cmd::AddTileset(sprite, srcTilesetCopy);
-        m_transaction.execute(addTileset);
-        tsi = addTileset->tilesetIndex();
+        if (data()->lastDuplicateSprite != sprite) {
+          data()->lastDuplicateSprite = sprite;
+          data()->mappedTilesets.clear();
+        }
+
+        const Tileset* srcTileset = srcTilemap->tileset();
+        auto it = data()->mappedTilesets.find(srcTileset->id());
+        if (it != data()->mappedTilesets.end()) {
+          tsi = it->second;
+        }
+        else {
+          Tileset* tilesetCopy = Tileset::MakeCopyCopyingImagesForSprite(srcTileset, sprite);
+
+          auto* addTileset = new cmd::AddTileset(sprite, tilesetCopy);
+          m_transaction.execute(addTileset);
+
+          tsi = addTileset->tilesetIndex();
+
+          // Cache duplicated tileset in case we are going to
+          // copyLayerForSprite() several times between different
+          // sprites. So can we match the same shared tilesets between
+          // the original sprite and the duplicated layers in the new
+          // sprite.
+          if (sprite != srcTilemap->sprite())
+            data()->mappedTilesets[srcTileset->id()] = tsi;
+        }
       }
 
       static_cast<LayerTilemap*>(clone.get())->setTilesetIndex(tsi);

--- a/src/app/doc_api.cpp
+++ b/src/app/doc_api.cpp
@@ -691,41 +691,40 @@ void DocApi::restackLayerBefore(Layer* layer, Layer* parent, Layer* beforeThis)
   restackLayerAfter(layer, parent, afterThis);
 }
 
-Layer* DocApi::copyLayerWithSprite(doc::Layer* layer, doc::Sprite* sprite)
+Layer* DocApi::copyLayerForSprite(doc::Layer* layer,
+                                  doc::Sprite* sprite,
+                                  const ShareTilesets shareTilesets)
 {
-  std::unique_ptr<doc::Layer> clone;
+  // Clone the original "layer" but with "sprite" as the owner (can be
+  // the same sprite).
+  std::unique_ptr<doc::Layer> clone(layer->clone(sprite));
 
   switch (layer->type()) {
-    case ObjectType::LayerImage:   clone = std::make_unique<LayerImage>(sprite); break;
-
-    case ObjectType::LayerGroup:   clone = std::make_unique<LayerGroup>(sprite); break;
-
     case ObjectType::LayerTilemap: {
-      auto* srcTilemap = static_cast<LayerTilemap*>(layer);
-      tileset_index tilesetIndex = srcTilemap->tilesetIndex();
+      auto* srcTilemap = static_cast<const LayerTilemap*>(layer);
+      tileset_index tsi = srcTilemap->tilesetIndex();
+
       // If the caller is trying to make a copy of a tilemap layer specifying a
       // different sprite as its owner, then we must copy the tilesets of the
       // given tilemap layer into the new owner.
-      if (sprite != srcTilemap->sprite()) {
+      if (sprite != srcTilemap->sprite() || (shareTilesets == ShareTilesets::No)) {
         auto* srcTilesetCopy = Tileset::MakeCopyCopyingImagesForSprite(srcTilemap->tileset(),
                                                                        sprite);
         auto* addTileset = new cmd::AddTileset(sprite, srcTilesetCopy);
         m_transaction.execute(addTileset);
-        tilesetIndex = addTileset->tilesetIndex();
+        tsi = addTileset->tilesetIndex();
       }
 
-      clone = std::make_unique<LayerTilemap>(sprite, tilesetIndex);
+      static_cast<LayerTilemap*>(clone.get())->setTilesetIndex(tsi);
       break;
     }
-
-    default: throw std::runtime_error("Invalid layer type");
   }
 
   if (auto* doc = dynamic_cast<app::Doc*>(sprite->document())) {
     LayerList children;
     doc->copyOneLayerContent(layer, doc, clone.get(), children);
     for (auto child : children) {
-      Layer* childClone = copyLayerWithSprite(child, sprite);
+      Layer* childClone = copyLayerForSprite(child, sprite, shareTilesets);
       if (childClone)
         clone->addLayer(childClone);
     }
@@ -737,10 +736,11 @@ Layer* DocApi::copyLayerWithSprite(doc::Layer* layer, doc::Sprite* sprite)
 Layer* DocApi::duplicateLayerAfter(Layer* sourceLayer,
                                    Layer* parent,
                                    Layer* afterLayer,
+                                   const ShareTilesets shareTilesets,
                                    const std::string& nameSuffix)
 {
   ASSERT(parent);
-  Layer* newLayerPtr = copyLayerWithSprite(sourceLayer, parent->sprite());
+  Layer* newLayerPtr = copyLayerForSprite(sourceLayer, parent->sprite(), shareTilesets);
 
   newLayerPtr->setName(Strings::general_copy_of(newLayerPtr->name()));
 
@@ -752,11 +752,12 @@ Layer* DocApi::duplicateLayerAfter(Layer* sourceLayer,
 Layer* DocApi::duplicateLayerBefore(Layer* sourceLayer,
                                     Layer* parent,
                                     Layer* beforeLayer,
+                                    const ShareTilesets shareTilesets,
                                     const std::string& nameSuffix)
 {
   ASSERT(parent);
   Layer* afterThis = (beforeLayer ? beforeLayer->getPreviousBrowsable() : nullptr);
-  Layer* newLayer = duplicateLayerAfter(sourceLayer, parent, afterThis);
+  Layer* newLayer = duplicateLayerAfter(sourceLayer, parent, afterThis, shareTilesets);
   if (newLayer)
     restackLayerBefore(newLayer, parent, beforeLayer);
   return newLayer;

--- a/src/app/doc_api.h
+++ b/src/app/doc_api.h
@@ -20,6 +20,7 @@
 #include "gfx/rect.h"
 
 #include <map>
+#include <memory>
 
 namespace doc {
 class Cel;
@@ -189,13 +190,24 @@ private:
 
   bool copyFromLinkedCels(Cel** srcCel, doc::ObjectId& srcDataId);
 
+  // Data for special operations.
+  struct Data {
+    // Map used in copyCel() to re-create the original set of linked
+    // cels from the src layers when we copy a block of cels.
+    // map: ObjectId of CelData -> Cel*
+    std::map<doc::ObjectId, doc::Cel*> linkedCels;
+
+    // Already duplicated tilesets to map source shared-tilesets when
+    // duplicating layers to other sprites.
+    doc::Sprite* lastDuplicateSprite = nullptr;
+    std::map<doc::ObjectId, doc::tileset_index> mappedTilesets;
+  };
+
+  Data* data();
+
   Doc* m_document;
   Transaction& m_transaction;
-
-  // Map used in copyCel() to re-create the original set of linked
-  // cels from the src layers when we copy a block of cels.
-  // map: ObjectId of CelData -> Cel*
-  std::map<doc::ObjectId, doc::Cel*> m_linkedCels;
+  std::unique_ptr<Data> m_data;
 };
 
 } // namespace app

--- a/src/app/doc_api.h
+++ b/src/app/doc_api.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2025  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -63,6 +63,10 @@ using namespace docapi;
 //
 class DocApi {
 public:
+  // When cloning layers, it indicates if we should share the tileset
+  // between the copy or create a new copy of the tileset.
+  enum class ShareTilesets { No, Yes };
+
   DocApi(Doc* document, Transaction& transaction);
 
   // Sprite API
@@ -122,11 +126,15 @@ public:
   Layer* duplicateLayerAfter(Layer* sourceLayer,
                              Layer* parent,
                              Layer* afterLayer,
-                             const std::string& nameSuffix = std::string());
+                             ShareTilesets shareTilesets,
+                             const std::string& nameSuffix = {});
   Layer* duplicateLayerBefore(Layer* sourceLayer,
                               Layer* parent,
                               Layer* beforeLayer,
-                              const std::string& nameSuffix = std::string());
+                              ShareTilesets shareTilesets,
+                              const std::string& nameSuffix = {});
+
+  Layer* copyLayerForSprite(doc::Layer* layer, doc::Sprite* sprite, ShareTilesets shareTilesets);
 
   // Images API
   void replaceImage(Sprite* sprite, const ImageRef& oldImage, const ImageRef& newImage);
@@ -160,8 +168,6 @@ private:
                   const frame_t delta,
                   const DropFramePlace dropFramePlace,
                   const TagsHandling tagsHandling);
-
-  Layer* copyLayerWithSprite(doc::Layer* layer, doc::Sprite* sprite);
 
   class HandleLinkedCels {
   public:

--- a/src/app/doc_api_dnd_helper.cpp
+++ b/src/app/doc_api_dnd_helper.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2025  Igara Studio S.A.
+// Copyright (C) 2025-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -129,10 +129,10 @@ void DocApi::dropDocumentsOnTimeline(app::Doc* destDoc,
     for (auto* srcLayer : srcDoc->sprite()->root()->layers()) {
       srcLayer->displaceFrames(0, frame);
       if (insert == InsertionPoint::AfterLayer) {
-        refLayer = duplicateLayerAfter(srcLayer, group, refLayer);
+        refLayer = duplicateLayerAfter(srcLayer, group, refLayer, DocApi::ShareTilesets::No);
       }
       else {
-        refLayer = duplicateLayerBefore(srcLayer, group, refLayer);
+        refLayer = duplicateLayerBefore(srcLayer, group, refLayer, DocApi::ShareTilesets::No);
         insert = InsertionPoint::AfterLayer;
       }
     }

--- a/src/app/doc_range_ops.cpp
+++ b/src/app/doc_range_ops.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2026  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -405,7 +405,11 @@ static DocRange drop_range_op(Doc* doc,
             if (place == kDocRangeBefore) {
               Layer* beforeThis = (!dstLayers.empty() ? dstLayers.front() : nullptr);
               for (Layer* srcLayer : srcLayers) {
-                Layer* copiedLayer = api.duplicateLayerBefore(srcLayer, parent, beforeThis);
+                Layer* copiedLayer = api.duplicateLayerBefore(
+                  srcLayer,
+                  parent,
+                  beforeThis,
+                  DocApi::ShareTilesets::No); // TODO configurable
 
                 resultRange.startRange(copiedLayer, -1, DocRange::kLayers);
                 resultRange.endRange(copiedLayer, -1);
@@ -416,7 +420,11 @@ static DocRange drop_range_op(Doc* doc,
 
               Layer* afterThis = (!dstLayers.empty() ? dstLayers.back() : nullptr);
               for (Layer* srcLayer : srcLayers) {
-                Layer* copiedLayer = api.duplicateLayerAfter(srcLayer, parent, afterThis);
+                Layer* copiedLayer = api.duplicateLayerAfter(
+                  srcLayer,
+                  parent,
+                  afterThis,
+                  DocApi::ShareTilesets::No); // TODO configurable
 
                 resultRange.startRange(copiedLayer, -1, DocRange::kLayers);
                 resultRange.endRange(copiedLayer, -1);

--- a/src/app/ui/editor/editor.cpp
+++ b/src/app/ui/editor/editor.cpp
@@ -2841,7 +2841,10 @@ void Editor::setZoomAndCenterInMouse(const Zoom& zoom,
   }
 }
 
-void Editor::pasteImage(const Image* image, const Mask* mask, const gfx::Point* position)
+void Editor::pasteImage(const Image* image,
+                        const Mask* mask,
+                        const gfx::Point* position,
+                        const Tileset* srcTileset)
 {
   ASSERT(image);
 
@@ -2932,6 +2935,10 @@ void Editor::pasteImage(const Image* image, const Mask* mask, const gfx::Point* 
 
   PixelsMovementPtr pixelsMovement(
     new PixelsMovement(UIContext::instance(), site, image, &mask2, "Paste", &m_tiledModeHelper));
+
+  // Adjust image when copying between tilemap layers
+  if (site.tilemapMode() == TilemapMode::Tiles && srcTileset != nullptr)
+    pixelsMovement->remapTilesForPaste(srcTileset);
 
   setState(EditorStatePtr(new MovingPixelsState(this, NULL, pixelsMovement, NoHandle)));
 }

--- a/src/app/ui/editor/editor.cpp
+++ b/src/app/ui/editor/editor.cpp
@@ -2850,7 +2850,10 @@ void Editor::setZoomAndCenterInMouse(const Zoom& zoom,
   }
 }
 
-void Editor::pasteImage(const Image* image, const Mask* mask, const gfx::Point* position)
+void Editor::pasteImage(const Image* image,
+                        const Mask* mask,
+                        const gfx::Point* position,
+                        const Tileset* srcTileset)
 {
   ASSERT(image);
 
@@ -2941,6 +2944,10 @@ void Editor::pasteImage(const Image* image, const Mask* mask, const gfx::Point* 
 
   PixelsMovementPtr pixelsMovement(
     new PixelsMovement(UIContext::instance(), site, image, &mask2, "Paste", &m_tiledModeHelper));
+
+  // Adjust image when copying between tilemap layers
+  if (site.tilemapMode() == TilemapMode::Tiles && srcTileset != nullptr)
+    pixelsMovement->remapTilesForPaste(srcTileset);
 
   setState(EditorStatePtr(new MovingPixelsState(this, NULL, pixelsMovement, NoHandle)));
 }

--- a/src/app/ui/editor/editor.h
+++ b/src/app/ui/editor/editor.h
@@ -245,7 +245,8 @@ public:
 
   void pasteImage(const Image* image,
                   const Mask* mask = nullptr,
-                  const gfx::Point* position = nullptr);
+                  const gfx::Point* position = nullptr,
+                  const Tileset* srcTileset = nullptr);
 
   void startSelectionTransformation(const gfx::Point& move, double angle);
   void startFlipTransformation(doc::algorithm::FlipType flipType);

--- a/src/app/ui/editor/pixels_movement.cpp
+++ b/src/app/ui/editor/pixels_movement.cpp
@@ -12,6 +12,7 @@
 #include "app/ui/editor/pixels_movement.h"
 
 #include "app/app.h"
+#include "app/cmd/add_tile.h"
 #include "app/cmd/clear_mask.h"
 #include "app/cmd/deselect_mask.h"
 #include "app/cmd/set_mask.h"
@@ -1390,6 +1391,39 @@ void PixelsMovement::drawTransformedTilemap(const Transformation& transformation
       draw_row(y, v, boxh);
   }
   draw_row(dst->height() - 1, src->height() - 1, 1);
+}
+
+void PixelsMovement::remapTilesForPaste(const Tileset* srcTileset)
+{
+  // Check that tile size matches before doing anything
+  LayerTilemap* dstLayer = static_cast<LayerTilemap*>(m_site.layer());
+  Tileset* dstTileset = dstLayer->tileset();
+  const doc::Grid& srcGrid = srcTileset->grid();
+  const doc::Grid& dstGrid = dstTileset->grid();
+  if (srcGrid.tileSize() != dstGrid.tileSize())
+    throw base::Exception("Tile size does not match.");
+
+  // Map source to destination
+  tile_index dstSz = dstTileset->size();
+  for (int y = 0; y < m_originalImage->height(); ++y) {
+    for (int x = 0; x < m_originalImage->width(); ++x) {
+      // Blank tile can be skipped
+      const color_t srcTi = m_originalImage->getPixel(x, y);
+      if (!srcTi)
+        continue;
+
+      // Add tile to destination if missing
+      tile_index dstTi;
+      const ImageRef t = srcTileset->get(srcTi);
+      if (!dstTileset->findTileIndex(t, dstTi)) {
+        m_tx(new cmd::AddTile(dstTileset, t, srcTileset->getTileData(srcTi)));
+        dstTi = dstSz++;
+      }
+
+      // Update tile index in image
+      m_originalImage->putPixel(x, y, dstTi);
+    }
+  }
 }
 
 void PixelsMovement::onPivotChange()

--- a/src/app/ui/editor/pixels_movement.h
+++ b/src/app/ui/editor/pixels_movement.h
@@ -132,6 +132,9 @@ public:
   const Transformation& getTransformation() const { return m_currentData; }
   void setTransformation(const Transformation& t);
 
+  // For copy/paste between tilemap layers
+  void remapTilesForPaste(const Tileset* srcTileset);
+
 private:
   void setTransformationBase(const Transformation& t);
   void adjustPivot();

--- a/src/app/ui/editor/pixels_movement.h
+++ b/src/app/ui/editor/pixels_movement.h
@@ -133,6 +133,9 @@ public:
   const Transformation& getTransformation() const { return m_currentData; }
   void setTransformation(const Transformation& t);
 
+  // For copy/paste between tilemap layers
+  void remapTilesForPaste(const Tileset* srcTileset);
+
 private:
   void setTransformationBase(const Transformation& t);
   void adjustPivot();

--- a/src/app/util/clipboard.cpp
+++ b/src/app/util/clipboard.cpp
@@ -11,6 +11,7 @@
 
 #include "app/app.h"
 #include "app/cmd/add_slice.h"
+#include "app/cmd/add_tileset.h"
 #include "app/cmd/clear_mask.h"
 #include "app/cmd/deselect_mask.h"
 #include "app/cmd/set_mask.h"
@@ -618,7 +619,10 @@ void Clipboard::paste(Context* ctx, const bool interactive, const gfx::Point* po
         // TODO add post-command parameters (issue #2324)
 
         // Change to MovingTilemapState
-        editor->pasteImage(m_data->tilemap.get(), m_data->mask.get(), position);
+        editor->pasteImage(m_data->tilemap.get(),
+                           m_data->mask.get(),
+                           position,
+                           m_data->tileset.get());
       }
       else {
         // TODO non-interactive version (for scripts)
@@ -790,7 +794,14 @@ void Clipboard::paste(Context* ctx, const bool interactive, const gfx::Point* po
               afterThis = dstSpr->root()->lastLayer();
 
             Layer* newLayer = nullptr;
-            if (srcLayer->isImage())
+            if (srcLayer->isTilemap()) {
+              Tileset* srcTileset = static_cast<LayerTilemap*>(srcLayer)->tileset();
+              Tileset* tilesetCopy = Tileset::MakeCopyCopyingImagesForSprite(srcTileset, dstSpr);
+              const tileset_index tsi = dstSpr->tilesets()->size();
+              tx(new cmd::AddTileset(dstSpr, tilesetCopy));
+              newLayer = new LayerTilemap(dstSpr, tsi);
+            }
+            else if (srcLayer->isImage())
               newLayer = new LayerImage(dstSpr);
             else if (srcLayer->isGroup())
               newLayer = new LayerGroup(dstSpr);

--- a/src/app/util/clipboard.cpp
+++ b/src/app/util/clipboard.cpp
@@ -786,31 +786,46 @@ void Clipboard::paste(Context* ctx, const bool interactive, const gfx::Point* po
           while (dstSpr->totalFrames() < maxFrame + 1)
             api.addEmptyFrame(dstSpr, dstSpr->totalFrames());
 
-          for (Layer* srcLayer : srcLayers) {
-            Layer* afterThis;
-            if (srcLayer->isBackground() && !dstDoc->sprite()->backgroundLayer())
-              afterThis = nullptr;
-            else
-              afterThis = dstSpr->root()->lastLayer();
+          std::vector<std::pair<Layer*, LayerList>> dstLayerAndSrcChildren;
+          dstLayerAndSrcChildren.push_back(std::make_pair(dstSpr->root(), srcLayers));
 
-            Layer* newLayer = nullptr;
-            if (srcLayer->isTilemap()) {
-              Tileset* srcTileset = static_cast<LayerTilemap*>(srcLayer)->tileset();
-              Tileset* tilesetCopy = Tileset::MakeCopyCopyingImagesForSprite(srcTileset, dstSpr);
-              const tileset_index tsi = dstSpr->tilesets()->size();
-              tx(new cmd::AddTileset(dstSpr, tilesetCopy));
-              newLayer = new LayerTilemap(dstSpr, tsi);
+          while (!dstLayerAndSrcChildren.empty()) {
+            auto kv = dstLayerAndSrcChildren.front();
+            dstLayerAndSrcChildren.erase(dstLayerAndSrcChildren.begin());
+            Layer* dstLayer = kv.first;
+
+            for (Layer* srcLayer : kv.second) {
+              Layer* afterThis;
+              if (srcLayer->isBackground() && !dstDoc->sprite()->backgroundLayer())
+                afterThis = nullptr;
+              else
+                afterThis = dstLayer->lastLayer();
+
+              Layer* newLayer = nullptr;
+              if (srcLayer->isTilemap()) {
+                Tileset* srcTileset = static_cast<LayerTilemap*>(srcLayer)->tileset();
+                Tileset* tilesetCopy = Tileset::MakeCopyCopyingImagesForSprite(srcTileset, dstSpr);
+
+                auto* addTileset = new cmd::AddTileset(dstSpr, tilesetCopy);
+                tx(addTileset);
+
+                const tileset_index tsi = addTileset->tilesetIndex();
+                newLayer = new LayerTilemap(dstSpr, tsi);
+              }
+              else if (srcLayer->isImage())
+                newLayer = new LayerImage(dstSpr);
+              else if (srcLayer->isGroup())
+                newLayer = new LayerGroup(dstSpr);
+              else
+                continue;
+
+              api.addLayer(dstLayer, newLayer, afterThis);
+
+              LayerList children;
+              srcDoc->copyOneLayerContent(srcLayer, dstDoc, newLayer, children);
+              if (!children.empty())
+                dstLayerAndSrcChildren.emplace_back(newLayer, children);
             }
-            else if (srcLayer->isImage())
-              newLayer = new LayerImage(dstSpr);
-            else if (srcLayer->isGroup())
-              newLayer = new LayerGroup(dstSpr);
-            else
-              continue;
-
-            api.addLayer(dstSpr->root(), newLayer, afterThis);
-
-            srcDoc->copyLayerContent(srcLayer, dstDoc, newLayer);
           }
 
           tx.commit();

--- a/src/app/util/clipboard.cpp
+++ b/src/app/util/clipboard.cpp
@@ -773,59 +773,33 @@ void Clipboard::paste(Context* ctx, const bool interactive, const gfx::Point* po
           srcLayersSet.removeChildrenIfParentIsSelected();
           LayerList srcLayers = srcLayersSet.toBrowsableLayerList();
 
-          // Expand frames of dstDoc if it's needed.
-          frame_t maxFrame = 0;
+          Layer* dstLayer = dstSpr->root();
           for (Layer* srcLayer : srcLayers) {
-            if (!srcLayer->isImage())
-              continue;
-
-            Cel* lastCel = static_cast<LayerImage*>(srcLayer)->getLastCel();
-            if (lastCel && maxFrame < lastCel->frame())
-              maxFrame = lastCel->frame();
-          }
-          while (dstSpr->totalFrames() < maxFrame + 1)
-            api.addEmptyFrame(dstSpr, dstSpr->totalFrames());
-
-          std::vector<std::pair<Layer*, LayerList>> dstLayerAndSrcChildren;
-          dstLayerAndSrcChildren.push_back(std::make_pair(dstSpr->root(), srcLayers));
-
-          while (!dstLayerAndSrcChildren.empty()) {
-            auto kv = dstLayerAndSrcChildren.front();
-            dstLayerAndSrcChildren.erase(dstLayerAndSrcChildren.begin());
-            Layer* dstLayer = kv.first;
-
-            for (Layer* srcLayer : kv.second) {
-              Layer* afterThis;
-              if (srcLayer->isBackground() && !dstDoc->sprite()->backgroundLayer())
-                afterThis = nullptr;
-              else
-                afterThis = dstLayer->lastLayer();
-
-              Layer* newLayer = nullptr;
-              if (srcLayer->isTilemap()) {
-                Tileset* srcTileset = static_cast<LayerTilemap*>(srcLayer)->tileset();
-                Tileset* tilesetCopy = Tileset::MakeCopyCopyingImagesForSprite(srcTileset, dstSpr);
-
-                auto* addTileset = new cmd::AddTileset(dstSpr, tilesetCopy);
-                tx(addTileset);
-
-                const tileset_index tsi = addTileset->tilesetIndex();
-                newLayer = new LayerTilemap(dstSpr, tsi);
-              }
-              else if (srcLayer->isImage())
-                newLayer = new LayerImage(dstSpr);
-              else if (srcLayer->isGroup())
-                newLayer = new LayerGroup(dstSpr);
-              else
+            // Expand frames of dstDoc if it's needed.
+            frame_t maxFrame = 0;
+            for (Layer* srcLayer : srcLayers) {
+              if (!srcLayer->isImage())
                 continue;
 
-              api.addLayer(dstLayer, newLayer, afterThis);
-
-              LayerList children;
-              srcDoc->copyOneLayerContent(srcLayer, dstDoc, newLayer, children);
-              if (!children.empty())
-                dstLayerAndSrcChildren.emplace_back(newLayer, children);
+              Cel* lastCel = static_cast<LayerImage*>(srcLayer)->getLastCel();
+              if (lastCel && maxFrame < lastCel->frame())
+                maxFrame = lastCel->frame();
             }
+            while (dstSpr->totalFrames() < maxFrame + 1)
+              api.addEmptyFrame(dstSpr, dstSpr->totalFrames());
+
+            // Copy layer
+            Layer* afterThis;
+            if (srcLayer->isBackground() && !dstDoc->sprite()->backgroundLayer())
+              afterThis = nullptr;
+            else
+              afterThis = dstLayer->lastLayer();
+
+            Layer* newLayer = api.copyLayerForSprite(srcLayer,
+                                                     dstSpr,
+                                                     // TODO configurable
+                                                     DocApi::ShareTilesets::No);
+            api.addLayer(dstLayer, newLayer, afterThis);
           }
 
           tx.commit();

--- a/src/doc/layer.h
+++ b/src/doc/layer.h
@@ -1,5 +1,5 @@
 // Aseprite Document Library
-// Copyright (C) 2019-2026  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -65,6 +65,7 @@ public:
   Layer& operator=(const Layer& other) = delete;
 
   virtual ~Layer();
+  virtual Layer* clone(Sprite* sprite) const = 0;
 
   int getMemSize() const override;
   void suspendObject() override;
@@ -233,6 +234,7 @@ public:
   LayerImage(ObjectType type, Sprite* sprite);
   explicit LayerImage(Sprite* sprite);
   virtual ~LayerImage();
+  LayerImage* clone(Sprite* sprite) const override { return new LayerImage(sprite); }
 
   void configureAsBackground();
 };
@@ -244,6 +246,7 @@ class LayerGroup final : public Layer {
 public:
   explicit LayerGroup(Sprite* sprite);
   virtual ~LayerGroup();
+  LayerGroup* clone(Sprite* sprite) const override { return new LayerGroup(sprite); }
 };
 
 } // namespace doc

--- a/src/doc/layer_tilemap.h
+++ b/src/doc/layer_tilemap.h
@@ -1,5 +1,5 @@
 // Aseprite Document Library
-// Copyright (c) 2019-2025  Igara Studio S.A.
+// Copyright (c) 2019-present  Igara Studio S.A.
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -19,6 +19,10 @@ class LayerTilemap final : public LayerImage {
 public:
   LayerTilemap(Sprite* sprite, tileset_index tsi);
   ~LayerTilemap();
+
+  // Clone layer without tileset index (as the "sprite" argument might
+  // be different to this->sprite()).
+  LayerTilemap* clone(Sprite* sprite) const override { return new LayerTilemap(sprite, 0); }
 
   Grid grid() const override;
 


### PR DESCRIPTION
- [x] rebased #5299 
- [x] copy full tilemap layer -> paste into a new sprite
- [ ] copy tiles from tilemap -> paste to regular layer
- [ ] copy tiles between tilemaps of different tile sizes
- [ ] solve copy & paste tilemap (copies tileset) vs duplicate tilemap layer (share tileset) difference (from [this comment](https://github.com/aseprite/aseprite/pull/5299#issuecomment-3356518100))
