### PR TITLE
Fix combo box lists do not expand in the Preference dialog on MacOS

### DIFF
--- a/src/ui/manager.cpp
+++ b/src/ui/manager.cpp
@@ -1483,6 +1483,15 @@ void Manager::_openWindow(Window* window, bool center)
       spec.transparent(window->isTransparent());
       spec.modal(window->isForeground());
 
+      // Convert the current window to modal if the parent window is also modal
+      // so the child window is not placed behind its modal parent.
+      if (!window->isForeground() && parentDisplay) {
+        if (auto* parentWindow = dynamic_cast<Window*>(parentDisplay->containedWidget())) {
+          if (parentWindow->isForeground())
+            spec.modal(true);
+        }
+      }
+
       if (!window->isDesktop()) {
         spec.parent(parentDisplay->nativeWindow());
       }


### PR DESCRIPTION
Regression of commit d9785e5c363a555fcda30ad0a256abc59f5f6550: 'Fix inactive window passes events to window below (#4561, #4835)'

On MacOS, this fixes combo box lists in the Preferences dialog when the 'UI with multiple windows' option was enabled.