### PR TITLE
Fix Drag-and-drop image into layers loses one color (treated as transparency) in RGB sprites (fix #5786)

### DIFF
--- a/src/app/cmd/set_pixel_format.cpp
+++ b/src/app/cmd/set_pixel_format.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2024  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -96,6 +96,17 @@ SetPixelFormat::SetPixelFormat(Sprite* sprite,
   }
 
   SuperDelegate superDel(nimages, delegate);
+
+  if (sprite->pixelFormat() == IMAGE_INDEXED) {
+    // If an indexed sprite has a background layer (which only supports
+    // opaque colors), set the image's maskColor on all background cels
+    // to a value outside the valid index range (0-255). This prevents
+    // RGB/grayscale conversion from treating any index as transparent.
+    const int maskIndex = (sprite->backgroundLayer() ? -1 : sprite->transparentColor());
+    for (Cel* cel : sprite->uniqueCels())
+      if (cel->layer()->isBackground())
+        cel->image()->setMaskColor(maskIndex);
+  }
 
   // Convert cel images
   for (Cel* cel : sprite->uniqueCels()) {

--- a/src/app/file/file.cpp
+++ b/src/app/file/file.cpp
@@ -499,11 +499,6 @@ FileOp* FileOp::createLoadDocumentOperation(Context* context,
       fop->m_dataFilename = dataFilename;
   }
 
-  // Avoid creating a background layer?
-  if (flags & FILE_LOAD_AVOID_BACKGROUND_LAYER) {
-    fop->m_avoidBackgroundLayer = true;
-  }
-
 done:;
   return fop.release();
 }
@@ -891,7 +886,7 @@ void FileOp::operate(IFileOpProgress* progress)
       if (m_document) {
         // Configure the layer as the 'Background'. Only if background layers
         // are welcome.
-        if (!m_seq.has_alpha && !m_avoidBackgroundLayer)
+        if (!m_seq.has_alpha)
           m_seq.layer->configureAsBackground();
 
         // Set the final canvas size (as the bigger loaded
@@ -1459,7 +1454,6 @@ FileOp::FileOp(FileOpType type, Context* context, const FileOpConfig* config)
   , m_oneframe(false)
   , m_createPaletteFromRgba(false)
   , m_ignoreEmpty(false)
-  , m_avoidBackgroundLayer(false)
   , m_embeddedColorProfile(false)
   , m_embeddedGridBounds(false)
 {

--- a/src/app/file/file.h
+++ b/src/app/file/file.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2023  Igara Studio S.A.
+// Copyright (C) 2018-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -27,14 +27,13 @@
 #include <string>
 
 // Flags for FileOp::createLoadDocumentOperation()
-#define FILE_LOAD_SEQUENCE_NONE          0x00000001
-#define FILE_LOAD_SEQUENCE_ASK           0x00000002
-#define FILE_LOAD_SEQUENCE_ASK_CHECKBOX  0x00000004
-#define FILE_LOAD_SEQUENCE_YES           0x00000008
-#define FILE_LOAD_ONE_FRAME              0x00000010
-#define FILE_LOAD_DATA_FILE              0x00000020
-#define FILE_LOAD_CREATE_PALETTE         0x00000040
-#define FILE_LOAD_AVOID_BACKGROUND_LAYER 0x00000080
+#define FILE_LOAD_SEQUENCE_NONE         0x00000001
+#define FILE_LOAD_SEQUENCE_ASK          0x00000002
+#define FILE_LOAD_SEQUENCE_ASK_CHECKBOX 0x00000004
+#define FILE_LOAD_SEQUENCE_YES          0x00000008
+#define FILE_LOAD_ONE_FRAME             0x00000010
+#define FILE_LOAD_DATA_FILE             0x00000020
+#define FILE_LOAD_CREATE_PALETTE        0x00000040
 
 namespace doc {
 class Tag;
@@ -307,7 +306,6 @@ private:
                                       // GIF/FLI/ASE).
   bool m_createPaletteFromRgba;
   bool m_ignoreEmpty;
-  bool m_avoidBackgroundLayer;
 
   // True if the file contained a color profile when it was loaded.
   bool m_embeddedColorProfile;

--- a/src/app/ui/timeline/doc_providers.cpp
+++ b/src/app/ui/timeline/doc_providers.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2025  Igara Studio S.A.
+// Copyright (C) 2025-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -26,8 +26,7 @@ std::unique_ptr<Doc> DocProviderFromPaths::nextDoc()
   m_paths.erase(m_paths.begin());
 
   Console console;
-  int flags = FILE_LOAD_DATA_FILE | FILE_LOAD_AVOID_BACKGROUND_LAYER | FILE_LOAD_CREATE_PALETTE |
-              FILE_LOAD_SEQUENCE_YES;
+  int flags = FILE_LOAD_DATA_FILE | FILE_LOAD_CREATE_PALETTE | FILE_LOAD_SEQUENCE_YES;
 
   std::unique_ptr<FileOp> fop(FileOp::createLoadDocumentOperation(m_context, path, flags));
 

--- a/src/app/util/clipboard.cpp
+++ b/src/app/util/clipboard.cpp
@@ -289,6 +289,9 @@ bool Clipboard::copyFromDocument(const Site& site, bool merged)
   if (!image)
     return false;
 
+  if (image->pixelFormat() == IMAGE_INDEXED && site.layer() && site.layer()->isBackground())
+    image->setMaskColor(-1);
+
   setData(image,
           (mask ? new Mask(*mask) : nullptr),
           (pal ? new Palette(*pal) : nullptr),


### PR DESCRIPTION
This fix includes two types of color loss related with background layer:
- Dragging files without transparent color to the timeline.
- Copy-paste images which source image corresponds to a background layer from a sprite.

I'm not entirely sure about the fix since I had to remove a flag that didn't seem to make much sense to me at the moment (`FILE_LOAD_AVOID_BACKGROUND_LAYER`).

A separate issue (discovered during testing #5809): I noticed that a background layer can be inserted in the middle of the timeline hierarchy if:
- You have a sprite with transparent layers
- You drag a sprite file with a background layer to a layer in the middle of the layer hierarchy.

Need advise of the first intention about `FILE_LOAD_AVOID_BACKGROUND_LAYER`.

fix #5786