### PR TITLE
Add "About Extensions" dialog in Preferences

### DIFF
--- a/data/extensions/aseprite-theme/dark/theme.xml
+++ b/data/extensions/aseprite-theme/dark/theme.xml
@@ -543,7 +543,7 @@
             <background color="textbox_face"/>
             <text color="textbox_text" align="left"/>
         </style>
-        <style id="textbox_label" extends="textbox_text">
+        <style id="textbox_label" border="0" extends="textbox_text">
             <background color="window_face"/>
             <text color="text" align="left"/>
         </style>

--- a/data/extensions/aseprite-theme/theme.xml
+++ b/data/extensions/aseprite-theme/theme.xml
@@ -539,7 +539,7 @@
             <background color="textbox_face"/>
             <text color="textbox_text" align="left"/>
         </style>
-        <style id="textbox_label" extends="textbox_text">
+        <style id="textbox_label" border="0" extends="textbox_text">
             <background color="window_face"/>
             <text color="text" align="left"/>
         </style>

--- a/data/strings/en.ini
+++ b/data/strings/en.ini
@@ -91,6 +91,7 @@ nothing_to_report = Crash Report<<Nothing to report||&OK
 install_extension = Warning\n<<Do you really want to install the given extension?\n<<"{0}"\n||&Install||&Cancel
 uninstall_extension_warning = Warning\n<<Do you really want to uninstall "{0}" extension?\n||&Yes||&No
 cannot_install_default_extension = Error<<This extension cannot be installed because tries to replace the default theme.<<Contact the developer so they fix the theme ID or theme name string<<from \"default\" to something else.||&OK
+cannot_read_extension = About Extension\n<<Failed to read the extension manifest.\n||&Open Folder||&Close
 unknown_output_file_format_error = Aseprite\n<<Unknown file format "{0}" in output filename\n||&OK
 update_screen_ui_scaling_with_theme_values = Update Screen/UI Scaling\n<<The new theme "{0}" wants to adjust some values for you:\n<<  Screen Scaling: {1}% -> {2}%\n<<  UI Scaling: {3}% -> {4}%\n<<Allow these changes?\n||&Adjust Scaling||&Don't Adjust Scaling
 update_extension = Update Extension\n<<The extension "{0}" already exists.\n<<Do you want to {1} from v{2} to v{3}?\n||&Yes||&No
@@ -1611,6 +1612,7 @@ add_extension_title = Add Extension
 enable_extension = &Enable
 disable_extension = &Disable
 uninstall_extension = &Uninstall
+open_extension_about = A&bout
 open_extension_folder = Open &Folder
 user_interface = User Interface
 color_quantization = Color Quantization
@@ -1661,6 +1663,14 @@ reset = &Reset
 ok = &OK
 apply = &Apply
 cancel = &Cancel
+
+[about_extension]
+title = About Extension
+title_builtin = About Built-in Extension
+id = ID
+version = Version
+author = Author:
+contributors = Contributors:
 
 [outline]
 color = Outline Color:

--- a/data/widgets/about_extension.xml
+++ b/data/widgets/about_extension.xml
@@ -1,0 +1,46 @@
+<!-- Aseprite -->
+<!-- Copyright (c) 2026-present Igara Studio S.A. -->
+<gui>
+  <window id="about_extension" text="@.title" expansive="true">
+    <vbox>
+      <hbox>
+        <boxfiller />
+        <label id="display_name" />
+        <boxfiller />
+      </hbox>
+
+      <hbox>
+        <boxfiller />
+        <label id="name" tooltip="@.id" style="mini_label" />
+        <label text="-" id="version_separator" style="mini_label" />
+        <label id="version" tooltip="@.version" style="mini_label" />
+        <boxfiller />
+      </hbox>
+
+      <textbox id="description" minwidth="180" wordwrap="true" text_align="center middle" style="textbox_label" />
+
+      <hbox id="url_container">
+        <boxfiller />
+        <link id="url" />
+        <boxfiller />
+      </hbox>
+
+      <vbox id="author_container">
+        <separator horizontal="true" text="@.author" />
+      </vbox>
+
+      <vbox id="contributors_container">
+        <separator horizontal="true" text="@.contributors" />
+        <vbox id="contributors">
+        </vbox>
+      </vbox>
+
+      <separator horizontal="true" />
+      <hbox>
+        <button text="@options.open_extension_folder" id="openFolder" minwidth="60" />
+        <boxfiller />
+        <button text="@general.close" closewindow="true" id="ok" magnet="true" minwidth="60" />
+      </hbox>
+    </vbox>
+  </window>
+</gui>

--- a/data/widgets/options.xml
+++ b/data/widgets/options.xml
@@ -572,7 +572,7 @@
             <boxfiller />
             <button id="disable_extension" text="@.disable_extension" minwidth="60" />
             <button id="uninstall_extension" text="@.uninstall_extension" minwidth="60" />
-            <button id="open_extension_folder" text="@.open_extension_folder" minwidth="60" />
+            <button id="open_extension_about" text="@.open_extension_about" minwidth="60" />
           </hbox>
         </vbox>
 

--- a/src/app/commands/cmd_options.cpp
+++ b/src/app/commands/cmd_options.cpp
@@ -58,6 +58,7 @@
   #include "app/sentry_wrapper.h"
 #endif
 
+#include "about_extension.xml.h"
 #include "options.xml.h"
 
 namespace app {
@@ -223,6 +224,81 @@ class OptionsWindow : public app::gen::Options {
     LangInfo m_langInfo;
   };
 
+  class AboutExtensionWindow : public gen::AboutExtension {
+  public:
+    explicit AboutExtensionWindow(const Extension* ext)
+    {
+      const auto& about = ext->readAbout();
+
+      if (!ext->canBeUninstalled())
+        setText(Strings::about_extension_title_builtin());
+
+      name()->setText(about.name);
+      version()->setText(about.version);
+
+      if (about.description.empty())
+        description()->setVisible(false);
+      else {
+        auto* desc = description();
+        desc->setText(about.description);
+      }
+
+      if (about.url.empty()) {
+        urlContainer()->setVisible(false);
+      }
+      else {
+        url()->setText(about.url);
+        url()->setUrl(about.url);
+      }
+
+      openFolder()->Click.connect([ext] { launcher::open_folder(ext->path()); });
+
+      if (about.displayName.empty() || about.displayName == about.name) {
+        displayName()->setText(about.name);
+        name()->setVisible(false);
+        versionSeparator()->setVisible(false);
+      }
+      else {
+        displayName()->setText(about.displayName);
+      }
+
+      if (about.author.has_value()) {
+        const auto& contributor = about.author.value();
+        Widget* label;
+        if (contributor.url.empty()) {
+          label = new Label(contributor.toString());
+        }
+        else {
+          label = new LinkLabel(contributor.url, contributor.toString());
+          tooltipManager()->addTooltipFor(label, contributor.url, BOTTOM);
+        }
+        authorContainer()->addChild(label);
+      }
+      else {
+        authorContainer()->setVisible(false);
+      }
+
+      if (!about.contributors.empty()) {
+        for (const auto& contributor : about.contributors) {
+          Widget* label;
+          if (!contributor.url.empty()) {
+            label = new LinkLabel(contributor.url, contributor.toString());
+            tooltipManager()->addTooltipFor(label, contributor.url, BOTTOM);
+          }
+          else {
+            label = new Label(contributor.toString());
+          }
+          contributors()->addChild(label);
+        }
+      }
+      else {
+        contributorsContainer()->setVisible(false);
+      }
+
+      layout();
+    };
+  };
+
   class ExtensionItem : public ListItem {
   public:
     ExtensionItem(Extension* extension) : ListItem(extension->displayName()), m_extension(extension)
@@ -277,10 +353,17 @@ class OptionsWindow : public app::gen::Options {
       m_extension = nullptr;
     }
 
-    void openFolder() const
+    void openAbout() const
     {
       ASSERT(m_extension);
-      app::launcher::open_folder(m_extension->path());
+      try {
+        AboutExtensionWindow about(m_extension);
+        about.openWindowInForeground();
+      }
+      catch (const std::exception&) {
+        if (Alert::show(Strings::alerts_cannot_read_extension()) == 1)
+          launcher::open_folder(m_extension->path());
+      }
     }
 
   private:
@@ -511,10 +594,11 @@ public:
 
     // Extensions buttons
     extensionsList()->Change.connect([this] { onExtensionChange(); });
+    extensionsList()->DoubleClickItem.connect([this] { onSelectExtension(); });
     addExtension()->Click.connect([this] { onAddExtension(); });
     disableExtension()->Click.connect([this] { onDisableExtension(); });
     uninstallExtension()->Click.connect([this] { onUninstallExtension(); });
-    openExtensionFolder()->Click.connect([this] { onOpenExtensionFolder(); });
+    openExtensionAbout()->Click.connect([this] { onOpenExtensionAbout(); });
 
     // Aseprite Format preferences
     celFormat()->Change.connect([this] { onCelFormatChange(); });
@@ -2002,13 +2086,20 @@ private:
       disableExtension()->processMnemonicFromText();
       disableExtension()->setEnabled(item->isEnabled() ? item->canBeDisabled() : true);
       uninstallExtension()->setEnabled(item->canBeUninstalled());
-      openExtensionFolder()->setEnabled(true);
+      openExtensionAbout()->setEnabled(true);
     }
     else {
       disableExtension()->setEnabled(false);
       uninstallExtension()->setEnabled(false);
-      openExtensionFolder()->setEnabled(false);
+      openExtensionAbout()->setEnabled(false);
     }
+  }
+
+  void onSelectExtension()
+  {
+    ExtensionItem* item = dynamic_cast<ExtensionItem*>(extensionsList()->getSelectedChild());
+    if (item && item->isInstalled())
+      item->openAbout();
   }
 
   void onAddExtension()
@@ -2157,11 +2248,11 @@ private:
     return nullptr;
   }
 
-  void onOpenExtensionFolder()
+  void onOpenExtensionAbout()
   {
     ExtensionItem* item = dynamic_cast<ExtensionItem*>(extensionsList()->getSelectedChild());
     if (item)
-      item->openFolder();
+      item->openAbout();
   }
 
   void onCelFormatChange()

--- a/src/app/extensions.cpp
+++ b/src/app/extensions.cpp
@@ -49,6 +49,7 @@
 
 #include "archive.h"
 #include "archive_entry.h"
+#include "fmt/format.h"
 #include "nlohmann/json.hpp"
 
 #include <fstream>
@@ -192,11 +193,11 @@ private:
   bool m_open;
 };
 
-void read_json_file(const std::string& path, nlohmann::json& json)
+nlohmann::json read_json_file(const std::string& path)
 {
-  auto file = base::open_file(path, "rb");
+  const auto file = base::open_file(path, "rb");
   try {
-    json = nlohmann::json::parse(file.get());
+    return nlohmann::json::parse(file.get());
   }
   catch (std::exception& e) {
     throw base::Exception("Error parsing JSON file: %s\n", e.what());
@@ -265,6 +266,53 @@ void Extension::executeExitActions()
   if (isEnabled() && hasScripts())
     exitScripts();
 #endif // ENABLE_SCRIPTING
+}
+
+Extension::About Extension::readAbout() const
+{
+  const std::string packageJson = base::join_path(m_path, kPackageJson);
+  auto json = read_json_file(packageJson);
+
+  About about{ m_name,
+               m_displayName,
+               m_version,
+               json.value("description", ""),
+               json.value("publisher", ""),
+               json.value("license", ""),
+               json.value("url", "") };
+
+  constexpr auto extractContributor = [](const auto& jsonObj) {
+    std::optional<About::Contributor> opt;
+    if (jsonObj.is_string()) {
+      opt = About::Contributor{ jsonObj };
+    }
+    else if (jsonObj.is_object()) {
+      opt = About::Contributor{
+        jsonObj.value("name", ""),
+        jsonObj.value("email", ""),
+        jsonObj.value("url", ""),
+      };
+    }
+
+    if (opt.has_value() && opt.value().toString().empty())
+      opt = std::nullopt;
+
+    return opt;
+  };
+
+  if (json.contains("author")) {
+    const auto& author = json.at("author");
+    about.author = extractContributor(author);
+  }
+
+  auto contributors = json.value("contributors", nlohmann::json::array());
+  for (const auto& obj : contributors) {
+    auto contributor = extractContributor(obj);
+    if (contributor.has_value())
+      about.contributors.push_back(contributor.value());
+  }
+
+  return about;
 }
 
 void Extension::addKeys(const std::string& id, const std::string& path)
@@ -687,8 +735,7 @@ void Extension::uninstallFiles(const std::string& path, const DeletePluginPref d
   if (!base::is_file(infoFn))
     throw base::Exception("Cannot remove extension, '%s' file doesn't exist", infoFn.c_str());
 
-  nlohmann::json json;
-  read_json_file(infoFn, json);
+  auto json = read_json_file(infoFn);
 
   base::paths installedDirs;
 
@@ -1043,6 +1090,23 @@ void Extension::addScript(const std::string& fn)
 }
 #endif // ENABLE_SCRIPTING
 
+std::string Extension::About::Contributor::toString() const
+{
+  if (name.empty() && email.empty() && url.empty())
+    return std::string();
+
+  if (name.empty()) {
+    if (email.empty())
+      return url;
+    return email;
+  }
+
+  if (!email.empty())
+    return fmt::format("{} <{}>", name, email);
+
+  return name;
+}
+
 //////////////////////////////////////////////////////////////////////
 // Extensions
 
@@ -1351,8 +1415,7 @@ Extension* Extensions::loadExtension(const std::string& path,
                                      const std::string& fullPackageFilename,
                                      const bool isBuiltinExtension)
 {
-  nlohmann::json json;
-  read_json_file(fullPackageFilename, json);
+  auto json = read_json_file(fullPackageFilename);
   const std::string& name = json.at("name");
   if (name.empty())
     throw base::Exception("Error loading extension '%s', empty name", path.c_str());

--- a/src/app/extensions.h
+++ b/src/app/extensions.h
@@ -14,6 +14,7 @@
 #include "render/dithering_matrix.h"
 
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -68,6 +69,25 @@ public:
     DitheringMatrices,
     Multiple,
     Max
+  };
+
+  struct About {
+    struct Contributor {
+      std::string name;
+      std::string email;
+      std::string url;
+      std::string toString() const;
+    };
+
+    std::string name;
+    std::string displayName;
+    std::string version;
+    std::string description;
+    std::string publisher;
+    std::string license;
+    std::string url;
+    std::optional<Contributor> author;
+    std::vector<Contributor> contributors;
   };
 
   bool isDefaultTheme() const;
@@ -126,6 +146,7 @@ public:
   const std::string& version() const { return m_version; }
   const std::string& displayName() const { return m_displayName; }
   Category category() const { return m_category; }
+  About readAbout() const;
 
   const ExtensionItems& keys() const { return m_keys; }
   const Languages& languages() const { return m_languages; }

--- a/src/app/extensions_tests.cpp
+++ b/src/app/extensions_tests.cpp
@@ -216,6 +216,10 @@ TEST(Extensions, Complex)
   "author": { "name": "Test",
               "email": "test@igara.com",
               "url": "https://aseprite.org/" },
+  "contributors": [
+    { "name": "Test 2" },
+    "Test 3"
+  ],
   "contributes": {
     "scripts": [
         { "path": "./script.lua" }
@@ -323,6 +327,19 @@ end
   EXPECT_EQ(testExt->displayName(), "Complex Extension Test");
   EXPECT_EQ(testExt->category(), Extension::Category::Multiple);
   EXPECT_EQ(testExt->version(), "0.1");
+
+  Extension::About about = testExt->readAbout();
+  EXPECT_EQ(about.name, "test-complex");
+  EXPECT_EQ(about.displayName, "Complex Extension Test");
+  EXPECT_EQ(about.version, "0.1");
+  {
+    const auto& author = about.author.value();
+    EXPECT_EQ(author.name, "Test");
+    EXPECT_EQ(author.email, "test@igara.com");
+    EXPECT_EQ(author.url, "https://aseprite.org/");
+  }
+  EXPECT_EQ(about.contributors[0].name, "Test 2");
+  EXPECT_EQ(about.contributors[1].name, "Test 3");
 
   EXPECT_EQ(testExt->keys().size(), 1);
   EXPECT_EQ(testExt->languages().size(), 1);

--- a/src/app/widget_loader.cpp
+++ b/src/app/widget_loader.cpp
@@ -394,6 +394,8 @@ Widget* WidgetLoader::convertXmlElementToWidget(const XMLElement* elem,
   else if (elem_name == "textbox") {
     const char* text = (elem->GetText() ? elem->GetText() : "");
     bool wordwrap = bool_attr(elem, "wordwrap", false);
+    const char* text_align = elem->Attribute("text_align");
+    int align = text_align ? convert_align_value_to_flags(text_align) : 0;
 
     if (!widget)
       widget = new TextBox(text, 0);
@@ -402,6 +404,9 @@ Widget* WidgetLoader::convertXmlElementToWidget(const XMLElement* elem,
 
     if (wordwrap)
       widget->setAlign(widget->align() | WORDWRAP);
+
+    if (align)
+      widget->setAlign(widget->align() | align);
   }
   else if (elem_name == "view") {
     if (!widget)

--- a/src/ui/theme.cpp
+++ b/src/ui/theme.cpp
@@ -896,6 +896,7 @@ void Theme::drawTextBox(Graphics* g,
   gfx::Point scroll;
   const text::FontRef& font = widget->font();
   const int lineheight = font->lineHeight();
+  const int lineseparation = (widget->type() == kTextBoxWidget) ? 2 * guiscale() : 0;
   char *beg_end, *old_end;
   int width;
   gfx::Rect vp;
@@ -1016,7 +1017,7 @@ void Theme::drawTextBox(Graphics* g,
     if (w)
       *w = std::max(*w, len);
 
-    y += lineheight;
+    y += lineheight + lineseparation;
 
     if (end) {
       *end = chr;
@@ -1025,7 +1026,7 @@ void Theme::drawTextBox(Graphics* g,
   }
 
   if (h)
-    *h = (y - y1 + scroll.y);
+    *h = (y - y1 - lineseparation + scroll.y);
 
   if (w)
     *w += widget->border().width();


### PR DESCRIPTION
Adds a new "About Extensions" dialog and button:

https://github.com/user-attachments/assets/1299f879-963f-40ed-a9e0-64533b1f8a5c

Moves the "Open Folder" button in here to avoid clutter, attempts to show as much information as possible that was previously hidden away in the package.json file.