### PR TITLE
Fix invisible widgets grabbing focus for key events

### DIFF
--- a/src/ui/manager.cpp
+++ b/src/ui/manager.cpp
@@ -2345,7 +2345,7 @@ void Manager::broadcastKeyMsg(Message* msg)
     msg->setRecipient(capture_widget);
   }
   // Send the msg to the focused widget
-  else if (focus_widget) {
+  else if (focus_widget && focus_widget->isVisible()) {
     msg->setRecipient(focus_widget);
   }
   // Finally, send the message to the manager, it'll know what to do


### PR DESCRIPTION
Fixes https://github.com/aseprite/aseprite/issues/5810 and potentially other issues, in the case of this script-based bug the problem was the Entry inside ComboBox was still in focus even after the dialog was closed, but I'm pretty sure sure this could happen with native dialogs as well.