### PR TITLE
Improve "Recover Files" UI (related issues #4130, #5513)

### DIFF
--- a/data/strings/en.ini
+++ b/data/strings/en.ini
@@ -1743,9 +1743,12 @@ refresh = Refresh
 raw_images_as_frames = Raw Images as Frames
 raw_images_as_layers = Raw Images as Layers
 loading = Loading...
+active_session = Active Session
 crash_sessions = Crashed Sessions
 old_sessions = Previous Sessions
 incompatible = [MIGHT BE INCOMPATIBLE v{1}] {0}
+no_closed_docs = When you close a file it will appear here
+in_memory = in memory
 
 [replace_color]
 title = Replace Color

--- a/data/strings/en.ini
+++ b/data/strings/en.ini
@@ -1747,8 +1747,9 @@ active_session = Active Session
 crash_sessions = Crashed Sessions
 old_sessions = Previous Sessions
 incompatible = [MIGHT BE INCOMPATIBLE v{1}] {0}
-no_closed_docs = When you close a file it will appear here
-in_memory = in memory
+no_closed_docs = Closed files and backups appear here
+in_memory = {} (in memory)
+on_disk = {} (on disk)
 
 [replace_color]
 title = Replace Color

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -129,6 +129,7 @@ if(ENABLE_DATA_RECOVERY)
   target_sources(app-lib PRIVATE
     crash/backup_observer.cpp
     crash/data_recovery.cpp
+    crash/document_info.cpp
     crash/read_document.cpp
     crash/session.cpp
     crash/write_document.cpp

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2025  Igara Studio S.A.
+// Copyright (C) 2018-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -18,6 +18,7 @@
 #include "app/cli/cli_processor.h"
 #include "app/cli/default_cli_delegate.h"
 #include "app/cli/preview_cli_delegate.h"
+#include "app/closed_docs.h"
 #include "app/color_spaces.h"
 #include "app/color_utils.h"
 #include "app/commands/commands.h"
@@ -416,7 +417,7 @@ struct DeleteAllDocs {
     // Add all documents that were closed in the past, these docs
     // are not part of any context and they are just temporarily in
     // memory just in case the user wants to recover them.
-    for (Doc* doc : static_cast<UIContext*>(m_ctx)->getAndRemoveAllClosedDocs())
+    for (Doc* doc : static_cast<UIContext*>(m_ctx)->closedDocs().getAndRemoveAllClosedDocs())
       docs.push_back(doc);
 
     // Add documents that are currently opened/in tabs/in the

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -556,6 +556,9 @@ void App::run(const bool runGuiManager)
     // Select no document
     static_cast<UIContext*>(context())->setActiveView(nullptr);
 
+    // Close "Recover Files" tab before deleting all the DataRecovery stuff.
+    m_mainWindow->closeDataRecoveryView();
+
     // Delete backups (this is a normal shutdown, we are not handling
     // exceptions, and we are not in a destructor).
     m_modules->deleteDataRecovery();

--- a/src/app/closed_docs.cpp
+++ b/src/app/closed_docs.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2023  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -12,11 +12,12 @@
 #include "app/doc.h"
 #include "app/pref/preferences.h"
 #include "base/thread.h"
+#include "ui/system.h"
 
 #include <algorithm>
 #include <limits>
 
-#define CLOSEDOC_TRACE(...) // TRACEARGS
+#define CLOSEDOC_TRACE(...) // TRACEARGS(__VA_ARGS__)
 
 namespace app {
 
@@ -80,14 +81,19 @@ void ClosedDocs::addClosedDoc(Doc* doc)
   ASSERT(doc->context() == nullptr);
 
   ClosedDoc closedDoc = { doc, base::current_tick() };
+  ObjectId docId = doc->id();
 
-  std::unique_lock<std::mutex> lock(m_mutex);
-  m_docs.insert(m_docs.begin(), std::move(closedDoc));
+  {
+    std::unique_lock<std::mutex> lock(m_mutex);
+    m_docs.insert(m_docs.begin(), std::move(closedDoc));
 
-  if (!m_thread.joinable())
-    m_thread = std::thread([this] { backgroundThread(); });
-  else
-    m_cv.notify_one();
+    if (!m_thread.joinable())
+      m_thread = std::thread([this] { backgroundThread(); });
+    else
+      m_cv.notify_one();
+  }
+
+  notify_observers(&ClosedDocsObserver::onNewClosedDoc, docId);
 }
 
 Doc* ClosedDocs::reopenLastClosedDoc()
@@ -102,7 +108,39 @@ Doc* ClosedDocs::reopenLastClosedDoc()
     CLOSEDOC_TRACE(" -> ", doc);
   }
   CLOSEDOC_TRACE("CLOSEDOC: Reopen last closed doc", doc);
+  if (doc)
+    notify_observers(&ClosedDocsObserver::onReopenClosedDoc, doc->id());
   return doc;
+}
+
+Doc* ClosedDocs::reopenClosedDocById(const doc::ObjectId docId)
+{
+  Doc* doc = nullptr;
+  {
+    std::unique_lock<std::mutex> lock(m_mutex);
+    for (auto it = m_docs.begin(), end = m_docs.end(); it != end; ++it) {
+      if (it->doc && it->doc->id() == docId) {
+        doc = it->doc;
+        m_docs.erase(it);
+        break;
+      }
+    }
+  }
+  CLOSEDOC_TRACE("CLOSEDOC: Reopen specific closed doc", doc);
+  if (doc)
+    notify_observers(&ClosedDocsObserver::onReopenClosedDoc, doc->id());
+  return doc;
+}
+
+std::vector<crash::DocumentInfo> ClosedDocs::getClosedDocInfos()
+{
+  std::vector<crash::DocumentInfo> infos;
+  {
+    std::unique_lock<std::mutex> lock(m_mutex);
+    for (const ClosedDoc& closedDoc : m_docs)
+      infos.push_back(crash::DocumentInfo(closedDoc.doc));
+  }
+  return infos;
 }
 
 std::vector<Doc*> ClosedDocs::getAndRemoveAllClosedDocs()
@@ -142,17 +180,24 @@ void ClosedDocs::backgroundThread()
 
       base::tick_t diff = now - closedDoc.timestamp;
       if (diff >= m_keepClosedDocAliveForMSecs) {
-        if ( // If we backup process is disabled
+        if ( // If the backup process is disabled
           m_dataRecoveryPeriodMSecs == 0 ||
           // Or this document doesn't need a backup (e.g. an unmodified document)
           !doc->needsBackup() ||
           // Or the document already has the backup done
           doc->isFullyBackedUp()) {
+          const bool backedup = (doc->needsBackup() && doc->isFullyBackedUp());
+
           // Finally delete the document (this is the place where we
           // delete all documents created/loaded by the user)
           CLOSEDOC_TRACE("CLOSEDOC: [BG] Delete doc", doc);
+          const doc::ObjectId docId = doc->id();
           delete doc;
           it = m_docs.erase(it);
+
+          ui::execute_from_ui_thread([this, docId, backedup] {
+            notify_observers(&ClosedDocsObserver::onArchiveClosedDoc, docId, backedup);
+          });
         }
         else {
           waitForMSecs = std::min(waitForMSecs, m_dataRecoveryPeriodMSecs);

--- a/src/app/closed_docs.cpp
+++ b/src/app/closed_docs.cpp
@@ -132,9 +132,9 @@ Doc* ClosedDocs::reopenClosedDocById(const doc::ObjectId docId)
   return doc;
 }
 
-std::vector<crash::DocumentInfo> ClosedDocs::getClosedDocInfos()
+crash::DocumentInfos ClosedDocs::getClosedDocInfos()
 {
-  std::vector<crash::DocumentInfo> infos;
+  crash::DocumentInfos infos;
   {
     std::unique_lock<std::mutex> lock(m_mutex);
     for (const ClosedDoc& closedDoc : m_docs)

--- a/src/app/closed_docs.h
+++ b/src/app/closed_docs.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2020  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -8,7 +8,10 @@
 #define APP_CLOSED_DOCS_H_INCLUDED
 #pragma once
 
+#include "app/crash/document_info.h"
 #include "base/time.h"
+#include "doc/object_id.h"
+#include "obs/observable.h"
 
 #include <atomic>
 #include <condition_variable>
@@ -21,6 +24,14 @@ namespace app {
 class Doc;
 class Preferences;
 
+class ClosedDocsObserver {
+public:
+  virtual ~ClosedDocsObserver() {}
+  virtual void onNewClosedDoc(const doc::ObjectId docId) {}
+  virtual void onReopenClosedDoc(const doc::ObjectId docId) {}
+  virtual void onArchiveClosedDoc(const doc::ObjectId docId, const bool backedup) {}
+};
+
 // Handle the list of closed docs:
 // * When a document is closed, we keep it for some time so the user
 //   can undo the close command without losing the undo history.
@@ -29,7 +40,7 @@ class Preferences;
 //   garbage collector).
 // * If the document was not restore, we delete it from memory, if
 //   the document was restore, we remove it from the m_docs.
-class ClosedDocs {
+class ClosedDocs : public obs::observable<ClosedDocsObserver> {
 public:
   ClosedDocs(const Preferences& pref);
   ~ClosedDocs();
@@ -37,10 +48,15 @@ public:
   bool hasClosedDocs();
   void addClosedDoc(Doc* doc);
   Doc* reopenLastClosedDoc();
+  Doc* reopenClosedDocById(const doc::ObjectId docId);
 
   // Called at the very end to get all closed docs, remove them from
   // the list of closed docs, and stop the thread.
   std::vector<Doc*> getAndRemoveAllClosedDocs();
+
+  // Returns the info of closed docs (used for the "Recover Files"
+  // view).
+  std::vector<crash::DocumentInfo> getClosedDocInfos();
 
 private:
   void backgroundThread();

--- a/src/app/closed_docs.h
+++ b/src/app/closed_docs.h
@@ -56,7 +56,7 @@ public:
 
   // Returns the info of closed docs (used for the "Recover Files"
   // view).
-  std::vector<crash::DocumentInfo> getClosedDocInfos();
+  crash::DocumentInfos getClosedDocInfos();
 
 private:
   void backgroundThread();

--- a/src/app/commands/cmd_reopen_closed_file.cpp
+++ b/src/app/commands/cmd_reopen_closed_file.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -8,6 +8,7 @@
   #include "config.h"
 #endif
 
+#include "app/closed_docs.h"
 #include "app/commands/command.h"
 #include "app/commands/commands.h"
 #include "app/ui_context.h"
@@ -30,7 +31,7 @@ ReopenClosedFileCommand::ReopenClosedFileCommand() : Command(CommandId::ReopenCl
 bool ReopenClosedFileCommand::onEnabled(Context* ctx)
 {
   if (auto uiCtx = dynamic_cast<UIContext*>(ctx)) {
-    return uiCtx->hasClosedDocs();
+    return uiCtx->closedDocs().hasClosedDocs();
   }
   return false;
 }

--- a/src/app/context_observer.h
+++ b/src/app/context_observer.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (c) 2026-present  Igara Studio S.A.
 // Copyright (c) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -16,8 +17,8 @@ class Site;
 class ContextObserver {
 public:
   virtual ~ContextObserver() {}
-  virtual void onActiveSiteChange(const Site& site) {};
-  virtual void onBeforeActiveSiteChange(const Site& fromSite) {};
+  virtual void onActiveSiteChange(const Site& site) {}
+  virtual void onBeforeActiveSiteChange(const Site& fromSite) {}
 };
 
 } // namespace app

--- a/src/app/crash/backup_observer.cpp
+++ b/src/app/crash/backup_observer.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2023  Igara Studio S.A.
+// Copyright (C) 2018-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -20,6 +20,7 @@
 
 #include "app/app.h"
 #include "app/context.h"
+#include "app/crash/data_recovery.h"
 #include "app/crash/log.h"
 #include "app/crash/recovery_config.h"
 #include "app/crash/session.h"
@@ -182,20 +183,21 @@ void BackupObserver::backgroundThread()
 // Executed from the backgroundThread() (non-UI thread)
 bool BackupObserver::saveDocData(Doc* doc)
 {
+  const ObjectId docId = doc->id();
   try {
     if (!doc->needsBackup())
       return true;
 
     if (doc->inhibitBackup()) {
-      RECO_TRACE("RECO: Document '%d' backup is temporarily inhibited\n", doc->id());
+      RECO_TRACE("RECO: Document '%d' backup is temporarily inhibited\n", docId);
     }
     else if (!m_session->saveDocumentChanges(doc)) {
-      RECO_TRACE("RECO: Document '%d' backup was canceled by UI\n", doc->id());
+      RECO_TRACE("RECO: Document '%d' backup was canceled by UI\n", docId);
     }
     else {
 #ifdef TEST_BACKUP_INTEGRITY
       DocReader reader(doc, 500);
-      std::unique_ptr<Doc> copy(m_session->restoreBackupDocById(doc->id(), nullptr));
+      std::unique_ptr<Doc> copy(m_session->restoreBackupDocById(docId, nullptr));
       DocDiff diff = compare_docs(doc, copy.get());
       if (diff.anything) {
         RECO_TRACE("RECO: Differences: %s %s %s %s %s %s %s %s %s %s %s\n",
@@ -218,11 +220,17 @@ bool BackupObserver::saveDocData(Doc* doc)
         RECO_TRACE("RECO: No differences\n");
       }
 #endif
+      Session* session = m_session;
+      ui::execute_from_ui_thread([session, docId] {
+        session->addBackupItem(docId);
+        if (App* app = App::instance())
+          app->dataRecovery()->BackupDone(docId);
+      });
       return true;
     }
   }
   catch (const std::exception&) {
-    RECO_TRACE("RECO: Document '%d' is locked\n", doc->id());
+    RECO_TRACE("RECO: Document '%d' is locked\n", docId);
   }
   return false;
 }

--- a/src/app/crash/data_recovery.cpp
+++ b/src/app/crash/data_recovery.cpp
@@ -139,7 +139,7 @@ DataRecovery::Sessions DataRecovery::sessions()
   return copy;
 }
 
-bool DataRecovery::isRunningSession(const SessionPtr& session) const
+bool DataRecovery::isRunningSession(const Session* session) const
 {
   ASSERT(session);
   ASSERT(m_inProgress);
@@ -157,7 +157,7 @@ void DataRecovery::searchForSessions()
     RECO_TRACE("RECO: Session '%s' ", itempath.c_str());
 
     SessionPtr session(new Session(&m_config, itempath));
-    if (!isRunningSession(session)) {
+    if (!isRunningSession(session.get())) {
       if ((session->isEmpty()) || (!session->isCrashedSession() && session->isOldSession())) {
         RECO_TRACE("to be deleted (%s)\n",
                    session->isEmpty() ? "is empty" :

--- a/src/app/crash/data_recovery.cpp
+++ b/src/app/crash/data_recovery.cpp
@@ -74,7 +74,7 @@ DataRecovery::DataRecovery(Context* ctx)
     }
   } while (newSessionDir.empty());
 
-  m_inProgress.reset(new Session(&m_config, newSessionDir));
+  m_inProgress.reset(new Session(&m_config, newSessionDir, true));
   m_inProgress->create(pid);
   RECO_TRACE("RECO: Session in progress '%s'\n", newSessionDir.c_str());
 
@@ -139,13 +139,6 @@ DataRecovery::Sessions DataRecovery::sessions()
   return copy;
 }
 
-bool DataRecovery::isRunningSession(const Session* session) const
-{
-  ASSERT(session);
-  ASSERT(m_inProgress);
-  return session->path() == m_inProgress->path();
-}
-
 void DataRecovery::searchForSessions()
 {
   Sessions sessions;
@@ -156,8 +149,9 @@ void DataRecovery::searchForSessions()
     const auto& itempath = base::join_path(m_sessionsDir, itemname);
     RECO_TRACE("RECO: Session '%s' ", itempath.c_str());
 
-    SessionPtr session(new Session(&m_config, itempath));
-    if (!isRunningSession(session.get())) {
+    const bool isRunningSession = (itempath == m_inProgress->path());
+    if (!isRunningSession) {
+      auto session = std::make_shared<Session>(&m_config, itempath, false);
       if ((session->isEmpty()) || (!session->isCrashedSession() && session->isOldSession())) {
         RECO_TRACE("to be deleted (%s)\n",
                    session->isEmpty() ? "is empty" :

--- a/src/app/crash/data_recovery.h
+++ b/src/app/crash/data_recovery.h
@@ -45,7 +45,7 @@ public:
   // Returns a copy of the list of sessions that can be recovered.
   Sessions sessions();
 
-  bool isRunningSession(const SessionPtr& session) const;
+  bool isRunningSession(const Session* session) const;
 
   // Triggered in the UI-thread from the m_thread using an
   // ui::execute_from_ui_thread() when the list of sessions is ready

--- a/src/app/crash/data_recovery.h
+++ b/src/app/crash/data_recovery.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2025  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -26,7 +26,7 @@ class BackupObserver;
 
 class DataRecovery {
 public:
-  typedef std::vector<SessionPtr> Sessions;
+  using Sessions = std::vector<SessionPtr>;
 
   DataRecovery(Context* context);
   ~DataRecovery();
@@ -40,17 +40,18 @@ public:
   // recover (i.e. a crashed session were changes weren't saved)
   bool hasRecoverySessions() const;
 
-  Session* activeSession() { return m_inProgress.get(); }
+  SessionPtr activeSession() { return m_inProgress; }
 
   // Returns a copy of the list of sessions that can be recovered.
   Sessions sessions();
-
-  bool isRunningSession(const Session* session) const;
 
   // Triggered in the UI-thread from the m_thread using an
   // ui::execute_from_ui_thread() when the list of sessions is ready
   // to be used.
   obs::signal<void()> SessionsListIsReady;
+
+  // Trigerred when a Doc is fully backed up in the active running session.
+  obs::signal<void(doc::ObjectId)> BackupDone;
 
 private:
   // Executed from m_thread to search for the list of sessions.

--- a/src/app/crash/document_info.cpp
+++ b/src/app/crash/document_info.cpp
@@ -1,0 +1,48 @@
+// Aseprite
+// Copyright (c) 2026-present Igara Studio S.A.
+//
+// This program is distributed under the terms of
+// the End-User License Agreement for Aseprite.
+
+#ifdef HAVE_CONFIG_H
+  #include "config.h"
+#endif
+
+#include "app/crash/document_info.h"
+
+#include "app/doc.h"
+#include "base/fs.h"
+#include "doc/sprite.h"
+#include "fmt/format.h"
+
+namespace app::crash {
+
+using namespace doc;
+
+DocumentInfo::DocumentInfo(const Doc* doc)
+{
+  const doc::Sprite* sprite = doc->sprite();
+  docId = doc->id();
+  mode = sprite->colorMode();
+  width = sprite->width();
+  height = sprite->height();
+  frames = sprite->totalFrames();
+  filename = doc->filename();
+}
+
+std::string DocumentInfo::toString(bool withFullPath) const
+{
+  return fmt::format("{} Sprite {}x{}, {} {}: {}",
+                     mode == ColorMode::RGB       ? "RGB" :
+                     mode == ColorMode::GRAYSCALE ? "Grayscale" :
+                     mode == ColorMode::INDEXED   ? "Indexed" :
+                     mode == ColorMode::BITMAP    ? "Bitmap" :
+                                                    "Unknown",
+                     width,
+                     height,
+                     frames,
+                     frames == 1 ? "frame" : "frames",
+                     withFullPath ? filename : base::get_file_name(filename));
+}
+
+} // namespace app::crash

--- a/src/app/crash/document_info.h
+++ b/src/app/crash/document_info.h
@@ -1,0 +1,38 @@
+// Aseprite
+// Copyright (c) 2026-present Igara Studio S.A.
+//
+// This program is distributed under the terms of
+// the End-User License Agreement for Aseprite.
+
+#ifndef APP_CRASH_DOCUMENT_INFO_H_INCLUDED
+#define APP_CRASH_DOCUMENT_INFO_H_INCLUDED
+#pragma once
+
+#include "doc/color_mode.h"
+#include "doc/frame.h"
+#include "doc/object_id.h"
+
+#include <string>
+
+namespace app {
+class Doc;
+namespace crash {
+
+struct DocumentInfo {
+  doc::ObjectId docId;
+  doc::ColorMode mode;
+  int width;
+  int height;
+  doc::frame_t frames;
+  std::string filename;
+
+  DocumentInfo() : mode(doc::ColorMode::RGB), width(0), height(0), frames(0) {}
+  explicit DocumentInfo(const Doc* doc);
+
+  std::string toString(bool withFullPath) const;
+};
+
+} // namespace crash
+} // namespace app
+
+#endif

--- a/src/app/crash/document_info.h
+++ b/src/app/crash/document_info.h
@@ -13,13 +13,14 @@
 #include "doc/object_id.h"
 
 #include <string>
+#include <vector>
 
 namespace app {
 class Doc;
 namespace crash {
 
 struct DocumentInfo {
-  doc::ObjectId docId;
+  doc::ObjectId docId = doc::NullId;
   doc::ColorMode mode;
   int width;
   int height;
@@ -29,8 +30,12 @@ struct DocumentInfo {
   DocumentInfo() : mode(doc::ColorMode::RGB), width(0), height(0), frames(0) {}
   explicit DocumentInfo(const Doc* doc);
 
+  bool isEmpty() const { return docId == doc::NullId; }
+
   std::string toString(bool withFullPath) const;
 };
+
+using DocumentInfos = std::vector<DocumentInfo>;
 
 } // namespace crash
 } // namespace app

--- a/src/app/crash/read_document.cpp
+++ b/src/app/crash/read_document.cpp
@@ -127,6 +127,7 @@ public:
 
   bool loadDocumentInfo(DocumentInfo& info)
   {
+    info.docId = m_docId;
     m_loadInfo = &info;
     return loadObject<Doc*>("doc", m_docId, &Reader::readDocument) == (Doc*)1;
   }

--- a/src/app/crash/read_document.h
+++ b/src/app/crash/read_document.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (c) 2018-2019 Igara Studio S.A.
+// Copyright (c) 2018-present Igara Studio S.A.
 // Copyright (C) 2001-2016  David Capello
 //
 // This program is distributed under the terms of
@@ -9,6 +9,7 @@
 #define APP_CRASH_READ_DOCUMENT_H_INCLUDED
 #pragma once
 
+#include "app/crash/document_info.h"
 #include "app/crash/raw_images_as.h"
 #include "base/task.h"
 #include "doc/color_mode.h"
@@ -19,16 +20,6 @@
 namespace app {
 class Doc;
 namespace crash {
-
-struct DocumentInfo {
-  doc::ColorMode mode;
-  int width;
-  int height;
-  doc::frame_t frames;
-  std::string filename;
-
-  DocumentInfo() : mode(doc::ColorMode::RGB), width(0), height(0), frames(0) {}
-};
 
 bool read_document_info(const std::string& dir, DocumentInfo& info);
 Doc* read_document(const std::string& dir, base::task_token* t);

--- a/src/app/crash/session.cpp
+++ b/src/app/crash/session.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2025  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -52,19 +52,9 @@ std::string Session::Backup::description(const bool withFullPath) const
   if (m_desc.empty()) {
     DocumentInfo info;
     read_document_info(m_dir, info);
-    m_fn = info.filename;
-    m_desc = fmt::format("{} Sprite {}x{}, {} {}",
-                         info.mode == ColorMode::RGB       ? "RGB" :
-                         info.mode == ColorMode::GRAYSCALE ? "Grayscale" :
-                         info.mode == ColorMode::INDEXED   ? "Indexed" :
-                         info.mode == ColorMode::BITMAP    ? "Bitmap" :
-                                                             "Unknown",
-                         info.width,
-                         info.height,
-                         info.frames,
-                         info.frames == 1 ? "frame" : "frames");
+    m_desc = info.toString(withFullPath);
   }
-  return fmt::format("{}: {}", m_desc, withFullPath ? m_fn : base::get_file_name(m_fn));
+  return m_desc;
 }
 
 Session::Session(RecoveryConfig* config, const std::string& path)
@@ -93,13 +83,17 @@ std::string Session::name() const
       parts[1].insert(4, 1, '.');
       parts[1].insert(2, 1, ':');
     }
-    return "Session date: " + parts[0] + " time: " + parts[1] + " (PID " + parts[2] + ")";
+    return fmt::format("Session date: {} time: {} (PID {}{})",
+                       parts[0],
+                       parts[1],
+                       parts[2],
+                       isCrashedSession() ? " CRASHED" : "");
   }
-  else
-    return name;
+
+  return name;
 }
 
-std::string Session::version()
+std::string Session::version() const
 {
   if (m_version.empty()) {
     std::string verfile = verFilename();
@@ -126,7 +120,13 @@ const Session::Backups& Session::backups()
   return m_backups;
 }
 
-bool Session::isCrashedSession()
+const Session::Backups& Session::reloadBackups()
+{
+  m_backups.clear();
+  return Session::backups();
+}
+
+bool Session::isCrashedSession() const
 {
   loadPid();
   return (m_pid != 0);
@@ -345,7 +345,7 @@ void Session::deleteBackup(const BackupPtr& backup)
     deleteDirectory(backup->dir());
 }
 
-void Session::loadPid()
+void Session::loadPid() const
 {
   if (m_pid)
     return;

--- a/src/app/crash/session.cpp
+++ b/src/app/crash/session.cpp
@@ -46,21 +46,19 @@ Session::Backup::Backup(const std::string& dir) : m_dir(dir)
 {
 }
 
-std::string Session::Backup::description(const bool withFullPath) const
+DocumentInfo Session::Backup::info() const
 {
-  // Lazy initialize description and filename.
-  if (m_desc.empty()) {
-    DocumentInfo info;
-    read_document_info(m_dir, info);
-    m_desc = info.toString(withFullPath);
-  }
-  return m_desc;
+  // Lazy initialize document info.
+  if (m_info.isEmpty())
+    read_document_info(m_dir, m_info);
+  return m_info;
 }
 
-Session::Session(RecoveryConfig* config, const std::string& path)
+Session::Session(RecoveryConfig* config, const std::string& path, const bool isActive)
   : m_pid(0)
   , m_path(path)
   , m_config(config)
+  , m_isActive(isActive)
 {
 }
 
@@ -245,7 +243,8 @@ bool Session::saveDocumentChanges(Doc* doc)
     return false;
 
   app::Context ctx;
-  std::string dir = base::join_path(m_path, base::convert_to<std::string>(doc->id()));
+  std::string dir = docBackupDir(doc->id());
+
   RECO_TRACE("RECO: Saving document '%s'...\n", dir.c_str());
 
   // Create directory for document
@@ -276,6 +275,20 @@ void Session::removeDocument(Doc* doc)
   catch (const std::exception& ex) {
     LOG(FATAL, "Exception deleting document %s\n", ex.what());
   }
+}
+
+void Session::addBackupItem(const doc::ObjectId docId)
+{
+  auto it = std::find_if(m_backups.begin(), m_backups.end(), [docId](const BackupPtr& b) {
+    return b->info().docId == docId;
+  });
+  if (it == m_backups.end())
+    m_backups.push_back(std::make_shared<Backup>(docBackupDir(docId)));
+}
+
+std::string Session::docBackupDir(doc::ObjectId docId)
+{
+  return base::join_path(m_path, base::convert_to<std::string>(docId));
 }
 
 Doc* Session::restoreBackupDoc(const std::string& backupDir, base::task_token* t)

--- a/src/app/crash/session.h
+++ b/src/app/crash/session.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2025  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -37,7 +37,6 @@ public:
   private:
     std::string m_dir;
     mutable std::string m_desc;
-    mutable std::string m_fn;
   };
   using BackupPtr = std::shared_ptr<Backup>;
   using Backups = std::vector<BackupPtr>;
@@ -46,11 +45,12 @@ public:
   ~Session();
 
   std::string name() const;
-  std::string version();
-  std::string& path() { return m_path; }
+  std::string version() const;
+  const std::string& path() const { return m_path; }
   const Backups& backups();
+  const Backups& reloadBackups();
 
-  bool isCrashedSession();
+  bool isCrashedSession() const;
   bool isOldSession();
   bool isEmpty();
 
@@ -69,7 +69,7 @@ public:
 
 private:
   Doc* restoreBackupDoc(const std::string& backupDir, base::task_token* t);
-  void loadPid();
+  void loadPid() const;
   std::string pidFilename() const;
   std::string verFilename() const;
   void markDocumentAsCorrectlyClosed(Doc* doc);
@@ -77,9 +77,9 @@ private:
   void fixFilename(Doc* doc);
   int filenamePartToInt(const std::string& part) const;
 
-  base::pid m_pid;
+  mutable base::pid m_pid;
   std::string m_path;
-  std::string m_version;
+  mutable std::string m_version;
   Backups m_backups;
   RecoveryConfig* m_config;
 

--- a/src/app/crash/session.h
+++ b/src/app/crash/session.h
@@ -9,6 +9,7 @@
 #define APP_CRASH_SESSION_H_INCLUDED
 #pragma once
 
+#include "app/crash/document_info.h"
 #include "app/crash/raw_images_as.h"
 #include "base/disable_copying.h"
 #include "base/process.h"
@@ -32,16 +33,16 @@ public:
   public:
     Backup(const std::string& dir);
     const std::string& dir() const { return m_dir; }
-    std::string description(const bool withFullPath) const;
+    DocumentInfo info() const;
 
   private:
     std::string m_dir;
-    mutable std::string m_desc;
+    mutable DocumentInfo m_info;
   };
   using BackupPtr = std::shared_ptr<Backup>;
   using Backups = std::vector<BackupPtr>;
 
-  Session(RecoveryConfig* config, const std::string& path);
+  Session(RecoveryConfig* config, const std::string& path, bool isActive);
   ~Session();
 
   std::string name() const;
@@ -50,6 +51,7 @@ public:
   const Backups& backups();
   const Backups& reloadBackups();
 
+  bool isActiveSession() const { return m_isActive; }
   bool isCrashedSession() const;
   bool isOldSession();
   bool isEmpty();
@@ -60,6 +62,8 @@ public:
 
   bool saveDocumentChanges(Doc* doc);
   void removeDocument(Doc* doc);
+  void addBackupItem(doc::ObjectId docId);
+  std::string docBackupDir(doc::ObjectId docId);
 
   Doc* restoreBackupDoc(const BackupPtr& backup, base::task_token* t);
   Doc* restoreBackupById(const doc::ObjectId id, base::task_token* t);
@@ -82,11 +86,12 @@ private:
   mutable std::string m_version;
   Backups m_backups;
   RecoveryConfig* m_config;
+  bool m_isActive = false;
 
   DISABLE_COPYING(Session);
 };
 
-typedef std::shared_ptr<Session> SessionPtr;
+using SessionPtr = std::shared_ptr<Session>;
 
 } // namespace crash
 } // namespace app

--- a/src/app/ui/data_recovery_view.cpp
+++ b/src/app/ui/data_recovery_view.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2024  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This program is distributed under the terms of
@@ -13,6 +13,7 @@
 
 #include "app/app.h"
 #include "app/app_menus.h"
+#include "app/closed_docs.h"
 #include "app/console.h"
 #include "app/crash/data_recovery.h"
 #include "app/crash/session.h"
@@ -29,6 +30,7 @@
 #include "app/ui/workspace.h"
 #include "app/ui_context.h"
 #include "base/fs.h"
+#include "fmt/format.h"
 #include "ui/alert.h"
 #include "ui/button.h"
 #include "ui/entry.h"
@@ -44,6 +46,8 @@
 
 #include <algorithm>
 
+#define DATAVIEW_TRACE(...) // TRACEARGS(__VA_ARGS__)
+
 namespace app {
 
 using namespace ui;
@@ -51,7 +55,49 @@ using namespace app::skin;
 
 namespace {
 
-class Item : public ListItem {
+class DataItem : public ListItem {
+public:
+  DataItem() {}
+  DataItem(const std::string& title) : ListItem(title) {}
+
+  virtual bool hasBackup() const { return false; }
+  virtual void restoreBackup() {}
+
+protected:
+  void onSizeHint(SizeHintEvent& ev) override
+  {
+    ListItem::onSizeHint(ev);
+    gfx::Size sz = ev.sizeHint();
+    sz.h += 4 * guiscale();
+    ev.setSizeHint(sz);
+  }
+};
+
+class ClosedDocItem : public DataItem {
+public:
+  ClosedDocItem(ObjectId id, const std::string& title)
+    : DataItem(fmt::format("{} ({})", title, Strings::recover_files_in_memory()))
+    , m_id(id)
+  {
+  }
+  bool hasBackup() const override { return m_id != doc::NullId; }
+  void restoreBackup() override
+  {
+    if (auto ctx = UIContext::instance())
+      ctx->reopenClosedDocById(m_id);
+  }
+  ObjectId docId() const { return m_id; }
+
+private:
+  ObjectId m_id;
+};
+
+class NoClosedDocItem : public DataItem {
+public:
+  NoClosedDocItem() : DataItem(Strings::recover_files_no_closed_docs()) {}
+};
+
+class Item : public DataItem {
 public:
   Item(crash::Session* session, const crash::Session::BackupPtr& backup)
     : m_session(session)
@@ -65,7 +111,9 @@ public:
 
   bool isTaskRunning() const { return m_task != nullptr; }
 
-  void restoreBackup()
+  bool hasBackup() const override { return m_backup != nullptr; }
+
+  void restoreBackup() override
   {
     if (m_task)
       return;
@@ -152,14 +200,6 @@ private:
     ListItem::onPaint(ev);
   }
 
-  void onSizeHint(SizeHintEvent& ev) override
-  {
-    ListItem::onSizeHint(ev);
-    gfx::Size sz = ev.sizeHint();
-    sz.h += 4 * guiscale();
-    ev.setSizeHint(sz);
-  }
-
   void onResize(ResizeEvent& ev) override
   {
     setBoundsQuietly(ev.bounds());
@@ -237,6 +277,189 @@ private:
 
 } // anonymous namespace
 
+class DataRecoveryView::SessionSeparator : public SeparatorInView,
+                                           public ClosedDocsObserver {
+public:
+  SessionSeparator(crash::Session* session, bool isRunningSession)
+    : SeparatorInView({}, HORIZONTAL)
+    , m_session(session)
+  {
+    std::string title;
+    if (isRunningSession) {
+      title = Strings::recover_files_active_session();
+      m_isRunningSession = true;
+    }
+    else {
+      title = session->name();
+      if (session->version() != get_app_version())
+        title = Strings::recover_files_incompatible(title, session->version());
+      m_isRunningSession = false;
+    }
+
+    setText(title);
+
+    if (m_isRunningSession) {
+      auto* ctx = UIContext::instance();
+      ctx->closedDocs().add_observer(this);
+    }
+  }
+
+  void onInitTheme(ui::InitThemeEvent& ev) override
+  {
+    Widget::onInitTheme(ev);
+    setBorder(border() + gfx::Border(0, 8, 0, 8) * guiscale());
+  }
+
+  ~SessionSeparator()
+  {
+    if (m_isRunningSession) {
+      auto* ctx = UIContext::instance();
+      ctx->closedDocs().remove_observer(this);
+    }
+  }
+
+  void initializeItems(ui::Widget* listBox)
+  {
+    addClosedDocs(listBox);
+    addBackups(listBox);
+
+    if (m_isRunningSession) {
+      listBox->addChild(m_noClosedDoc = new NoClosedDocItem);
+      m_noClosedDoc->setVisible(m_isEmpty);
+    }
+  }
+
+  bool isEmpty() const { return m_isEmpty; }
+
+  crash::Session* session() const { return m_session; }
+
+private:
+  void addClosedDocs(ui::Widget* listBox)
+  {
+    if (!m_isRunningSession)
+      return;
+
+    const bool fullPath = Preferences::instance().general.showFullPath();
+    auto* ctx = UIContext::instance();
+    for (const auto& info : ctx->closedDocs().getClosedDocInfos()) {
+      auto* item = new ClosedDocItem(info.docId, info.toString(fullPath));
+      listBox->addChild(item);
+      m_isEmpty = false;
+    }
+  }
+
+  int clearBackups(ui::Widget* listBox)
+  {
+    int n = int(parent()->children().size());
+    int i = parent()->getChildIndex(this);
+    for (++i; i < n; ++i) {
+      Widget* child = parent()->at(i);
+
+      // Outside this section
+      if (dynamic_cast<Separator*>(child))
+        break;
+
+      if (dynamic_cast<Item*>(child)) {
+        listBox->removeChild(child);
+        child->deferDelete();
+        --i;
+        --n;
+      }
+    }
+    return i;
+  }
+
+  void addBackups(ui::Widget* listBox, int index = -1)
+  {
+    for (auto& backup : m_session->backups()) {
+      auto* item = new Item(m_session, backup);
+      if (index < 0)
+        listBox->addChild(item);
+      else
+        listBox->insertChild(index++, item);
+      m_isEmpty = false;
+    }
+  }
+
+  // ClosedDocObserver implementation
+  void onNewClosedDoc(const doc::ObjectId docId) override
+  {
+    DATAVIEW_TRACE("DATAVIEW: onNewClosedDoc", (int)docId);
+
+    int i = parent()->getChildIndex(this);
+
+    const bool fullPath = Preferences::instance().general.showFullPath();
+    const crash::DocumentInfo info(doc::get<Doc>(docId));
+    parent()->insertChild(i + 1, new ClosedDocItem(info.docId, info.toString(fullPath)));
+
+    updateNoClosedDocVisibility();
+  }
+
+  void onReopenClosedDoc(doc::ObjectId docId) override
+  {
+    DATAVIEW_TRACE("DATAVIEW: onReopenClosedDoc", (int)docId);
+
+    for (auto* widget : parent()->children()) {
+      if (auto item = dynamic_cast<ClosedDocItem*>(widget)) {
+        if (item->docId() == docId) {
+          parent()->removeChild(item);
+          item->deferDelete();
+          break;
+        }
+      }
+    }
+
+    updateNoClosedDocVisibility();
+  }
+
+  void onArchiveClosedDoc(doc::ObjectId docId, const bool backedup) override
+  {
+    DATAVIEW_TRACE("DATAVIEW: onArchiveClosedDoc", (int)docId, "backedup=", backedup);
+
+    onReopenClosedDoc(docId);
+
+    int index = clearBackups(parent());
+    m_session->reloadBackups();
+    addBackups(parent(), index);
+
+    updateNoClosedDocVisibility();
+  }
+
+  void updateNoClosedDocVisibility()
+  {
+    ASSERT(m_noClosedDoc);
+    if (m_noClosedDoc)
+      m_noClosedDoc->setVisible(countItemsInThisSection() == 0);
+    parent()->parent()->layout();
+  }
+
+  int countItemsInThisSection()
+  {
+    int itemsInThisSection = 0;
+    int n = int(parent()->children().size());
+    int i = parent()->getChildIndex(this);
+    for (++i; i < n; ++i) {
+      Widget* child = parent()->at(i);
+
+      // Outside this section
+      if (dynamic_cast<Separator*>(child))
+        break;
+
+      // Don't count the "no closed item"
+      if (dynamic_cast<NoClosedDocItem*>(child))
+        continue;
+
+      ++itemsInThisSection;
+    }
+    return itemsInThisSection;
+  }
+
+  crash::Session* m_session = nullptr;
+  NoClosedDocItem* m_noClosedDoc = nullptr;
+  bool m_isEmpty = true;
+  bool m_isRunningSession = false;
+};
+
 DataRecoveryView::DataRecoveryView(crash::DataRecovery* dataRecovery)
   : m_dataRecovery(dataRecovery)
   , m_openButton(Strings::recover_files_recover_sprite().c_str())
@@ -301,68 +524,46 @@ void DataRecoveryView::refreshListNotification()
 void DataRecoveryView::clearList()
 {
   WidgetsList children = m_listBox.children();
-  for (auto child : children) {
+  for (auto* child : children) {
     m_listBox.removeChild(child);
     child->deferDelete();
   }
+  m_runningSession = nullptr;
 }
 
 void DataRecoveryView::fillList()
 {
   clearList();
 
-  if (m_dataRecovery->isSearching())
-    m_listBox.addChild(new ListItem(Strings::recover_files_loading()));
-  else {
-    fillListWith(true);
-    fillListWith(false);
+  if (m_dataRecovery->isSearching()) {
+    m_listBox.addChild(new DataItem(Strings::recover_files_loading()));
+    return;
+  }
+
+  // Add current session
+  addSession(m_dataRecovery->activeSession());
+
+  // Add previous sessions
+  for (auto& session : m_dataRecovery->sessions()) {
+    if (!session->isEmpty())
+      addSession(session.get());
   }
 }
 
-void DataRecoveryView::fillListWith(const bool crashes)
+void DataRecoveryView::addSession(crash::Session* session)
 {
-  bool first = true;
+  const bool isRunningSession = m_dataRecovery->isRunningSession(session);
 
-  for (auto& session : m_dataRecovery->sessions()) {
-    if ((session->isEmpty()) || (crashes && !session->isCrashedSession()) ||
-        (!crashes && session->isCrashedSession()))
-      continue;
+  auto* sep = new SessionSeparator(session, isRunningSession);
+  m_listBox.addChild(sep);
+  sep->initializeItems(&m_listBox);
 
-    if (first) {
-      first = false;
-
-      // Separator for "crash sessions" vs "old sessions"
-      auto sep = new Separator(
-        (crashes ? Strings::recover_files_crash_sessions() : Strings::recover_files_old_sessions()),
-        HORIZONTAL);
-      sep->InitTheme.connect([sep] {
-        auto theme = skin::SkinTheme::get(sep);
-        sep->setStyle(theme->styles.separatorInViewReverse());
-        sep->setBorder(sep->border() + gfx::Border(0, 8, 0, 8) * guiscale());
-      });
-      sep->initTheme();
-      m_listBox.addChild(sep);
-    }
-
-    std::string title = session->name();
-    if (session->version() != get_app_version())
-      title = Strings::recover_files_incompatible(title, session->version());
-
-    auto sep = new SeparatorInView(title, HORIZONTAL);
-    sep->InitTheme.connect(
-      [sep] { sep->setBorder(sep->border() + gfx::Border(0, 8, 0, 8) * guiscale()); });
-    sep->initTheme();
-    m_listBox.addChild(sep);
-
-    for (auto& backup : session->backups()) {
-      auto item = new Item(session.get(), backup);
-      m_listBox.addChild(item);
-    }
+  if (isRunningSession)
+    m_runningSession = sep;
+  else if (sep->isEmpty()) {
+    delete sep;
+    return;
   }
-
-  // If there are no crash items, we call Empty() signal
-  if (crashes && first)
-    Empty();
 }
 
 void DataRecoveryView::disableRefresh()
@@ -419,16 +620,26 @@ void DataRecoveryView::onTabPopup(Workspace* workspace)
   menu->showPopup(mousePosInDisplay(), display());
 }
 
-void DataRecoveryView::onOpen()
+WidgetsList DataRecoveryView::selectedItems()
 {
-  disableRefresh();
-
+  WidgetsList selected;
   for (auto widget : m_listBox.children()) {
     if (!widget->isVisible() || !widget->isSelected())
       continue;
 
-    if (auto item = dynamic_cast<Item*>(widget)) {
-      if (item->backup())
+    if (auto item = dynamic_cast<DataItem*>(widget))
+      selected.push_back(item);
+  }
+  return selected;
+}
+
+void DataRecoveryView::onOpen()
+{
+  disableRefresh();
+
+  for (auto* widget : selectedItems()) {
+    if (auto item = dynamic_cast<DataItem*>(widget)) {
+      if (item->hasBackup())
         item->restoreBackup();
     }
   }
@@ -438,10 +649,7 @@ void DataRecoveryView::onOpenRaw(crash::RawImagesAs as)
 {
   disableRefresh();
 
-  for (auto widget : m_listBox.children()) {
-    if (!widget->isVisible() || !widget->isSelected())
-      continue;
-
+  for (auto* widget : selectedItems()) {
     if (auto item = dynamic_cast<Item*>(widget)) {
       if (item->backup())
         item->restoreRawImages(as);
@@ -510,7 +718,7 @@ void DataRecoveryView::onChangeSelection()
     if (!widget->isVisible() || !widget->isSelected())
       continue;
 
-    if (dynamic_cast<Item*>(widget)) {
+    if (auto* item = dynamic_cast<DataItem*>(widget); item && item->hasBackup()) {
       ++count;
     }
   }

--- a/src/app/ui/data_recovery_view.cpp
+++ b/src/app/ui/data_recovery_view.cpp
@@ -55,10 +55,13 @@ using namespace app::skin;
 
 namespace {
 
+using ClosedIds = std::set<doc::ObjectId>;
+
 class DataItem : public ListItem {
 public:
   DataItem() {}
   DataItem(const std::string& title) : ListItem(title) {}
+  ~DataItem() {}
 
   virtual bool hasBackup() const { return false; }
   virtual void restoreBackup() {}
@@ -76,7 +79,7 @@ protected:
 class ClosedDocItem : public DataItem {
 public:
   ClosedDocItem(ObjectId id, const std::string& title)
-    : DataItem(fmt::format("{} ({})", title, Strings::recover_files_in_memory()))
+    : DataItem(Strings::recover_files_in_memory(title))
     , m_id(id)
   {
   }
@@ -97,9 +100,9 @@ public:
   NoClosedDocItem() : DataItem(Strings::recover_files_no_closed_docs()) {}
 };
 
-class Item : public DataItem {
+class BackupItem : public DataItem {
 public:
-  Item(crash::Session* session, const crash::Session::BackupPtr& backup)
+  BackupItem(crash::Session* session, const crash::Session::BackupPtr& backup)
     : m_session(session)
     , m_backup(backup)
     , m_task(nullptr)
@@ -185,7 +188,13 @@ public:
       if (!m_backup)
         return;
 
-      setText(m_backup->description(Preferences::instance().general.showFullPath()));
+      const std::string desc = m_backup->info().toString(
+        Preferences::instance().general.showFullPath());
+
+      if (m_session->isActiveSession())
+        setText(Strings::recover_files_on_disk(desc));
+      else
+        setText(desc);
     }
   }
 
@@ -280,29 +289,73 @@ private:
 class DataRecoveryView::SessionSeparator : public SeparatorInView,
                                            public ClosedDocsObserver {
 public:
-  SessionSeparator(crash::Session* session, bool isRunningSession)
+  SessionSeparator(const crash::SessionPtr& session)
     : SeparatorInView({}, HORIZONTAL)
     , m_session(session)
   {
     std::string title;
-    if (isRunningSession) {
+    if (session->isActiveSession()) {
       title = Strings::recover_files_active_session();
-      m_isRunningSession = true;
     }
     else {
       title = session->name();
       if (session->version() != get_app_version())
         title = Strings::recover_files_incompatible(title, session->version());
-      m_isRunningSession = false;
     }
 
     setText(title);
 
-    if (m_isRunningSession) {
+    if (m_session->isActiveSession()) {
       auto* ctx = UIContext::instance();
       ctx->closedDocs().add_observer(this);
     }
   }
+
+  ~SessionSeparator()
+  {
+    if (m_session->isActiveSession()) {
+      auto* ctx = UIContext::instance();
+      ctx->closedDocs().remove_observer(this);
+    }
+  }
+
+  NoClosedDocItem* noClosedDoc() { return m_noClosedDoc; }
+
+  void initializeItems()
+  {
+    m_isEmpty = true;
+    addClosedDocs();
+    addBackups();
+
+    if (m_session->isActiveSession()) {
+      if (!m_noClosedDoc)
+        listBox()->addChild(m_noClosedDoc = new NoClosedDocItem);
+      m_noClosedDoc->setVisible(m_isEmpty);
+    }
+
+    updateView();
+  }
+
+  bool isEmpty() const { return m_isEmpty; }
+
+  crash::SessionPtr session() const { return m_session; }
+
+  void notifyDocBackupDone(const doc::ObjectId docId)
+  {
+    if (!existsBackupItem(docId)) {
+      DATAVIEW_TRACE("DATAVIEW: notifyDocBackupDone", (int)docId, "doesn't exist, adding item");
+
+      addBackup(docId);
+      updateNoClosedDocVisibility();
+      updateView();
+    }
+    else {
+      DATAVIEW_TRACE("DATAVIEW: notifyDocBackupDone", (int)docId, "already exists");
+    }
+  }
+
+private:
+  ui::Widget* listBox() const { return parent(); }
 
   void onInitTheme(ui::InitThemeEvent& ev) override
   {
@@ -310,57 +363,35 @@ public:
     setBorder(border() + gfx::Border(0, 8, 0, 8) * guiscale());
   }
 
-  ~SessionSeparator()
+  void addClosedDocs()
   {
-    if (m_isRunningSession) {
-      auto* ctx = UIContext::instance();
-      ctx->closedDocs().remove_observer(this);
-    }
-  }
-
-  void initializeItems(ui::Widget* listBox)
-  {
-    addClosedDocs(listBox);
-    addBackups(listBox);
-
-    if (m_isRunningSession) {
-      listBox->addChild(m_noClosedDoc = new NoClosedDocItem);
-      m_noClosedDoc->setVisible(m_isEmpty);
-    }
-  }
-
-  bool isEmpty() const { return m_isEmpty; }
-
-  crash::Session* session() const { return m_session; }
-
-private:
-  void addClosedDocs(ui::Widget* listBox)
-  {
-    if (!m_isRunningSession)
+    m_closedIds.clear();
+    if (!m_session->isActiveSession())
       return;
 
     const bool fullPath = Preferences::instance().general.showFullPath();
     auto* ctx = UIContext::instance();
     for (const auto& info : ctx->closedDocs().getClosedDocInfos()) {
       auto* item = new ClosedDocItem(info.docId, info.toString(fullPath));
-      listBox->addChild(item);
-      m_isEmpty = false;
+      listBox()->addChild(item);
+
+      m_closedIds.insert(info.docId);
     }
   }
 
-  int clearBackups(ui::Widget* listBox)
+  int clearBackups()
   {
-    int n = int(parent()->children().size());
-    int i = parent()->getChildIndex(this);
+    int n = int(listBox()->children().size());
+    int i = listBox()->getChildIndex(this);
     for (++i; i < n; ++i) {
-      Widget* child = parent()->at(i);
+      Widget* child = listBox()->at(i);
 
       // Outside this section
       if (dynamic_cast<Separator*>(child))
         break;
 
-      if (dynamic_cast<Item*>(child)) {
-        listBox->removeChild(child);
+      if (dynamic_cast<BackupItem*>(child)) {
+        listBox()->removeChild(child);
         child->deferDelete();
         --i;
         --n;
@@ -369,15 +400,52 @@ private:
     return i;
   }
 
-  void addBackups(ui::Widget* listBox, int index = -1)
+  bool existsBackupItem(const doc::ObjectId docId)
+  {
+    bool exists = false;
+    forEachItemInSection([docId, &exists](DataItem* item) {
+      if (auto* backupItem = dynamic_cast<BackupItem*>(item)) {
+        if (backupItem->backup()->info().docId == docId) {
+          exists = true;
+          return true; // Stop
+        }
+      }
+      return false; // Continue
+    });
+    return exists;
+  }
+
+  void addBackup(const doc::ObjectId docId)
   {
     for (auto& backup : m_session->backups()) {
-      auto* item = new Item(m_session, backup);
-      if (index < 0)
-        listBox->addChild(item);
-      else
-        listBox->insertChild(index++, item);
-      m_isEmpty = false;
+      if (backup->info().docId == docId) {
+        addBackup(backup, lastIndexInSection());
+        break;
+      }
+    }
+  }
+
+  void addBackup(const crash::Session::BackupPtr& backup, int index = -1)
+  {
+    auto* item = new BackupItem(m_session.get(), backup);
+    if (index < 0)
+      listBox()->addChild(item);
+    else
+      listBox()->insertChild(index, item);
+
+    // Don't show backup items on disk for sprites that are still in memory.
+    const bool backupVisible = (m_closedIds.find(backup->info().docId) == m_closedIds.end());
+    item->setVisible(backupVisible);
+
+    m_isEmpty = false;
+  }
+
+  void addBackups(int index = -1)
+  {
+    for (auto& backup : m_session->backups()) {
+      addBackup(backup, index);
+      if (index >= 0)
+        ++index;
     }
   }
 
@@ -386,43 +454,67 @@ private:
   {
     DATAVIEW_TRACE("DATAVIEW: onNewClosedDoc", (int)docId);
 
-    int i = parent()->getChildIndex(this);
+    int i = listBox()->getChildIndex(this);
 
     const bool fullPath = Preferences::instance().general.showFullPath();
     const crash::DocumentInfo info(doc::get<Doc>(docId));
-    parent()->insertChild(i + 1, new ClosedDocItem(info.docId, info.toString(fullPath)));
+    listBox()->insertChild(i + 1, new ClosedDocItem(info.docId, info.toString(fullPath)));
 
+    m_closedIds.insert(docId);
+    updateMatchingBackupItemVisibility(docId);
     updateNoClosedDocVisibility();
+    updateView();
   }
 
-  void onReopenClosedDoc(doc::ObjectId docId) override
+  void onReopenClosedDoc(const doc::ObjectId docId) override
   {
     DATAVIEW_TRACE("DATAVIEW: onReopenClosedDoc", (int)docId);
+    deleteClosedDocItem(docId);
+  }
 
-    for (auto* widget : parent()->children()) {
-      if (auto item = dynamic_cast<ClosedDocItem*>(widget)) {
+  void onArchiveClosedDoc(const doc::ObjectId docId, const bool backedup) override
+  {
+    DATAVIEW_TRACE("DATAVIEW: onArchiveClosedDoc", (int)docId, "backedup=", backedup);
+    deleteClosedDocItem(docId);
+  }
+
+  void deleteClosedDocItem(const doc::ObjectId docId)
+  {
+    if (auto it = m_closedIds.find(docId); it != m_closedIds.end())
+      m_closedIds.erase(it);
+
+    for (auto* widget : listBox()->children()) {
+      if (auto* item = dynamic_cast<ClosedDocItem*>(widget)) {
         if (item->docId() == docId) {
-          parent()->removeChild(item);
+          listBox()->removeChild(item);
           item->deferDelete();
           break;
         }
       }
     }
 
+    updateMatchingBackupItemVisibility(docId);
     updateNoClosedDocVisibility();
+    updateView();
   }
 
-  void onArchiveClosedDoc(doc::ObjectId docId, const bool backedup) override
+  void updateMatchingBackupItemVisibility(const doc::ObjectId docId)
   {
-    DATAVIEW_TRACE("DATAVIEW: onArchiveClosedDoc", (int)docId, "backedup=", backedup);
-
-    onReopenClosedDoc(docId);
-
-    int index = clearBackups(parent());
-    m_session->reloadBackups();
-    addBackups(parent(), index);
-
-    updateNoClosedDocVisibility();
+    forEachItemInSection([this, docId](DataItem* item) {
+      // Backup item found...
+      if (auto* backupItem = dynamic_cast<BackupItem*>(item)) {
+        const doc::ObjectId backupDocId = backupItem->backup()->info().docId;
+        if (backupDocId == docId) {
+          // Show/hide the backup item depending if there is a closed
+          // sprite related (we prefer to display the ClosedDocItem as
+          // it contains undo information).
+          const bool backupVisible = (m_closedIds.find(backupDocId) == m_closedIds.end());
+          backupItem->setVisible(backupVisible);
+          return true; // Stop
+        }
+      }
+      return false; // Continue
+    });
   }
 
   void updateNoClosedDocVisibility()
@@ -430,39 +522,66 @@ private:
     ASSERT(m_noClosedDoc);
     if (m_noClosedDoc)
       m_noClosedDoc->setVisible(countItemsInThisSection() == 0);
-    parent()->parent()->layout();
+  }
+
+  void updateView()
+  {
+    if (auto view = View::getView(this->parent()))
+      view->updateView();
+    else
+      parent()->layout();
   }
 
   int countItemsInThisSection()
   {
     int itemsInThisSection = 0;
-    int n = int(parent()->children().size());
-    int i = parent()->getChildIndex(this);
-    for (++i; i < n; ++i) {
-      Widget* child = parent()->at(i);
-
-      // Outside this section
-      if (dynamic_cast<Separator*>(child))
-        break;
-
-      // Don't count the "no closed item"
-      if (dynamic_cast<NoClosedDocItem*>(child))
-        continue;
-
+    return forEachItemInSection([&itemsInThisSection](DataItem* item) {
       ++itemsInThisSection;
-    }
+      return false; // Continue for all items
+    });
     return itemsInThisSection;
   }
 
-  crash::Session* m_session = nullptr;
+  int lastIndexInSection()
+  {
+    return forEachItemInSection([](DataItem* item) {
+      if (auto* backupItem = dynamic_cast<BackupItem*>(item))
+        return true; // Stop and return the index of this item
+      return false;
+    });
+  }
+
+  int forEachItemInSection(std::function<bool(DataItem*)> callback)
+  {
+    int n = int(listBox()->children().size());
+    int i = listBox()->getChildIndex(this);
+    for (++i; i < n; ++i) {
+      Widget* child = listBox()->at(i);
+
+      // Outside this section
+      if (dynamic_cast<Separator*>(child))
+        return i;
+
+      // Don't count the "no closed item"
+      if (dynamic_cast<NoClosedDocItem*>(child))
+        return i;
+
+      auto* item = dynamic_cast<DataItem*>(child);
+      if (callback(item))
+        return i; // If returns true we stop
+    }
+    return i;
+  }
+
+  crash::SessionPtr m_session = nullptr;
   NoClosedDocItem* m_noClosedDoc = nullptr;
   bool m_isEmpty = true;
-  bool m_isRunningSession = false;
+  ClosedIds m_closedIds;
 };
 
 DataRecoveryView::DataRecoveryView(crash::DataRecovery* dataRecovery)
   : m_dataRecovery(dataRecovery)
-  , m_openButton(Strings::recover_files_recover_sprite().c_str())
+  , m_openButton(Strings::recover_files_recover_sprite())
   , m_deleteButton(Strings::recover_files_delete())
   , m_refreshButton(Strings::recover_files_refresh())
   , m_waitToEnableRefreshTimer(100)
@@ -503,13 +622,14 @@ DataRecoveryView::DataRecoveryView(crash::DataRecovery* dataRecovery)
   m_listBox.DoubleClickItem.connect([this] { onOpen(); });
   m_waitToEnableRefreshTimer.Tick.connect([this] { onCheckIfWeCanEnableRefreshButton(); });
 
-  m_conn = Preferences::instance().general.showFullPath.AfterChange.connect(
+  m_connFullPath = Preferences::instance().general.showFullPath.AfterChange.connect(
     [this](const bool&) { onShowFullPathPrefChange(); });
+  m_connBackup = dataRecovery->BackupDone.connect(
+    [this](const doc::ObjectId docId) { m_runningSession->notifyDocBackupDone(docId); });
 }
 
 DataRecoveryView::~DataRecoveryView()
 {
-  m_conn.disconnect();
 }
 
 void DataRecoveryView::refreshListNotification()
@@ -525,10 +645,12 @@ void DataRecoveryView::clearList()
 {
   WidgetsList children = m_listBox.children();
   for (auto* child : children) {
+    if (m_runningSession && (child == m_runningSession || child == m_runningSession->noClosedDoc()))
+      continue;
+
     m_listBox.removeChild(child);
     child->deferDelete();
   }
-  m_runningSession = nullptr;
 }
 
 void DataRecoveryView::fillList()
@@ -541,29 +663,28 @@ void DataRecoveryView::fillList()
   }
 
   // Add current session
-  addSession(m_dataRecovery->activeSession());
+  if (!m_runningSession)
+    addSession(m_dataRecovery->activeSession());
+  else
+    m_runningSession->initializeItems();
 
   // Add previous sessions
   for (auto& session : m_dataRecovery->sessions()) {
     if (!session->isEmpty())
-      addSession(session.get());
+      addSession(session);
   }
 }
 
-void DataRecoveryView::addSession(crash::Session* session)
+void DataRecoveryView::addSession(const crash::SessionPtr& session)
 {
-  const bool isRunningSession = m_dataRecovery->isRunningSession(session);
-
-  auto* sep = new SessionSeparator(session, isRunningSession);
+  auto* sep = new SessionSeparator(session);
   m_listBox.addChild(sep);
-  sep->initializeItems(&m_listBox);
+  sep->initializeItems();
 
-  if (isRunningSession)
+  if (session->isActiveSession())
     m_runningSession = sep;
-  else if (sep->isEmpty()) {
+  else if (sep->isEmpty())
     delete sep;
-    return;
-  }
 }
 
 void DataRecoveryView::disableRefresh()
@@ -577,7 +698,7 @@ bool DataRecoveryView::someItemIsBusy()
   // Just in case check that we are not already running some task (so
   // we cannot refresh the list)
   for (auto widget : m_listBox.children()) {
-    if (auto item = dynamic_cast<Item*>(widget)) {
+    if (auto* item = dynamic_cast<BackupItem*>(widget)) {
       if (item->isTaskRunning())
         return true;
     }
@@ -627,7 +748,7 @@ WidgetsList DataRecoveryView::selectedItems()
     if (!widget->isVisible() || !widget->isSelected())
       continue;
 
-    if (auto item = dynamic_cast<DataItem*>(widget))
+    if (auto* item = dynamic_cast<DataItem*>(widget))
       selected.push_back(item);
   }
   return selected;
@@ -638,7 +759,7 @@ void DataRecoveryView::onOpen()
   disableRefresh();
 
   for (auto* widget : selectedItems()) {
-    if (auto item = dynamic_cast<DataItem*>(widget)) {
+    if (auto* item = dynamic_cast<DataItem*>(widget)) {
       if (item->hasBackup())
         item->restoreBackup();
     }
@@ -650,7 +771,7 @@ void DataRecoveryView::onOpenRaw(crash::RawImagesAs as)
   disableRefresh();
 
   for (auto* widget : selectedItems()) {
-    if (auto item = dynamic_cast<Item*>(widget)) {
+    if (auto* item = dynamic_cast<BackupItem*>(widget)) {
       if (item->backup())
         item->restoreRawImages(as);
     }
@@ -677,12 +798,12 @@ void DataRecoveryView::onDelete()
 {
   disableRefresh();
 
-  std::vector<Item*> items; // Items to delete.
+  std::vector<BackupItem*> items; // Items to delete.
   for (auto widget : m_listBox.children()) {
     if (!widget->isVisible() || !widget->isSelected())
       continue;
 
-    if (auto item = dynamic_cast<Item*>(widget)) {
+    if (auto item = dynamic_cast<BackupItem*>(widget)) {
       if (item->backup() && !item->isTaskRunning())
         items.push_back(item);
     }
@@ -701,6 +822,9 @@ void DataRecoveryView::onDelete()
 
 void DataRecoveryView::onRefresh()
 {
+  // This starts the timer to re-fill the list in case some item is busy.
+  disableRefresh();
+
   if (someItemIsBusy())
     return;
 
@@ -738,8 +862,13 @@ void DataRecoveryView::onCheckIfWeCanEnableRefreshButton()
   if (someItemIsBusy())
     return;
 
-  m_refreshButton.setEnabled(true);
   m_waitToEnableRefreshTimer.stop();
+  m_refreshButton.setEnabled(true);
+
+  // After re-enabling the Refresh button the mouse might be above the
+  // same button so in this way the user can re-click the button
+  // without moving the mouse.
+  manager()->_updateMouseWidgets();
 
   onChangeSelection();
 
@@ -754,7 +883,7 @@ void DataRecoveryView::onCheckIfWeCanEnableRefreshButton()
 void DataRecoveryView::onShowFullPathPrefChange()
 {
   for (auto widget : m_listBox.children()) {
-    if (auto item = dynamic_cast<Item*>(widget)) {
+    if (auto* item = dynamic_cast<BackupItem*>(widget)) {
       if (!item->isTaskRunning())
         item->updateText();
     }
@@ -764,7 +893,7 @@ void DataRecoveryView::onShowFullPathPrefChange()
 bool DataRecoveryView::thereAreCrashSessions() const
 {
   for (auto widget : m_listBox.children()) {
-    if (auto item = dynamic_cast<const Item*>(widget)) {
+    if (auto* item = dynamic_cast<const BackupItem*>(widget)) {
       if (item && item->isVisible() && item->session() && item->session()->isCrashedSession())
         return true;
     }

--- a/src/app/ui/data_recovery_view.h
+++ b/src/app/ui/data_recovery_view.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This program is distributed under the terms of
@@ -21,7 +21,8 @@
 namespace app {
 namespace crash {
 class DataRecovery;
-}
+class Session;
+} // namespace crash
 
 class DataRecoveryView : public ui::VBox,
                          public TabView,
@@ -52,9 +53,10 @@ public:
 private:
   void clearList();
   void fillList();
-  void fillListWith(const bool crashes);
+  void addSession(crash::Session* session);
   void disableRefresh();
   bool someItemIsBusy();
+  ui::WidgetsList selectedItems();
 
   void onOpen();
   void onOpenRaw(crash::RawImagesAs as);
@@ -73,6 +75,10 @@ private:
   ui::Button m_deleteButton;
   ui::Button m_refreshButton;
   ui::Timer m_waitToEnableRefreshTimer;
+
+  // Running session separator.
+  class SessionSeparator;
+  SessionSeparator* m_runningSession = nullptr;
 
   // Connection to to showFullPath.AfterChange signal to update the
   // items text when the setting is changed.

--- a/src/app/ui/data_recovery_view.h
+++ b/src/app/ui/data_recovery_view.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "app/crash/raw_images_as.h"
+#include "app/crash/session.h"
 #include "app/ui/drop_down_button.h"
 #include "app/ui/tabs.h"
 #include "app/ui/workspace_view.h"
@@ -53,7 +54,7 @@ public:
 private:
   void clearList();
   void fillList();
-  void addSession(crash::Session* session);
+  void addSession(const crash::SessionPtr& session);
   void disableRefresh();
   bool someItemIsBusy();
   ui::WidgetsList selectedItems();
@@ -82,7 +83,9 @@ private:
 
   // Connection to to showFullPath.AfterChange signal to update the
   // items text when the setting is changed.
-  obs::connection m_conn;
+  obs::scoped_connection m_connFullPath;
+
+  obs::scoped_connection m_connBackup;
 };
 
 } // namespace app

--- a/src/app/ui/drop_down_button.cpp
+++ b/src/app/ui/drop_down_button.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2022-2023  Igara Studio S.A.
+// Copyright (C) 2022-present  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This program is distributed under the terms of
@@ -22,10 +22,10 @@ namespace app {
 using namespace app::skin;
 using namespace ui;
 
-DropDownButton::DropDownButton(const char* text)
+DropDownButton::DropDownButton(const std::string& text)
   : HBox()
   , m_button(new Button(text))
-  , m_dropDown(new Button(""))
+  , m_dropDown(new Button({}))
 {
   m_button->setExpansive(true);
   m_button->Click.connect(&DropDownButton::onButtonClick, this);

--- a/src/app/ui/drop_down_button.h
+++ b/src/app/ui/drop_down_button.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2023  Igara Studio S.A.
+// Copyright (C) 2023-present  Igara Studio S.A.
 // Copyright (C) 2001-2016  David Capello
 //
 // This program is distributed under the terms of
@@ -21,7 +21,7 @@ namespace app {
 
 class DropDownButton : public ui::HBox {
 public:
-  DropDownButton(const char* text);
+  explicit DropDownButton(const std::string& text);
 
   ui::Button* mainButton() { return m_button; }
   ui::Button* dropDown() { return m_dropDown; }

--- a/src/app/ui/home_view.cpp
+++ b/src/app/ui/home_view.cpp
@@ -105,7 +105,7 @@ HomeView::~HomeView()
 #ifdef ENABLE_DATA_RECOVERY
   if (m_dataRecoveryView) {
     ASSERT(!m_dataRecoveryView->parent());
-    delete m_dataRecoveryView;
+    m_dataRecoveryView.reset();
   }
 #endif
 }
@@ -129,6 +129,16 @@ void HomeView::dataRecoverySessionsAreReady()
   }
   if (m_dataRecoveryView) {
     m_dataRecoveryView->refreshListNotification();
+  }
+#endif
+}
+
+void HomeView::closeDataRecoveryView()
+{
+#ifdef ENABLE_DATA_RECOVERY
+  if (m_dataRecoveryView) {
+    App::instance()->workspace()->removeView(m_dataRecoveryView.get());
+    m_dataRecoveryView.reset();
   }
 #endif
 }
@@ -172,7 +182,7 @@ bool HomeView::onCloseView(Workspace* workspace, bool quitting)
 void HomeView::onAfterRemoveView(Workspace* workspace)
 {
   if (m_dataRecoveryView && m_dataRecoveryView->parent()) {
-    workspace->removeView(m_dataRecoveryView);
+    workspace->removeView(m_dataRecoveryView.get());
   }
 }
 
@@ -341,7 +351,7 @@ void HomeView::onRecoverSprites()
     return;
 
   if (!m_dataRecoveryView) {
-    m_dataRecoveryView = new DataRecoveryView(m_dataRecovery);
+    m_dataRecoveryView = std::make_unique<DataRecoveryView>(m_dataRecovery);
 
     // Restore the "Recover Files" link style when the
     // DataRecoveryView is empty (so there is no more warning icon on
@@ -354,9 +364,9 @@ void HomeView::onRecoverSprites()
   }
 
   if (!m_dataRecoveryView->parent())
-    App::instance()->workspace()->addView(m_dataRecoveryView);
+    App::instance()->workspace()->addView(m_dataRecoveryView.get());
 
-  App::instance()->mainWindow()->getTabsBar()->selectTab(m_dataRecoveryView);
+  App::instance()->mainWindow()->getTabsBar()->selectTab(m_dataRecoveryView.get());
 #endif
 }
 

--- a/src/app/ui/home_view.h
+++ b/src/app/ui/home_view.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2024  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2016  David Capello
 //
 // This program is distributed under the terms of
@@ -16,6 +16,8 @@
 #include "ui/box.h"
 
 #include "home_view.xml.h"
+
+#include <memory>
 
 namespace ui {
 class View;
@@ -48,6 +50,8 @@ public:
   // When crash::DataRecovery finish to search for sessions, this
   // function is called.
   void dataRecoverySessionsAreReady();
+
+  void closeDataRecoveryView();
 
 #if ENABLE_SENTRY
   void updateConsentCheckbox();
@@ -96,7 +100,7 @@ private:
   RecentFoldersListBox* m_folders;
   NewsListBox* m_news;
   crash::DataRecovery* m_dataRecovery;
-  DataRecoveryView* m_dataRecoveryView;
+  std::unique_ptr<DataRecoveryView> m_dataRecoveryView;
 };
 
 } // namespace app

--- a/src/app/ui/main_window.cpp
+++ b/src/app/ui/main_window.cpp
@@ -465,6 +465,11 @@ void MainWindow::dataRecoverySessionsAreReady()
   getHomeView()->dataRecoverySessionsAreReady();
 }
 
+void MainWindow::closeDataRecoveryView()
+{
+  getHomeView()->closeDataRecoveryView();
+}
+
 bool MainWindow::onProcessMessage(ui::Message* msg)
 {
   if (msg->type() == kOpenMessage)

--- a/src/app/ui/main_window.h
+++ b/src/app/ui/main_window.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2025  Igara Studio S.A.
+// Copyright (C) 2018-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -99,6 +99,8 @@ public:
   // When crash::DataRecovery finish to search for sessions, this
   // function is called.
   void dataRecoverySessionsAreReady();
+
+  void closeDataRecoveryView();
 
   // TabsDelegate implementation.
   bool isTabModified(Tabs* tabs, TabView* tabView) override;

--- a/src/app/ui_context.cpp
+++ b/src/app/ui_context.cpp
@@ -284,11 +284,6 @@ Editor* UIContext::getEditorFor(Doc* document)
     return nullptr;
 }
 
-bool UIContext::hasClosedDocs()
-{
-  return m_closedDocs.hasClosedDocs();
-}
-
 void UIContext::reopenLastClosedDoc()
 {
   if (Doc* doc = m_closedDocs.reopenLastClosedDoc()) {
@@ -297,9 +292,17 @@ void UIContext::reopenLastClosedDoc()
   }
 }
 
-std::vector<Doc*> UIContext::getAndRemoveAllClosedDocs()
+void UIContext::reopenClosedDocById(doc::ObjectId docId)
 {
-  return m_closedDocs.getAndRemoveAllClosedDocs();
+  if (Doc* doc = m_closedDocs.reopenClosedDocById(docId)) {
+    // Put the document in the context again.
+    doc->setContext(this);
+  }
+}
+
+ClosedDocs& UIContext::closedDocs()
+{
+  return m_closedDocs;
 }
 
 void UIContext::onAddDocument(Doc* doc)

--- a/src/app/ui_context.h
+++ b/src/app/ui_context.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2023  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -16,6 +16,7 @@
 #include <vector>
 
 namespace app {
+class ClosedDocs;
 class DocView;
 class Editor;
 
@@ -45,9 +46,9 @@ public:
   // new one if it's necessary.
   Editor* getEditorFor(Doc* document);
 
-  bool hasClosedDocs();
   void reopenLastClosedDoc();
-  std::vector<Doc*> getAndRemoveAllClosedDocs();
+  void reopenClosedDocById(doc::ObjectId docId);
+  ClosedDocs& closedDocs();
 
   // Sets the DocView used to run some specific commands
   // (e.g. commands that depend on the current view or the preview

--- a/src/app/widget_loader.cpp
+++ b/src/app/widget_loader.cpp
@@ -452,7 +452,7 @@ Widget* WidgetLoader::convertXmlElementToWidget(const XMLElement* elem,
   }
   else if (elem_name == "dropdownbutton") {
     if (!widget) {
-      widget = new DropDownButton(m_xmlTranslator(elem, "text").c_str());
+      widget = new DropDownButton(m_xmlTranslator(elem, "text"));
     }
   }
   else if (elem_name == "buttonset") {

--- a/src/ui/widget.h
+++ b/src/ui/widget.h
@@ -170,7 +170,12 @@ public:
   const WidgetsList& children() const { return m_children; }
   bool hasChildren() const { return !m_children.empty(); }
 
-  Widget* at(int index) { return m_children[index]; }
+  Widget* at(int index) const
+  {
+    if (index >= 0 && index < m_children.size())
+      return m_children[index];
+    return nullptr;
+  }
   int getChildIndex(Widget* child);
 
   // Returns the first/last child or nullptr if it doesn't exist.


### PR DESCRIPTION
This PR adds the "Active Session" in the "Recover Files" tab:

<img width="813" height="499" alt="image" src="https://github.com/user-attachments/assets/3f1d917c-80cf-419f-920a-21f20c19305f" />

#### When we close a sprite:

<img width="813" height="499" alt="image" src="https://github.com/user-attachments/assets/61619089-78ad-46f2-87bb-5462f39d5b7a" />

#### When a version of the sprite is fully backed up in disk and we close the sprite we can see both versions (the one closed still in memory with undo info, and the backed up sprite in disk):

<img width="813" height="499" alt="image" src="https://github.com/user-attachments/assets/504c2da4-ae77-4c9b-9ec8-41affc773c3e" />

#### After the file in memory is freed only the backed up data is displayed:

<img width="813" height="499" alt="image" src="https://github.com/user-attachments/assets/38c7dd40-a1a1-44df-9a4f-30e84602f5d7" />
