### PR TITLE
Add DAP-compatible debugger for scripts and extensions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -81,3 +81,6 @@
 [submodule "third_party/json"]
 	path = third_party/json
 	url = https://github.com/aseprite/json
+[submodule "third_party/cppdap"]
+	path = third_party/cppdap
+	url = https://github.com/aseprite/cppdap

--- a/data/strings/en.ini
+++ b/data/strings/en.ini
@@ -113,6 +113,8 @@ overwrite_files_on_export_sprite_sheet = Export Sprite Sheet Warning\n<<Do you w
 overwrite_files_on_export = Export Warning\n<<Do you want to overwrite the following file?\n<<{0}\n||&Yes||&No
 enter_license_disabled = Information\n<<This copy of Aseprite does not support entering a license key.\n<<Consider getting one from https://aseprite.org/download.\n<<Activating Aseprite will give you access to automatic updates.\n||&OK
 reset_default_confirm = Resetting Preferences\n<<Are you sure you want to reset the selected preferences to their default values?\n||&Yes||&No
+debugger_end_session_before_disabling = Error\n<<Please end the current debugging session before disabling the debugger.\n||&OK
+debugger_failed_to_enable = Error\n<<Failed to enable the debugger.\n<<Error: {0}\n||&OK
 
 [brightness_contrast]
 title = Brightness/Contrast
@@ -502,15 +504,38 @@ Zoom_Set = Zoom {0}%
 
 [debugger]
 title = Debugger
-continue = Start or Continue Debugging
-step_into = Step Into
-step_over = Step Over
-step_out = Step Out
-toggle_breakpoint = Toggle Breakpoint
-stacktrace = Stacktrace
 console = Console
-locals = Locals
 cancel = Cancel
+connect_using = Connect using the
+vscode = VSCode Extension
+or_compatible = or any DAP-compatible debugger.
+configuration = Configuration
+address = Address:
+port = Port:
+help = [Learn More]
+enable = Enable Debugger
+disable = Disable Debugger
+locals = Locals
+globals = Globals
+main = [main]
+unnamed_function = [unnamed function]
+tail_call = (tailcall)
+error = Debugger error: {0}
+error_in_use = Another debugger is already active or the port is in use.
+error_server_creation = Could not create debugger server.
+error_no_simultaneous_debugger = Aseprite does not support multiple simultaneous debugger sessions.
+error_requires_argument = Requires the "{0}" argument
+error_requires_arguments = Requires the "{0}" or "{1}" arguments
+error_extension_not_enabled = The Extension is not currently enabled, enable it inside Aseprite or use the 'launch' request.
+error_extension_no_scripts = The Extension does not have any scripts to debug.
+error_extension_not_found = Extension "{0}" not found
+error_script_not_found = Script file not found
+error_script_error = Script encountered an error
+error_bp_source_not_found = Cannot find source for breakpoint
+error_already_paused = Already paused
+error_is_not_paused = Execution is not paused
+error_already_top_level = Already at the top level
+error_unsupported = Option unsupported
 
 [document_tab_popup_menu]
 duplicate_view = Duplicate &View

--- a/data/widgets/debugger.xml
+++ b/data/widgets/debugger.xml
@@ -1,0 +1,25 @@
+<!-- Aseprite -->
+<!-- Copyright (C) 2026-present by Igara Studio S.A. -->
+<gui>
+<window id="debugger" text="@.title">
+  <vbox>
+    <hbox childspacing="1">
+      <label text="@.connect_using" /><link text="@.vscode" url="https://github.com/aseprite/aseprite-vscode-debugger" />
+    </hbox>
+    <label text="@.or_compatible" />
+    <separator text="@.configuration" horizontal="true" />
+    <hbox>
+      <label text="@.address" for="address_entry" />
+      <entry id="address_entry" maxsize="45" />
+      <label text="@.port" for="port_entry" />
+      <entry id="port_entry" maxsize="5" />
+    </hbox>
+    <separator horizontal="true" />
+    <hbox>
+      <link text="@.help" url="https://www.aseprite.org/docs/debugger/" />
+      <boxfiller />
+      <button id="toggle_debugger" magnet="true" text="@.enable" />
+    </hbox>
+  </vbox>
+</window>
+</gui>

--- a/docs/LICENSES.md
+++ b/docs/LICENSES.md
@@ -4,6 +4,7 @@ Aseprite uses the following open source projects:
 * [Bresenham algorithm implementations by Alois Zingl](http://members.chello.at/easyfilter/bresenham.html)
 * [cityhash](https://github.com/google/cityhash)
 * [cmark](https://github.com/jgm/cmark)
+* [cppdap](https://github.com/google/cppdap)
 * [curl](http://curl.haxx.se/)
 * [fmt](https://github.com/fmtlib/fmt)
 * [FreeType](http://www.freetype.org/)
@@ -279,6 +280,212 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+# [cppdap](https://github.com/google/cppdap)
+
+```
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 ```
 
 # [curl](http://curl.haxx.se/)

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -176,6 +176,7 @@ endif()
 if(ENABLE_SCRIPTING)
   target_link_libraries(app-lib lua lauxlib lualib)
   target_compile_definitions(app-lib PUBLIC -DENABLE_SCRIPTING)
+  target_link_libraries(app-lib cppdap)
 
   if(ENABLE_WEBSOCKET)
     target_link_libraries(app-lib ixwebsocket)
@@ -200,6 +201,7 @@ if(ENABLE_SCRIPTING)
     script/cels_class.cpp
     script/color_class.cpp
     script/color_space_class.cpp
+    script/debugger.cpp
     script/dialog_class.cpp
     script/editor_class.cpp
     script/engine.cpp
@@ -214,6 +216,7 @@ if(ENABLE_SCRIPTING)
     script/image_spec_class.cpp
     script/images_class.cpp
     script/json_class.cpp
+    script/iterator_class.cpp
     script/keys.cpp
     script/layer_class.cpp
     script/layers_class.cpp

--- a/src/app/commands/debugger.cpp
+++ b/src/app/commands/debugger.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2021-2022  Igara Studio S.A.
+// Copyright (C) 2021-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -13,25 +13,94 @@
 #endif
 
 #include "app/commands/debugger.h"
+#include "app/console.h"
+#include "app/context.h"
+#include "app/i18n/strings.h"
+#include "app/script/debugger.h"
+#include "ui/alert.h"
+#include "ui/system.h"
 
-#include "app/app.h"
+#include "debugger.xml.h"
 
 namespace app {
 
 using namespace ui;
 
+constexpr auto kDefaultAddress = "localhost";
+constexpr uint16_t kDefaultPort = 58000;
+
+class DebuggerWindow final : public gen::Debugger {
+public:
+  DebuggerWindow() : m_debugger(nullptr)
+  {
+    addressEntry()->setPlaceholder(kDefaultAddress);
+    portEntry()->setPlaceholder(std::to_string(kDefaultPort));
+    toggleDebugger()->Click.connect(&DebuggerWindow::toggle, this);
+  }
+
+  void toggle()
+  {
+    if (m_debugger) {
+      if (m_debugger->isDebugging()) {
+        // TODO: We could also have a signal coming from the debugger to tell us when we have an
+        // active session (and some information) so we can change the UI accordingly. Having a
+        // button to disconnect the debugging session from aseprite would also be good, with some
+        // kind of indicator.
+        Alert::show(Strings::alerts_debugger_end_session_before_disabling());
+        return;
+      }
+      toggleDebugger()->setText(Strings::debugger_enable());
+      m_debugger.reset();
+    }
+    else {
+      toggleDebugger()->setText(Strings::debugger_disable());
+      std::string address = kDefaultAddress;
+      if (!addressEntry()->text().empty())
+        address = addressEntry()->text();
+
+      uint16_t port = kDefaultPort;
+      if (!portEntry()->text().empty()) {
+        const int entryPort = portEntry()->textInt();
+        port = std::clamp<uint16_t>(entryPort, 0, UINT16_MAX);
+        if (entryPort != port && port != kDefaultPort)
+          portEntry()->setTextf("%d", port);
+      }
+
+      try {
+        m_debugger = std::make_unique<script::Debugger>(address, port);
+        m_debugger->Error.connect([](const std::string& error) {
+          execute_now_or_enqueue([error] { Console::println(error); });
+        });
+      }
+      catch (const base::Exception& ex) {
+        m_debugger = nullptr;
+        toggleDebugger()->setText(Strings::debugger_enable());
+        Alert::show(Strings::alerts_debugger_failed_to_enable(ex.what()));
+      }
+    }
+  }
+
+private:
+  std::unique_ptr<script::Debugger> m_debugger;
+};
+
+static DebuggerWindow* g_window = nullptr;
+
 DebuggerCommand::DebuggerCommand() : Command(CommandId::Debugger())
 {
 }
 
-bool DebuggerCommand::onEnabled(Context*)
+bool DebuggerCommand::onEnabled(Context* context)
 {
-  return false;
+  return context->isUIAvailable();
 }
 
 void DebuggerCommand::onExecute(Context*)
 {
-  // TODO: Implement a DAP host and the UI to turn it on/off.
+  if (!g_window)
+    g_window = new DebuggerWindow();
+
+  g_window->openWindow();
 }
 
 Command* CommandFactory::createDebuggerCommand()

--- a/src/app/commands/debugger.h
+++ b/src/app/commands/debugger.h
@@ -10,8 +10,6 @@
 
 #include "app/commands/command.h"
 
-#include <memory>
-
 namespace app {
 
 class DebuggerCommand : public Command {

--- a/src/app/extensions.h
+++ b/src/app/extensions.h
@@ -32,7 +32,8 @@ class Command;
 #ifdef ENABLE_SCRIPTING
 namespace script {
 class Engine;
-}
+class Debugger;
+} // namespace script
 #endif
 
 // Key=id
@@ -116,6 +117,10 @@ public:
   };
 
 #ifdef ENABLE_SCRIPTING
+  // Allows the debugger to initialize m_engine before initScripts() with the debugger already
+  // attached
+  friend script::Debugger;
+
   struct CustomFormatDefinition {
     std::string name;
     std::vector<std::string> extensions;

--- a/src/app/script/app_clipboard_object.cpp
+++ b/src/app/script/app_clipboard_object.cpp
@@ -257,7 +257,7 @@ const Property Clipboard_properties[] = {
   { "content",  Clipboard_get_content, Clipboard_set_content },
   { nullptr,    nullptr,               nullptr               }
 };
-
+DEF_ITERATOR_PAIRS(Clipboard);
 } // anonymous namespace
 
 DEF_MTNAME(Clipboard);

--- a/src/app/script/app_command_object.cpp
+++ b/src/app/script/app_command_object.cpp
@@ -102,7 +102,7 @@ const luaL_Reg AppCommand_methods[] = {
   { "__index", AppCommand_index },
   { nullptr,   nullptr          }
 };
-
+DEF_ITERATOR_PAIRS(Command);
 } // anonymous namespace
 
 DEF_MTNAME(Command);

--- a/src/app/script/app_fs_object.cpp
+++ b/src/app/script/app_fs_object.cpp
@@ -214,7 +214,7 @@ const luaL_Reg AppFS_methods[] = {
   { "removeDirectory",    AppFS_removeDirectory                             },
   { nullptr,              nullptr                                           }
 };
-
+DEF_ITERATOR_PAIRS(AppFS);
 } // anonymous namespace
 
 DEF_MTNAME(AppFS);

--- a/src/app/script/app_object.cpp
+++ b/src/app/script/app_object.cpp
@@ -927,7 +927,7 @@ const Property App_properties[] = {
   { "clipboard",      App_get_clipboard,      nullptr                },
   { nullptr,          nullptr,                nullptr                }
 };
-
+DEF_ITERATOR_PAIRS(App);
 } // anonymous namespace
 
 DEF_MTNAME(App);

--- a/src/app/script/app_os_object.cpp
+++ b/src/app/script/app_os_object.cpp
@@ -99,7 +99,7 @@ const Property AppOS_properties[] = {
 const luaL_Reg AppOS_methods[] = {
   { nullptr, nullptr }
 };
-
+DEF_ITERATOR_PAIRS(AppOS);
 } // anonymous namespace
 
 DEF_MTNAME(AppOS);

--- a/src/app/script/app_theme_object.cpp
+++ b/src/app/script/app_theme_object.cpp
@@ -149,7 +149,7 @@ const luaL_Reg ThemeColor_methods[] = {
   { "__index", ThemeColor_index },
   { nullptr,   nullptr          }
 };
-
+DEF_ITERATOR_PAIRS(Theme);
 } // anonymous namespace
 
 DEF_MTNAME(Theme);

--- a/src/app/script/brush_class.cpp
+++ b/src/app/script/brush_class.cpp
@@ -211,7 +211,7 @@ const Property Brush_properties[] = {
   { "patternOrigin", Brush_get_patternOrigin, nullptr },
   { nullptr,         nullptr,                 nullptr }
 };
-
+DEF_ITERATOR_PAIRS(Brush);
 } // anonymous namespace
 
 DEF_MTNAME(BrushObj);

--- a/src/app/script/cel_class.cpp
+++ b/src/app/script/cel_class.cpp
@@ -181,7 +181,7 @@ const Property Cel_properties[] = {
   { "properties",  UserData_get_properties<Cel>, UserData_set_properties<Cel> },
   { nullptr,       nullptr,                      nullptr                      }
 };
-
+DEF_ITERATOR_PAIRS(Cel);
 } // anonymous namespace
 
 DEF_MTNAME(Cel);

--- a/src/app/script/color_class.cpp
+++ b/src/app/script/color_class.cpp
@@ -468,7 +468,7 @@ const Property Color_properties[] = {
   { "grayPixel",     Color_get_grayPixel,     nullptr                 },
   { nullptr,         nullptr,                 nullptr                 }
 };
-
+DEF_ITERATOR_PAIRS(Color);
 } // anonymous namespace
 
 DEF_MTNAME(app::Color);

--- a/src/app/script/color_space_class.cpp
+++ b/src/app/script/color_space_class.cpp
@@ -90,7 +90,7 @@ const Property ColorSpace_properties[] = {
   { "name",  ColorSpace_get_name, ColorSpace_set_name },
   { nullptr, nullptr,             nullptr             }
 };
-
+DEF_ITERATOR_PAIRS(ColorSpace);
 } // anonymous namespace
 
 DEF_MTNAME(gfx::ColorSpace);

--- a/src/app/script/debugger.cpp
+++ b/src/app/script/debugger.cpp
@@ -1,0 +1,808 @@
+// Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
+//
+// This program is distributed under the terms of
+// the End-User License Agreement for Aseprite.
+
+#ifdef HAVE_CONFIG_H
+  #include "config.h"
+#endif
+
+#include "app/app.h"
+#include "app/i18n/strings.h"
+#include "app/resource_finder.h"
+#include "app/script/debugger.h"
+#include "app/script/engine_manager.h"
+#include "app/script/luacpp.h"
+#include "base/exception.h"
+#include "base/fs.h"
+#include "doc/layer.h"
+#include "ui/manager.h"
+#include "ui/message_loop.h"
+#include "ui/register_message.h"
+#include "ui/system.h"
+
+#include "dap/io.h"
+#include "dap/network.h"
+#include "dap/protocol.h"
+#include "dap/session.h"
+
+#include "fmt/format.h"
+
+#include <future>
+
+struct AseLaunchRequest : dap::LaunchRequest {
+  using Response = dap::LaunchResponse;
+  dap::optional<dap::string> extensionName;
+  dap::optional<dap::string> scriptFilename;
+};
+
+struct AseAttachRequest : dap::AttachRequest {
+  using Response = dap::AttachResponse;
+  dap::optional<dap::string> extensionName;
+};
+
+namespace {
+constexpr int kLocals = std::numeric_limits<int>::max() - 1;
+constexpr int kGlobals = std::numeric_limits<int>::max();
+
+std::string next_key_string(lua_State* L)
+{
+  lua_pushvalue(L, -2);
+  std::string key;
+  const int keyType = lua_type(L, -1);
+  if (keyType == LUA_TSTRING || keyType == LUA_TNUMBER) {
+    key = lua_tostring(L, -1);
+  }
+  else if (keyType == LUA_TBOOLEAN) {
+    key = fmt::format("[bool:{}]", lua_toboolean(L, -1) ? "true" : "false");
+  }
+  else {
+    key = fmt::format("[{}]", lua_typename(L, keyType));
+  }
+  lua_pop(L, 1);
+  return key;
+}
+} // namespace
+
+namespace dap {
+DAP_STRUCT_TYPEINFO_EXT(AseLaunchRequest,
+                        LaunchRequest,
+                        "launch",
+                        DAP_FIELD(extensionName, "extensionName"),
+                        DAP_FIELD(scriptFilename, "scriptFilename"));
+DAP_STRUCT_TYPEINFO_EXT(AseAttachRequest,
+                        AttachRequest,
+                        "attach",
+                        DAP_FIELD(extensionName, "extensionName"));
+} // namespace dap
+
+namespace app::script {
+
+ui::RegisterMessage kDebuggerWakeMessage;
+
+Debugger::Debugger(const std::string& address, const uint16_t port)
+  : m_extension(nullptr)
+  , m_hookState(State::Pass)
+  , m_hookStackLevel(0)
+  , m_commandStackLevel(0)
+{
+  ui::assert_ui_thread();
+
+  // cppdap hangs inside a mutex lock if we attempt to start a server when there's already one open
+  // so we need to test it beforehand.
+  if (dap::net::connect(address.c_str(), port, 100))
+    throw base::Exception(Strings::debugger_error_in_use());
+
+  m_server = dap::net::Server::create();
+  const bool result = m_server->start(
+    address.c_str(),
+    port,
+    [this](const auto& rw) { onClientConnected(rw); },
+    [this](const char* msg) {
+      Error(Strings::debugger_error(msg));
+      m_session.reset();
+    });
+  if (!result)
+    throw base::Exception(Strings::debugger_error_server_creation());
+
+  m_threadId = std::hash<std::thread::id>{}(std::this_thread::get_id());
+  m_changeConn = App::instance()->extensions().ScriptsChange.connect(&Debugger::onExtensionChange,
+                                                                     this);
+}
+
+Debugger::~Debugger()
+{
+  ASSERT(!isDebugging());
+  m_session.reset();
+  m_server->stop();
+}
+
+void Debugger::setHookState(const State hookState)
+{
+  if (m_hookState == hookState)
+    return;
+
+  m_hookState = hookState;
+
+  if (hookState == State::Wait)
+    return;
+
+  // When we're going from a wait state to another, we need to send a message to the queue wake up
+  // the loop inside the hook
+  ui::execute_from_ui_thread(
+    [] { ui::Manager::getDefault()->enqueueMessage(new ui::Message(kDebuggerWakeMessage)); });
+}
+
+void Debugger::updateVariables(lua_State* L)
+{
+  // Go through the registry and unref all the refs.
+  for (const auto& refs : m_registry) {
+    for (const auto& ref : refs) {
+      luaL_unref(L, LUA_REGISTRYINDEX, ref.ref);
+    }
+  }
+  m_registry.clear();
+
+  // Updating locals
+  m_locals.clear();
+  lua_Debug ar;
+  if (lua_getstack(L, 0, &ar)) {
+    for (int n = 1;; ++n) {
+      const char* name = lua_getlocal(L, &ar, n);
+      if (!name)
+        break;
+
+      // These special names are returned by luaG_findlocal()
+      if (strcmp(name, "(temporary)") == 0 || strcmp(name, "(C temporary)") == 0) {
+        lua_pop(L, 1);
+        continue;
+      }
+
+      m_locals.push_back(makeVariable(L, name));
+      lua_pop(L, 1);
+    }
+  }
+
+  // Updating globals
+  m_globals.clear();
+  lua_pushglobaltable(L);
+  lua_pushnil(L);
+  while (lua_next(L, -2) != 0) {
+    const std::string name = next_key_string(L);
+    if (name != "_G" && name != "_ENV")
+      m_globals.push_back(makeVariable(L, name));
+    lua_pop(L, 1);
+  }
+  lua_pop(L, 1);
+}
+
+void Debugger::updateStackTrace(lua_State* L)
+{
+  m_currentStackTrace.clear();
+  lua_Debug ar;
+  int level = 0;
+  while (lua_getstack(L, level++, &ar)) {
+    dap::StackFrame frame;
+    frame.id = level;
+    lua_getinfo(L, "Slntf", &ar);
+    const std::string filename(ar.short_src, ar.srclen - 1);
+
+    if (!filename.empty() && filename != "[C]") {
+      dap::Source source;
+      source.path = filename;
+      frame.source = source;
+    }
+
+    if (ar.currentline > 0)
+      frame.line = ar.currentline;
+
+    // If we're inside a pcall we lose ar.name
+    if (ar.name) {
+      frame.name = ar.name;
+    }
+    else if (strcmp(ar.what, "main") == 0) {
+      frame.name = Strings::debugger_main();
+    }
+    else {
+      frame.name = Strings::debugger_unnamed_function();
+    }
+
+    if (ar.istailcall)
+      frame.name += " " + Strings::debugger_tail_call();
+    m_currentStackTrace.push_back(frame);
+
+    lua_pop(L, 1);
+  }
+}
+
+dap::Variable Debugger::makeVariable(lua_State* L, const std::string& name)
+{
+  dap::Variable var;
+  var.name = name;
+
+  switch (lua_type(L, -1)) {
+    case LUA_TNIL:
+      var.type = "nil";
+      var.value = "nil";
+      break;
+    case LUA_TBOOLEAN:
+      var.type = "boolean";
+      var.value = lua_toboolean(L, -1) ? "true" : "false";
+      break;
+    case LUA_TNUMBER:
+      var.type = "number";
+      if (lua_isinteger(L, -1)) {
+        var.value = std::to_string(lua_tointeger(L, -1));
+      }
+      else {
+        var.value = std::to_string(lua_tonumber(L, -1));
+      }
+      break;
+    case LUA_TSTRING:
+      var.type = "string";
+      if (auto* str = lua_tostring(L, -1))
+        var.value = str;
+      break;
+    case LUA_TLIGHTUSERDATA: var.type = "lightuserdata"; break;
+    case LUA_TFUNCTION:      var.type = "function"; break;
+    case LUA_TTABLE:         {
+      var.type = "table";
+      lua_pushnil(L);
+      std::vector<VariableReference> references;
+      while (lua_next(L, -2) != 0) {
+        VariableReference ref;
+        ref.name = next_key_string(L);
+        ref.ref = luaL_ref(L, LUA_REGISTRYINDEX);
+        references.push_back(ref);
+      }
+      var.namedVariables = references.size();
+      m_registry.push_back(references);
+      var.variablesReference = m_registry.size();
+      break;
+    }
+    case LUA_TUSERDATA: {
+      if (luaL_getmetafield(L, -1, "__typename") == LUA_TSTRING) {
+        if (const auto* typeName = lua_tostring(L, -1))
+          var.type = typeName;
+        lua_pop(L, 1);
+      }
+
+      if (luaL_getmetafield(L, -1, "__pairs") == LUA_TFUNCTION) {
+        std::vector<VariableReference> references;
+        lua_pushvalue(L, -2);
+        lua_call(L, 1, 3);
+        for (;;) {
+          lua_pushvalue(L, -2);
+          lua_pushvalue(L, -2);
+          lua_copy(L, -5, -3);
+          lua_call(L, 2, 2);
+          const int type = lua_type(L, -2);
+          if (type == LUA_TNIL) {
+            lua_pop(L, 4);
+            break;
+          }
+          VariableReference ref;
+          ref.name = next_key_string(L);
+          ref.ref = luaL_ref(L, LUA_REGISTRYINDEX);
+          references.push_back(ref);
+        }
+
+        m_registry.push_back(references);
+        var.indexedVariables = references.size();
+        var.variablesReference = m_registry.size();
+      }
+      else if (luaL_getmetafield(L, -1, "__len") == LUA_TFUNCTION) {
+        // There doesn't seem to be a way to check for the __len metamethod without also putting it
+        // in the stack and we *could* call it manually, but it's more finicky than using lua_len
+        // so we just pop the function back out.
+        lua_pop(L, 1);
+
+        std::vector<VariableReference> references;
+        auto objIndex = lua_absindex(L, -1);
+        lua_len(L, objIndex);
+        auto len = lua_tointeger(L, -1);
+        lua_pop(L, 1);
+
+        for (lua_Integer i = 1; i <= len; i++) {
+          lua_pushinteger(L, i);
+          lua_gettable(L, objIndex);
+          if (!lua_isnil(L, -1)) {
+            VariableReference ref;
+            ref.index = i;
+            ref.ref = luaL_ref(L, LUA_REGISTRYINDEX);
+            references.push_back(ref);
+          }
+          else
+            lua_pop(L, 1);
+        }
+        m_registry.push_back(references);
+        var.variablesReference = m_registry.size();
+        if (!var.type.has_value())
+          var.type = "table";
+      }
+      else {
+        // Last ditch effort, stringify the value
+        size_t len;
+        const char* str = luaL_tolstring(L, -1, &len);
+        lua_pop(L, 1);
+        if (len > 0) {
+          var.type = "string";
+          var.value = std::string(str, len);
+        }
+      }
+
+      if (!var.type.has_value())
+        var.type = "userdata";
+      break;
+    }
+    case LUA_TTHREAD: var.type = "thread"; break;
+    default:          break;
+  }
+
+  return var;
+}
+
+// Sends the stop event and sets the hook state to "wait"
+// Valid reasons:
+// 'step', 'breakpoint', 'exception', 'pause', 'entry', 'goto', 'function breakpoint',
+// 'data breakpoint', 'instruction breakpoint'
+void Debugger::stop(const std::string& reason, const dap::integer)
+{
+  dap::StoppedEvent event;
+  event.reason = reason;
+  event.threadId = m_threadId;
+  m_session->send(event);
+  setHookState(State::Wait);
+}
+
+void Debugger::onHook(lua_State* L, lua_Debug* ar)
+{
+  ASSERT(isDebugging());
+  ASSERT(m_session);
+  ASSERT(ar);
+
+  m_lastHookTick = base::current_tick();
+
+  if (m_hookState.load() == State::Abort)
+    return;
+
+  const int ret = lua_getinfo(L, "lSn", ar);
+  if (ret == 0 || ar->currentline < 0)
+    return;
+
+  switch (ar->event) {
+    case LUA_HOOKCALL: ++m_hookStackLevel; break;
+    case LUA_HOOKRET:  --m_hookStackLevel; break;
+    case LUA_HOOKLINE:
+      if (m_hookState.load() == State::NextLine && m_hookStackLevel <= m_commandStackLevel) {
+        m_commandStackLevel = m_hookStackLevel;
+        stop("step", ar->currentline);
+        break;
+      }
+
+      std::string filename = ar->source;
+      if (!filename.empty() && filename[0] == '@')
+        filename = ar->source + 1;
+      filename = base::normalize_path(filename);
+#ifdef LAF_WINDOWS
+      filename = base::string_to_lower(filename);
+#endif
+
+      const std::lock_guard lock(m_mutex);
+      for (auto [itr, rangeEnd] = m_breakpoints.equal_range(filename); itr != rangeEnd; ++itr) {
+        if (itr->second == ar->currentline) {
+          stop("breakpoint", ar->currentline);
+          break;
+        }
+      }
+      break;
+  }
+
+  if (m_hookState.load() == State::Wait) {
+    {
+      const std::lock_guard lock(m_mutex);
+      updateVariables(L);
+      updateStackTrace(L);
+    }
+    ui::MessageLoop loop(ui::Manager::getDefault());
+    while (m_hookState.load() == State::Wait)
+      loop.pumpMessages();
+  }
+}
+
+void Debugger::onExtensionChange(Extension* ext)
+{
+  if (!m_extension)
+    return;
+
+  if (m_extension == ext && !m_extension->isEnabled()) {
+    // If scripts have changed in any way we must terminate the debugging session to avoid having a
+    // dangling Extension pointer.
+    m_session->send(dap::TerminatedEvent{});
+  }
+}
+
+void Debugger::onClientConnected(const std::shared_ptr<dap::ReaderWriter>& rw)
+{
+  if (isDebugging()) {
+    // Close any incoming connection attempts while we're already debugging.
+    Error(Strings::debugger_error_in_use());
+    rw->close();
+    return;
+  }
+
+  // Clear everything before we allow another client.
+  m_currentStackTrace.clear();
+  m_breakpoints.clear();
+  m_locals.clear();
+  m_globals.clear();
+  m_commandStackLevel = 0;
+  m_hookStackLevel = 0;
+
+  m_session = dap::Session::create();
+
+  registerHandlers();
+
+  m_session->setOnInvalidData(dap::kClose);
+  m_session->bind(rw, [this] { onSessionClosed(); });
+
+  dap::ThreadEvent threadStartedEvent;
+  threadStartedEvent.reason = "started";
+  threadStartedEvent.threadId = m_threadId;
+  m_session->send(threadStartedEvent);
+}
+
+void Debugger::registerHandlers()
+{
+  m_session->onError([this](const char* msg) { onSessionError(msg); });
+
+  // Static response handlers
+  m_session->registerHandler([](const dap::InitializeRequest&) {
+    dap::InitializeResponse response;
+    response.supportsReadMemoryRequest = false;
+    response.supportsDataBreakpoints = false;
+    response.supportsExceptionOptions = false;
+    response.supportsDelayedStackTraceLoading = false;
+    response.supportsSetVariable = false;
+    response.supportsConditionalBreakpoints = false;
+    response.supportsConfigurationDoneRequest = true;
+    return response;
+  });
+  m_session->registerSentHandler([this](const dap::ResponseOrError<dap::InitializeResponse>&) {
+    m_session->send(dap::InitializedEvent{});
+  });
+  m_session->registerHandler(
+    [](const dap::ConfigurationDoneRequest&) { return dap::ConfigurationDoneResponse{}; });
+
+  // Main handlers
+  m_session->registerHandler(
+    [this](const dap::ThreadsRequest& request) { return onThreads(request); });
+  m_session->registerHandler([this](const AseAttachRequest& request) { return onAttach(request); });
+  m_session->registerHandler([this](const AseLaunchRequest& request) { return onLaunch(request); });
+  m_session->registerHandler(
+    [this](const dap::SetBreakpointsRequest& request) { return onSetBreakpoints(request); });
+  m_session->registerHandler([this](const dap::PauseRequest& request) { return onPause(request); });
+  m_session->registerHandler(
+    [this](const dap::ContinueRequest& request) { return onContinue(request); });
+  m_session->registerHandler([this](const dap::NextRequest& request) { return onNext(request); });
+  m_session->registerHandler(
+    [this](const dap::StepInRequest& request) { return onStepIn(request); });
+  m_session->registerHandler(
+    [this](const dap::StepOutRequest& request) { return onStepOut(request); });
+  m_session->registerHandler(
+    [](const dap::DisconnectRequest&) { return dap::DisconnectResponse{}; });
+  m_session->registerHandler(
+    [this](const dap::StackTraceRequest& request) { return onStackTrace(request); });
+  m_session->registerHandler(
+    [this](const dap::ScopesRequest& request) { return onScopes(request); });
+  m_session->registerHandler(
+    [this](const dap::VariablesRequest& request) { return onVariables(request); });
+}
+
+void Debugger::onSessionError(const char* msg)
+{
+  Error(fmt::format("Debugger session error: {}", msg));
+}
+
+dap::ThreadsResponse Debugger::onThreads(const dap::ThreadsRequest&) const
+{
+  dap::ThreadsResponse response;
+  dap::Thread thread;
+  thread.id = m_threadId;
+  thread.name = "Main";
+  response.threads.push_back(thread);
+  return response;
+}
+
+dap::ResponseOrError<dap::AttachResponse> Debugger::onAttach(const AseAttachRequest& request)
+{
+  if (isDebugging())
+    return dap::Error(Strings::debugger_error_no_simultaneous_debugger());
+
+  if (!request.extensionName.has_value() || request.extensionName.value().empty())
+    return dap::Error(Strings::debugger_error_requires_argument("extensionName"));
+
+  const auto& name = request.extensionName.value();
+  for (Extension* ext : App::instance()->extensions()) {
+    if (ext->name() == name) {
+      if (!ext->isEnabled())
+        return dap::Error(Strings::debugger_error_extension_not_enabled());
+
+      if (!ext->hasScripts())
+        return dap::Error(Strings::debugger_error_extension_no_scripts());
+
+      m_extension = ext;
+      setHookState(State::Pass);
+      ui::execute_from_ui_thread([this] { m_extension->scriptEngine()->setDebugger(this); });
+
+      return dap::AttachResponse{};
+    }
+  }
+
+  return dap::Error(Strings::debugger_error_extension_not_found(name));
+}
+
+dap::ResponseOrError<dap::LaunchResponse> Debugger::onLaunch(const AseLaunchRequest& request)
+{
+  if (request.noDebug)
+    return dap::Error(Strings::debugger_error_unsupported());
+
+  if (isDebugging())
+    return dap::Error(Strings::debugger_error_no_simultaneous_debugger());
+
+  if ((!request.extensionName.has_value() || request.extensionName.value().empty()) &&
+      (!request.scriptFilename.has_value() || request.scriptFilename.value().empty()))
+    return dap::Error(
+      Strings::debugger_error_requires_arguments("extensionName", "scriptFilename"));
+
+  if (request.scriptFilename.has_value() && !request.scriptFilename.value().empty()) {
+    std::string filename = request.scriptFilename.value();
+
+    if (!base::is_absolute_path(filename) && !base::is_file(filename)) {
+      ResourceFinder rf;
+      rf.includeUserDir(base::join_path("scripts", filename));
+      if (rf.findFirst())
+        filename = rf.filename();
+    }
+    filename = base::normalize_path(filename);
+    if (!base::is_file(filename))
+      return dap::Error(Strings::debugger_error_script_not_found());
+
+    ui::execute_from_ui_thread([this, filename] {
+      setHookState(State::Pass);
+      m_engine = EngineManager::create();
+      std::string lastError;
+      m_engine->ConsoleError.connect([&lastError](const std::string& error) { lastError = error; });
+      m_engine->setDebugger(this);
+      m_engine->evalUserFile(filename);
+
+      if (m_engine->returnCode() < 0) {
+        dap::StoppedEvent event;
+        event.description = Strings::debugger_error_script_error();
+        event.reason = "exception";
+        event.text = lastError;
+        m_session->send(event);
+      }
+
+      if (m_engine->hasLingeringObjects())
+        return;
+
+      m_engine.reset();
+      if (m_hookState.load() != State::Abort)
+        m_session->send(dap::TerminatedEvent{});
+    });
+  }
+  else if (request.extensionName.has_value() && !request.extensionName.value().empty()) {
+    for (Extension* ext : App::instance()->extensions()) {
+      if (base::string_to_lower(ext->name()) ==
+          base::string_to_lower(request.extensionName.value())) {
+        if (!ext->hasScripts())
+          return dap::Error(Strings::debugger_error_extension_no_scripts());
+
+        std::promise<Extension*> promise;
+        ui::execute_from_ui_thread([this, &promise, ext] {
+          if (ext->isEnabled())
+            App::instance()->extensions().enableExtension(ext, false);
+
+          setHookState(State::Pass);
+
+          // Pre-initialize the engine with the debugger already created, so that we can
+          // set breakpoints inside init().
+          ext->m_engine = EngineManager::create();
+          ext->m_engine->setDebugger(this);
+          promise.set_value(ext);
+        });
+
+        m_extension = promise.get_future().get();
+
+        ui::execute_from_ui_thread(
+          [this] { App::instance()->extensions().enableExtension(m_extension, true); });
+      }
+    }
+    if (!m_extension)
+      return dap::Error(Strings::debugger_error_extension_not_found(request.extensionName.value()));
+  }
+
+  return dap::LaunchResponse{};
+}
+
+dap::ResponseOrError<dap::SetBreakpointsResponse> Debugger::onSetBreakpoints(
+  const dap::SetBreakpointsRequest& request)
+{
+  const std::lock_guard lock(m_mutex);
+
+  if (!request.breakpoints.has_value())
+    return dap::SetBreakpointsResponse{};
+
+  if (!request.source.path.has_value())
+    return dap::Error(Strings::debugger_error_bp_source_not_found());
+
+  dap::SetBreakpointsResponse response{};
+
+  auto path = base::normalize_path(request.source.path.value());
+#ifdef LAF_WINDOWS
+  // Some debuggers can send the drive letter in lowercase
+  path = base::string_to_lower(path);
+#endif
+
+  m_breakpoints.erase(path);
+  for (const auto& breakpoint : request.breakpoints.value()) {
+    m_breakpoints.emplace(path, breakpoint.line);
+
+    dap::Breakpoint bp;
+    // TODO: Ideally we would store this Breakpoint object inside m_breakpoints and then verify
+    // them after we run through them inside the hook, moving the line in case the breakpoint is
+    // on an empty line.
+    bp.verified = true;
+    bp.line = breakpoint.line;
+    response.breakpoints.push_back(bp);
+  }
+
+  return response;
+}
+
+dap::ResponseOrError<dap::PauseResponse> Debugger::onPause(const dap::PauseRequest&)
+{
+  if (isWaiting())
+    return dap::Error(Strings::debugger_error_already_paused());
+
+  setHookState(State::Wait);
+  stop("pause", 0);
+  return dap::PauseResponse{};
+}
+
+dap::ResponseOrError<dap::ContinueResponse> Debugger::onContinue(const dap::ContinueRequest&)
+{
+  if (!isWaiting())
+    return dap::Error(Strings::debugger_error_is_not_paused());
+
+  setHookState(State::Pass);
+  return dap::ContinueResponse{};
+}
+
+dap::ResponseOrError<dap::NextResponse> Debugger::onNext(const dap::NextRequest&)
+{
+  if (!isWaiting())
+    return dap::Error(Strings::debugger_error_is_not_paused());
+
+  m_commandStackLevel = m_hookStackLevel;
+  setHookState(State::NextLine);
+  return dap::NextResponse{};
+}
+
+dap::ResponseOrError<dap::StepInResponse> Debugger::onStepIn(const dap::StepInRequest&)
+{
+  if (!isWaiting())
+    return dap::Error(Strings::debugger_error_is_not_paused());
+
+  m_commandStackLevel += 1;
+  setHookState(State::NextLine);
+  return dap::StepInResponse{};
+}
+
+dap::ResponseOrError<dap::StepOutResponse> Debugger::onStepOut(const dap::StepOutRequest&)
+{
+  if (!isWaiting())
+    return dap::Error(Strings::debugger_error_is_not_paused());
+
+  if (m_hookStackLevel == 0 || m_commandStackLevel == 0)
+    return dap::Error(Strings::debugger_error_already_top_level());
+
+  m_commandStackLevel -= 1;
+  setHookState(State::NextLine);
+  return dap::StepOutResponse{};
+}
+
+dap::ResponseOrError<dap::StackTraceResponse> Debugger::onStackTrace(const dap::StackTraceRequest&)
+{
+  const std::lock_guard lock(m_mutex);
+  dap::StackTraceResponse response;
+  response.stackFrames = m_currentStackTrace;
+  return response;
+}
+
+dap::ResponseOrError<dap::ScopesResponse> Debugger::onScopes(const dap::ScopesRequest&)
+{
+  dap::ScopesResponse response;
+  dap::Scope locals;
+  locals.expensive = false;
+  locals.name = Strings::debugger_locals();
+  locals.variablesReference = kLocals;
+
+  dap::Scope globals;
+  globals.expensive = false;
+  globals.name = Strings::debugger_globals();
+  globals.variablesReference = kGlobals;
+
+  response.scopes = { locals, globals };
+  return response;
+}
+
+dap::ResponseOrError<dap::VariablesResponse> Debugger::onVariables(
+  const dap::VariablesRequest& request)
+{
+  dap::VariablesResponse response;
+  if (request.variablesReference == kLocals) {
+    const std::lock_guard lock(m_mutex);
+    response.variables = m_locals;
+  }
+  else if (request.variablesReference == kGlobals) {
+    const std::lock_guard lock(m_mutex);
+    response.variables = m_globals;
+  }
+  else {
+    std::promise<std::vector<dap::Variable>> promise;
+    ui::execute_from_ui_thread([this, &request, &promise] {
+      const auto& list = m_registry[request.variablesReference - 1];
+      auto* L = m_extension ? m_extension->scriptEngine()->luaState() : m_engine->luaState();
+      std::vector<dap::Variable> vars;
+      vars.reserve(list.size());
+      for (const auto& [name, index, ref] : list) {
+        lua_rawgeti(L, LUA_REGISTRYINDEX, ref);
+        vars.push_back(makeVariable(L, name.empty() ? std::to_string(index) : name));
+        lua_pop(L, 1);
+      }
+      promise.set_value(vars);
+    });
+    response.variables = promise.get_future().get();
+  }
+
+  return response;
+}
+
+void Debugger::onSessionClosed()
+{
+  if (!isDebugging())
+    return;
+
+  // Alternate path to handle when the debugger disconnects:
+  const bool wasBreaking = m_hookState.load() != State::Pass && m_hookState.load() != State::Abort;
+  setHookState(State::Abort);
+
+  if (wasBreaking) {
+    // We don't have a way to know when the currently stopped script finished execution so we're
+    // going to try to sleep periodically and check that enough time has passed between the last
+    // time our hook was called, which is something that should happen every instruction and thus
+    // keep incrementing while we're still using the Lua state.
+    do {
+      std::this_thread::sleep_for(std::chrono::milliseconds(150));
+      if (base::current_tick() - m_lastHookTick > 200)
+        break;
+    } while (true);
+  }
+
+  ui::execute_from_ui_thread([this] {
+    if (m_engine) {
+      m_engine->setDebugger(nullptr);
+      m_engine.reset();
+    }
+    if (m_extension) {
+      if (m_extension->scriptEngine())
+        m_extension->scriptEngine()->setDebugger(nullptr);
+      m_extension = nullptr;
+    }
+  });
+}
+
+} // namespace app::script

--- a/src/app/script/debugger.h
+++ b/src/app/script/debugger.h
@@ -1,0 +1,123 @@
+// Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
+//
+// This program is distributed under the terms of
+// the End-User License Agreement for Aseprite.
+
+#ifndef APP_SCRIPT_DEBUGGER_H_INCLUDED
+#define APP_SCRIPT_DEBUGGER_H_INCLUDED
+#pragma once
+
+#ifdef ENABLE_SCRIPTING
+  #include "base/time.h"
+  #include "obs/signal.h"
+
+  #include "lua.h"
+
+  #include "dap/protocol.h"
+  #include "dap/session.h"
+
+  #include <map>
+  #include <vector>
+
+struct lua_State;
+struct lua_Debug;
+struct AseLaunchRequest;
+struct AseAttachRequest;
+
+namespace dap {
+class integer;
+struct Variable;
+struct StackFrame;
+namespace net {
+class Server;
+}
+class ReaderWriter;
+class Session;
+} // namespace dap
+
+namespace app {
+class Extension;
+}
+
+namespace app::script {
+class Engine;
+
+class Debugger final {
+  enum class State : uint8_t { Pass, Wait, NextLine, StepIn, StepOut, Abort };
+
+  struct VariableReference {
+    std::string name;
+    size_t index = 0;
+    int ref = -1;
+  };
+
+public:
+  Debugger(const std::string& address, uint16_t port);
+  ~Debugger();
+
+  void setHookState(State hookState);
+  bool isWaiting() const { return m_hookState.load() == State::Wait; }
+  bool isDebugging() const { return (m_engine || m_extension); }
+
+  void onHook(lua_State* L, lua_Debug* ar);
+
+  obs::safe_signal<void(const std::string&)> Error;
+
+private:
+  void onClientConnected(const std::shared_ptr<dap::ReaderWriter>& rw);
+  void onExtensionChange(Extension* ext);
+  void updateVariables(lua_State* L);
+  void updateStackTrace(lua_State* L);
+  dap::Variable makeVariable(lua_State* L, const std::string& name);
+  void stop(const std::string& reason, dap::integer line);
+
+  void registerHandlers();
+  dap::InitializeResponse onInitialize(const dap::InitializeRequest& request);
+  dap::ThreadsResponse onThreads(const dap::ThreadsRequest& request) const;
+  dap::ResponseOrError<dap::AttachResponse> onAttach(const AseAttachRequest& request);
+  dap::ResponseOrError<dap::LaunchResponse> onLaunch(const AseLaunchRequest& request);
+  dap::ResponseOrError<dap::SetBreakpointsResponse> onSetBreakpoints(
+    const dap::SetBreakpointsRequest& request);
+  dap::ResponseOrError<dap::PauseResponse> onPause(const dap::PauseRequest& request);
+  dap::ResponseOrError<dap::ContinueResponse> onContinue(const dap::ContinueRequest& request);
+  dap::ResponseOrError<dap::NextResponse> onNext(const dap::NextRequest& request);
+  dap::ResponseOrError<dap::StepInResponse> onStepIn(const dap::StepInRequest& request);
+  dap::ResponseOrError<dap::StepOutResponse> onStepOut(const dap::StepOutRequest& request);
+  dap::ResponseOrError<dap::StackTraceResponse> onStackTrace(const dap::StackTraceRequest& request);
+  dap::ResponseOrError<dap::ScopesResponse> onScopes(const dap::ScopesRequest& request);
+  dap::ResponseOrError<dap::VariablesResponse> onVariables(const dap::VariablesRequest& request);
+
+  void onSessionError(const char* msg);
+  void onSessionClosed();
+
+  int m_threadId;
+  obs::scoped_connection m_changeConn;
+
+  std::unique_ptr<dap::net::Server> m_server;
+  std::unique_ptr<dap::Session> m_session;
+
+  std::mutex m_mutex;
+  std::multimap<std::string, int> m_breakpoints;
+  std::unique_ptr<Engine> m_engine;
+  Extension* m_extension;
+  std::atomic<State> m_hookState;
+  base::tick_t m_lastHookTick;
+
+  // The currently executing stack level of the Lua script
+  uint32_t m_hookStackLevel;
+  // The stack level that we want to step through.
+  uint32_t m_commandStackLevel;
+
+  std::vector<dap::StackFrame> m_currentStackTrace;
+  std::vector<dap::Variable> m_locals;
+  std::vector<dap::Variable> m_globals;
+
+  std::vector<std::vector<VariableReference>> m_registry;
+};
+
+} // namespace app::script
+
+#endif // ENABLE_SCRIPTING
+
+#endif

--- a/src/app/script/dialog_class.cpp
+++ b/src/app/script/dialog_class.cpp
@@ -2056,7 +2056,7 @@ const Property Dialog_properties[] = {
   { "sizeHint", Dialog_get_sizeHint, nullptr            },
   { nullptr,    nullptr,             nullptr            }
 };
-
+DEF_ITERATOR_PAIRS(Dialog);
 } // anonymous namespace
 
 DEF_MTNAME(Dialog);

--- a/src/app/script/editor_class.cpp
+++ b/src/app/script/editor_class.cpp
@@ -390,7 +390,7 @@ const Property Editor_properties[] = {
   { "scroll",    Editor_get_scroll,    Editor_set_scroll },
   { nullptr,     nullptr,              nullptr           }
 };
-
+DEF_ITERATOR_PAIRS(Editor);
 } // anonymous namespace
 
 DEF_MTNAME(EditorObj);

--- a/src/app/script/engine.cpp
+++ b/src/app/script/engine.cpp
@@ -17,6 +17,7 @@
 #include "app/file/file_format.h"
 #include "app/pref/preferences.h"
 #include "app/script/blend_mode.h"
+#include "app/script/debugger.h"
 #include "app/script/events.h"
 #include "app/script/luacpp.h"
 #include "app/script/security.h"
@@ -86,6 +87,7 @@ void register_app_command_object(lua_State* L);
 void register_app_preferences_object(lua_State* L);
 void register_json_object(lua_State* L);
 
+void register_iterator_class(lua_State* L);
 void register_brush_class(lua_State* L);
 void register_cel_class(lua_State* L);
 void register_cels_class(lua_State* L);
@@ -137,12 +139,20 @@ void set_app_params(lua_State* L, const Params& params);
 namespace {
 
 // Wraps member functions to be registered directly to Lua.
-using memberFunction = int (Engine::*)();
-template<memberFunction function>
+using member_function_t = int (Engine::*)();
+template<member_function_t function>
 int wrap(lua_State* L)
 {
   Engine* ptr = *static_cast<Engine**>(lua_getextraspace(L));
   return (ptr->*function)();
+}
+
+using member_hook_t = void (Engine::*)(lua_Debug*);
+template<member_hook_t function>
+void wrap_hook(lua_State* L, lua_Debug* ar)
+{
+  Engine* ptr = *static_cast<Engine**>(lua_getextraspace(L));
+  (ptr->*function)(ar);
 }
 
 // Functions like the Lua allocator except filling the Engine memory tracker and
@@ -224,6 +234,7 @@ constexpr luaL_Reg lua_libraries[] = {
 };
 
 constexpr auto registration_functions = {
+  register_iterator_class,
   register_app_object,
   register_app_pixel_color_object,
   register_app_fs_object,
@@ -604,6 +615,22 @@ int Engine::lua_os_clock()
 {
   lua_pushnumber(L, m_clock.elapsed());
   return 1;
+}
+
+void Engine::lua_hook(lua_Debug* ar)
+{
+  ASSERT(m_debugger)
+  if (m_debugger)
+    m_debugger->onHook(L, ar);
+}
+
+void Engine::setDebugger(Debugger* debugger)
+{
+  m_debugger = debugger;
+  if (m_debugger)
+    lua_sethook(L, &wrap_hook<&Engine::lua_hook>, LUA_MASKCALL | LUA_MASKRET | LUA_MASKLINE, 0);
+  else
+    lua_sethook(L, nullptr, 0, 0);
 }
 
 AppEvents* Engine::appEvents()

--- a/src/app/script/engine.h
+++ b/src/app/script/engine.h
@@ -73,14 +73,7 @@ namespace script {
 class AppEvents;
 class WindowEvents;
 class SpriteEvents;
-
-class DebuggerDelegate {
-public:
-  virtual ~DebuggerDelegate() {}
-  virtual void hook(lua_State* L, lua_Debug* ar) = 0;
-  virtual void startFile(const std::string& file, const std::string& content) = 0;
-  virtual void endFile(const std::string& file) = 0;
-};
+class Debugger;
 
 class Engine {
 public:
@@ -98,6 +91,7 @@ public:
   int returnCode() const { return m_returnCode; }
   lua_State* luaState() const { return L; }
   const MemoryTracker& memoryTracker() const { return m_tracker; }
+  void setDebugger(Debugger* debugger);
   AppEvents* appEvents();
   WindowEvents* windowEvents(ui::Window* window);
   SpriteEvents* spriteEvents(const doc::Sprite* sprite);
@@ -121,12 +115,14 @@ public:
   int lua_dofile();
   int lua_loadfile();
   int lua_os_clock();
+  void lua_hook(lua_Debug* ar);
 
   obs::signal<void(const std::string&)> ConsolePrint;
   obs::signal<void(const std::string&)> ConsoleError;
 
 private:
   lua_State* L;
+  Debugger* m_debugger = nullptr;
 
   // Events
   std::unique_ptr<AppEvents> m_appEvents;
@@ -148,6 +144,8 @@ private:
   int m_returnCode;
   uint32_t m_objectTracker;
 };
+
+int ObjectIterator_pairs_next(lua_State* L);
 
 void push_app_events(lua_State* L);
 void push_app_theme(lua_State* L, int uiscale = 1);

--- a/src/app/script/events.cpp
+++ b/src/app/script/events.cpp
@@ -145,6 +145,16 @@ bool Events::empty() const
   return true;
 }
 
+AppEvents::AppEvents(lua_State* L) : Events(L), m_addedObserver(0)
+{
+}
+
+AppEvents::~AppEvents()
+{
+  if (m_addedObserver)
+    App::instance()->context()->remove_observer(this);
+}
+
 void AppEvents::onAddFirstListener(EventType eventType)
 {
   auto* app = App::instance();

--- a/src/app/script/events.h
+++ b/src/app/script/events.h
@@ -64,7 +64,8 @@ public:
     AfterCommand,
   };
 
-  explicit AppEvents(lua_State* L) : Events(L), m_addedObserver(0) {}
+  explicit AppEvents(lua_State* L);
+  ~AppEvents();
 
   EventType eventType(const char* eventName) const override;
 

--- a/src/app/script/frame_class.cpp
+++ b/src/app/script/frame_class.cpp
@@ -118,7 +118,7 @@ const Property Frame_properties[] = {
   { "next",        Frame_get_next,        nullptr            },
   { nullptr,       nullptr,               nullptr            }
 };
-
+DEF_ITERATOR_PAIRS(Frame);
 } // anonymous namespace
 
 DEF_MTNAME(FrameObj);

--- a/src/app/script/graphics_context.cpp
+++ b/src/app/script/graphics_context.cpp
@@ -590,7 +590,7 @@ const Property GraphicsContext_properties[] = {
   { "palette",     GraphicsContext_get_palette,     GraphicsContext_set_palette     },
   { nullptr,       nullptr,                         nullptr                         }
 };
-
+DEF_ITERATOR_PAIRS(GraphicsContext);
 } // anonymous namespace
 
 DEF_MTNAME(GraphicsContext);

--- a/src/app/script/grid_class.cpp
+++ b/src/app/script/grid_class.cpp
@@ -71,7 +71,7 @@ const Property Grid_properties[] = {
   { "origin",   Grid_get_origin,   nullptr },
   { nullptr,    nullptr,           nullptr }
 };
-
+DEF_ITERATOR_PAIRS(Grid);
 } // anonymous namespace
 
 DEF_MTNAME(Grid);

--- a/src/app/script/image_class.cpp
+++ b/src/app/script/image_class.cpp
@@ -794,7 +794,7 @@ const Property Image_properties[] = {
   { "context",       Image_get_context,       nullptr         },
   { nullptr,         nullptr,                 nullptr         }
 };
-
+DEF_ITERATOR_PAIRS(Image);
 } // anonymous namespace
 
 DEF_MTNAME(ImageObj);

--- a/src/app/script/image_iterator_class.cpp
+++ b/src/app/script/image_iterator_class.cpp
@@ -90,6 +90,9 @@ int ImageIterator_index(lua_State* L)
     { "__call",  ImageIterator_call<Prefix##Traits>  },                                              \
     { "__gc",    ImageIterator_gc<Prefix##Traits>    },                                                  \
     { nullptr,   nullptr                             }                                                                           \
+  };                                                                                               \
+  const luaL_Reg Prefix##ImageIterator_properties[] = {                                            \
+    { nullptr, nullptr }                                                                           \
   }
 
 DEFINE_METHODS(Rgb);

--- a/src/app/script/image_spec_class.cpp
+++ b/src/app/script/image_spec_class.cpp
@@ -153,7 +153,7 @@ const Property ImageSpec_properties[] = {
   { "transparentColor", ImageSpec_get_transparentColor, ImageSpec_set_transparentColor },
   { nullptr,            nullptr,                        nullptr                        }
 };
-
+DEF_ITERATOR_PAIRS(ImageSpec);
 } // anonymous namespace
 
 DEF_MTNAME(doc::ImageSpec);

--- a/src/app/script/iterator_class.cpp
+++ b/src/app/script/iterator_class.cpp
@@ -1,0 +1,43 @@
+// Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
+//
+// This program is distributed under the terms of
+// the End-User License Agreement for Aseprite.
+
+#include "app/script/luacpp.h"
+
+namespace app::script {
+
+int ObjectIterator_pairs_next(lua_State* L)
+{
+  auto* it = get_obj<ObjectIterator>(L, lua_upvalueindex(1));
+  const auto& prop = it->properties[it->i];
+  if (prop.getter == nullptr)
+    return 0;
+
+  lua_pushstring(L, prop.name);
+  prop.getter(L);
+  ++it->i;
+  return 2;
+}
+
+namespace {
+int ObjectIterator_gc(lua_State* L)
+{
+  get_obj<ObjectIterator>(L, 1)->~ObjectIterator();
+  return 0;
+}
+
+const luaL_Reg ObjectIterator_methods[] = {
+  { "__gc",  ObjectIterator_gc },
+  { nullptr, nullptr           }
+};
+} // namespace
+
+DEF_MTNAME(ObjectIterator);
+
+void register_iterator_class(lua_State* L)
+{
+  REG_CLASS(L, ObjectIterator);
+}
+} // namespace app::script

--- a/src/app/script/layer_class.cpp
+++ b/src/app/script/layer_class.cpp
@@ -512,7 +512,7 @@ const Property Layer_properties[] = {
   { "uuid",          Layer_get_uuid,                 nullptr                        },
   { nullptr,         nullptr,                        nullptr                        }
 };
-
+DEF_ITERATOR_PAIRS(Layer);
 } // anonymous namespace
 
 DEF_MTNAME(Layer);

--- a/src/app/script/luacpp.h
+++ b/src/app/script/luacpp.h
@@ -153,6 +153,20 @@ struct Property {
   lua_CFunction setter;
 };
 
+struct ObjectIterator {
+  int i = 0;
+  const Property* properties;
+};
+int ObjectIterator_pairs_next(lua_State* L);
+#define DEF_ITERATOR_PAIRS(T)                                                                      \
+  int T##_pairs(lua_State* L)                                                                      \
+  {                                                                                                \
+    push_obj(L, ObjectIterator{ 0, T##_properties });                                              \
+    lua_pushcclosure(L, ObjectIterator_pairs_next, 1);                                             \
+    lua_pushvalue(L, 1);                                                                           \
+    return 2;                                                                                      \
+  }
+
 int generic_mt_index(lua_State* L);
 int generic_mt_newindex(lua_State* L);
 void create_mt_getters_setters(lua_State* L, const char* tname, const Property* properties);
@@ -163,6 +177,10 @@ bool lua_is_key_true(lua_State* L, int tableIndex, const char* keyName);
   {                                                                                                \
     luaL_getmetatable(L, get_mtname<T>());                                                         \
     create_mt_getters_setters(L, get_mtname<T>(), T##_properties);                                 \
+    lua_pushcfunction(L, T##_pairs);                                                               \
+    lua_setfield(L, -2, "__pairs");                                                                \
+    lua_pushstring(L, #T);                                                                         \
+    lua_setfield(L, -2, "__typename");                                                             \
     lua_pop(L, 1);                                                                                 \
   }
 

--- a/src/app/script/palette_class.cpp
+++ b/src/app/script/palette_class.cpp
@@ -267,7 +267,7 @@ const Property Palette_properties[] = {
   { "frameNumber", Palette_get_frameNumber, nullptr },
   { nullptr,       nullptr,                 nullptr }
 };
-
+DEF_ITERATOR_PAIRS(Palette);
 } // anonymous namespace
 
 DEF_MTNAME(PaletteObj);

--- a/src/app/script/plugin_class.cpp
+++ b/src/app/script/plugin_class.cpp
@@ -502,7 +502,7 @@ const Property Plugin_properties[] = {
   { "preferences", Plugin_get_preferences, Plugin_set_preferences },
   { nullptr,       nullptr,                nullptr                }
 };
-
+DEF_ITERATOR_PAIRS(Plugin)
 } // anonymous namespace
 
 DEF_MTNAME(Plugin);

--- a/src/app/script/point_class.cpp
+++ b/src/app/script/point_class.cpp
@@ -207,7 +207,7 @@ const Property Point_properties[] = {
   { "y",     Point_get_y, Point_set_y },
   { nullptr, nullptr,     nullptr     }
 };
-
+DEF_ITERATOR_PAIRS(Point);
 } // anonymous namespace
 
 DEF_MTNAME(gfx::Point);

--- a/src/app/script/range_class.cpp
+++ b/src/app/script/range_class.cpp
@@ -429,7 +429,7 @@ const Property Range_properties[] = {
   { "slices",         Range_get_slices,         Range_set_slices },
   { nullptr,          nullptr,                  nullptr          }
 };
-
+DEF_ITERATOR_PAIRS(Range);
 } // anonymous namespace
 
 DEF_MTNAME(RangeObj);

--- a/src/app/script/rectangle_class.cpp
+++ b/src/app/script/rectangle_class.cpp
@@ -261,7 +261,7 @@ const Property Rectangle_properties[] = {
   { "isEmpty", Rectangle_get_isEmpty, nullptr              },
   { nullptr,   nullptr,               nullptr              }
 };
-
+DEF_ITERATOR_PAIRS(Rectangle);
 } // anonymous namespace
 
 DEF_MTNAME(gfx::Rect);

--- a/src/app/script/selection_class.cpp
+++ b/src/app/script/selection_class.cpp
@@ -345,7 +345,7 @@ const Property Selection_properties[] = {
   { "isEmpty", Selection_get_isEmpty, nullptr              },
   { nullptr,   nullptr,               nullptr              }
 };
-
+DEF_ITERATOR_PAIRS(Selection);
 } // anonymous namespace
 
 DEF_MTNAME(SelectionObj);

--- a/src/app/script/site_class.cpp
+++ b/src/app/script/site_class.cpp
@@ -119,7 +119,7 @@ const Property Site_properties[] = {
   { "tilesetMode", Site_get_tilesetMode, nullptr },
   { nullptr,       nullptr,              nullptr }
 };
-
+DEF_ITERATOR_PAIRS(Site);
 } // anonymous namespace
 
 DEF_MTNAME(app::Site);

--- a/src/app/script/size_class.cpp
+++ b/src/app/script/size_class.cpp
@@ -225,7 +225,7 @@ const Property Size_properties[] = {
   { "height", Size_get_height, Size_set_height },
   { nullptr,  nullptr,         nullptr         }
 };
-
+DEF_ITERATOR_PAIRS(Size);
 } // anonymous namespace
 
 DEF_MTNAME(gfx::Size);

--- a/src/app/script/slice_class.cpp
+++ b/src/app/script/slice_class.cpp
@@ -147,7 +147,7 @@ const Property Slice_properties[] = {
   { "properties", UserData_get_properties<Slice>, UserData_set_properties<Slice> },
   { nullptr,      nullptr,                        nullptr                        }
 };
-
+DEF_ITERATOR_PAIRS(Slice);
 } // anonymous namespace
 
 DEF_MTNAME(Slice);

--- a/src/app/script/sprite_class.cpp
+++ b/src/app/script/sprite_class.cpp
@@ -1152,7 +1152,7 @@ const Property Sprite_properties[] = {
   { "isValid",              Sprite_get_isValid,              nullptr                         },
   { nullptr,                nullptr,                         nullptr                         }
 };
-
+DEF_ITERATOR_PAIRS(Sprite);
 } // anonymous namespace
 
 DEF_MTNAME(doc::Sprite);

--- a/src/app/script/tag_class.cpp
+++ b/src/app/script/tag_class.cpp
@@ -161,7 +161,7 @@ const Property Tag_properties[] = {
   { "properties", UserData_get_properties<Tag>, UserData_set_properties<Tag> },
   { nullptr,      nullptr,                      nullptr                      }
 };
-
+DEF_ITERATOR_PAIRS(Tag);
 } // anonymous namespace
 
 DEF_MTNAME(Tag);

--- a/src/app/script/tile_class.cpp
+++ b/src/app/script/tile_class.cpp
@@ -202,7 +202,7 @@ const Property Tile_properties[] = {
   { "properties", Tile_get_properties, Tile_set_properties },
   { nullptr,      nullptr,             nullptr             }
 };
-
+DEF_ITERATOR_PAIRS(Tile);
 } // anonymous namespace
 
 DEF_MTNAME(Tile);

--- a/src/app/script/tileset_class.cpp
+++ b/src/app/script/tileset_class.cpp
@@ -126,7 +126,7 @@ const Property Tileset_properties[] = {
   { "properties", UserData_get_properties<Tileset>, UserData_set_properties<Tileset> },
   { nullptr,      nullptr,                          nullptr                          }
 };
-
+DEF_ITERATOR_PAIRS(Tileset);
 } // anonymous namespace
 
 DEF_MTNAME(Tileset);

--- a/src/app/script/timer_class.cpp
+++ b/src/app/script/timer_class.cpp
@@ -154,7 +154,7 @@ const Property Timer_properties[] = {
   { "isRunning", Timer_get_isRunning, nullptr            },
   { nullptr,     nullptr,             nullptr            }
 };
-
+DEF_ITERATOR_PAIRS(Timer);
 } // anonymous namespace
 
 DEF_MTNAME(Timer);

--- a/src/app/script/tool_class.cpp
+++ b/src/app/script/tool_class.cpp
@@ -33,7 +33,7 @@ const Property Tool_properties[] = {
   { "id",    Tool_get_id, nullptr },
   { nullptr, nullptr,     nullptr }
 };
-
+DEF_ITERATOR_PAIRS(Tool);
 } // anonymous namespace
 
 using Tool = tools::Tool;

--- a/src/app/script/version_class.cpp
+++ b/src/app/script/version_class.cpp
@@ -125,7 +125,7 @@ const Property Version_properties[] = {
   { "prereleaseNumber", Version_get_prereleaseNumber, nullptr },
   { nullptr,            nullptr,                      nullptr }
 };
-
+DEF_ITERATOR_PAIRS(Version);
 } // anonymous namespace
 
 DEF_MTNAME(base::Version);

--- a/src/app/script/websocket_class.cpp
+++ b/src/app/script/websocket_class.cpp
@@ -231,7 +231,7 @@ const Property WebSocket_properties[] = {
   { "url",   WebSocket_get_url, nullptr },
   { nullptr, nullptr,           nullptr }
 };
-
+DEF_ITERATOR_PAIRS(WebSocket);
 } // anonymous namespace
 
 using WebSocket = ix::WebSocket;

--- a/src/app/script/window_class.cpp
+++ b/src/app/script/window_class.cpp
@@ -47,7 +47,7 @@ const Property Window_properties[] = {
   { "events", Window_get_events, nullptr },
   { nullptr,  nullptr,           nullptr }
 };
-
+DEF_ITERATOR_PAIRS(Window);
 } // anonymous namespace
 
 DEF_MTNAME(ui::Window);

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -238,6 +238,11 @@ if(ENABLE_SCRIPTING)
     target_include_directories(ixwebsocket PUBLIC)
   endif()
 
+  set(CPPDAP_BUILD_TESTS OFF CACHE INTERNAL "")
+  set(CPPDAP_BUILD_EXAMPLES OFF CACHE INTERNAL "")
+  set(CPPDAP_INSTALL_VSCODE_EXAMPLES OFF CACHE INTERNAL "")
+  set(CPPDAP_THIRD_PARTY_DIR ${CMAKE_SOURCE_DIR}/third_party CACHE INTERNAL "")
+  add_subdirectory(cppdap)
 endif()
 
 # qoi


### PR DESCRIPTION
Created as a draft because we're missing the documentation URLs and LAF changes for the event queue on Windows & Linux.

Adds a DAP-based debugger server using [cppdap](https://github.com/google/cppdap) (RIP in peace).

## Easiest way to test:
 * Download the WIP VSCode Extension: [aseprite-debugger.vsix.zip](https://github.com/user-attachments/files/27793973/aseprite-debugger.vsix.zip)
 * Unzip and open [this testing folder](https://github.com/user-attachments/files/27794027/testing.zip) in Visual Studio Code
 * Set some breakpoints on `debugger_testing.lua` or `debugger_testing_2.lua`
 * Launch the debugger from the `Run and Debug` panel

## Things to do before we merge:
 - [ ] Create a repo for the extension, finish the readme
- [ ] Add the documentation and change the URL inside debugger.xml
- [x] Fix [the queue issues in LAF](https://github.com/aseprite/laf/pull/176) that make it so that the debugger won't wake up.