### PR TITLE
Fix Issue #5801

### DIFF
--- a/data/strings/en.ini
+++ b/data/strings/en.ini
@@ -107,6 +107,7 @@ run_script = Run Script\n<<Do you want to run the following script?\n<<\n<<  {0}
 save_sprite_changes = Warning\n<<Saving changes to the sprite\n<<"{0}" before {1}?\n||&Save||Do&n't Save||&Cancel
 save_sprite_changes_quitting = quitting
 save_sprite_changes_closing = closing
+shortcut_overwrite_alert = Warning\n<<Do you really want to overwrite "{0}" keyboard shortcut? The previous assigned shortcut will be deleted\n||&Yes||&No
 overwrite_existent_file = Warning<<File exists, overwrite it?<<{0}||&Yes||&No||&Cancel
 overwrite_files_on_export_sprite_sheet = Export Sprite Sheet Warning\n<<Do you want to overwrite the following file(s)?\n{0}\n||&Yes||&No
 overwrite_files_on_export = Export Warning\n<<Do you want to overwrite the following file?\n<<{0}\n||&Yes||&No

--- a/src/app/commands/cmd_keyboard_shortcuts.cpp
+++ b/src/app/commands/cmd_keyboard_shortcuts.cpp
@@ -205,13 +205,28 @@ private:
     Shortcut origShortcut = m_key->shortcuts()[index];
     SelectShortcut window(origShortcut, m_key->keycontext(), m_keys);
     window.openWindowInForeground();
-
+    bool conflict = false;
     if (window.isModified()) {
-      m_key->disableShortcut(origShortcut, KeySource::UserDefined);
-      if (!window.shortcut().isEmpty())
-        m_key->add(window.shortcut(), KeySource::UserDefined, m_keys);
+    for (KeyPtr& key : m_keys) {
+      if (key.get() != m_key.get() && key->keycontext() == m_key->keycontext() && key->hasShortcut(window.shortcut()) &&
+        // Tools can contain the same keyboard shortcut
+        (key->type() != KeyType::Tool || m_key.get() == nullptr || m_key->type() != KeyType::Tool) &&
+        // DragActions can share the same keyboard shortcut (e.g. to
+        // change different values using different DragVectors)
+        (key->type() != KeyType::DragAction || m_key.get() == nullptr ||
+        m_key->type() != KeyType::DragAction)) {
+        conflict = true;
+        break;
+      }
     }
-
+    if (conflict) {
+      if (ui::Alert::show(Strings::alerts_shortcut_overwrite_alert(window.shortcut().toString())) != 1)
+          return;
+    }
+    m_key->disableShortcut(origShortcut, KeySource::UserDefined);
+    if (!window.shortcut().isEmpty())
+      m_key->add(window.shortcut(), KeySource::UserDefined, m_keys);
+    }
     this->window()->layout();
   }
 
@@ -250,10 +265,27 @@ private:
 
         m_menuKeys[m_menuitem] = m_key;
       }
-
+      bool conflict = false;
+    
+        
+      for (KeyPtr& key : m_keys) {
+        if (key.get() != m_key.get() && key->keycontext() == m_key->keycontext() && key->hasShortcut(window.shortcut()) &&
+          // Tools can contain the same keyboard shortcut
+          (key->type() != KeyType::Tool || m_key.get() == nullptr || m_key->type() != KeyType::Tool) &&
+          // DragActions can share the same keyboard shortcut (e.g. to
+          // change different values using different DragVectors)
+          (key->type() != KeyType::DragAction || m_key.get() == nullptr ||
+          m_key->type() != KeyType::DragAction)) {
+          conflict = true;
+          break;
+        }
+      }
+      if (conflict) {
+        if (ui::Alert::show(Strings::alerts_shortcut_overwrite_alert(window.shortcut().toString())) != 1)
+            return;
+      }
       m_key->add(window.shortcut(), KeySource::UserDefined, m_keys);
     }
-
     this->window()->layout();
   }
 

--- a/src/app/commands/cmd_keyboard_shortcuts.cpp
+++ b/src/app/commands/cmd_keyboard_shortcuts.cpp
@@ -239,7 +239,7 @@ private:
 
     if (ui::Alert::show(Strings::alerts_delete_shortcut(shortcut.toString())) != 1)
       return;
-
+    
     m_key->disableShortcut(shortcut, KeySource::UserDefined);
     window()->layout();
   }
@@ -266,8 +266,6 @@ private:
         m_menuKeys[m_menuitem] = m_key;
       }
       bool conflict = false;
-    
-        
       for (KeyPtr& key : m_keys) {
         if (key.get() != m_key.get() && key->keycontext() == m_key->keycontext() && key->hasShortcut(window.shortcut()) &&
           // Tools can contain the same keyboard shortcut


### PR DESCRIPTION
Implemented the logic to check and give an alert to user if they try to assign a shortcut key that is already assigned. I used AI for understand the codebase and finding those files where I had to make changes. I asked it for logic flow and further fixing my implementation if there were some errors. All of the code was written by me, and AI (Github Copilot) was used as a guidance tool. The required feature if I understood it correctly is working correctly on my locally build aseprite.exe

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the Individual Contributor License Agreement V4.0. -->
<!-- If you're a first-time contributor, please sign the CLA
     as indicated in https://github.com/igarastudio/cla#signing
     and acknowledge it by leaving the statement below. -->

I declare that my contributions are not co-authored using a generative AI technology.

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing
