### PR TITLE
Update Entry and ResouceFinder to avoid using raw char buffers

### DIFF
--- a/src/app/resource_finder.cpp
+++ b/src/app/resource_finder.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2023  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2016  David Capello
 //
 // This program is distributed under the terms of
@@ -15,9 +15,6 @@
 #include "base/fs.h"
 #include "base/string.h"
 #include "ver/info.h"
-
-#include <cstdio>
-#include <cstdlib>
 
 #ifdef _WIN32
   #include <shlobj.h>
@@ -76,48 +73,46 @@ void ResourceFinder::addPath(const std::string& path)
   m_paths.push_back(path);
 }
 
-void ResourceFinder::includeBinDir(const char* filename)
+void ResourceFinder::includeBinDir(const std::string& filename)
 {
   addPath(base::join_path(base::get_file_path(base::get_app_path()), filename));
 }
 
-void ResourceFinder::includeDataDir(const char* filename)
+void ResourceFinder::includeDataDir(const std::string& filename)
 {
-  char buf[4096];
-
 #ifdef _WIN32
 
-  std::snprintf(buf, sizeof(buf), "data/%s", filename);
-  includeHomeDir(buf); // %AppData%/Aseprite/data/filename
-  includeBinDir(buf);  // $BINDIR/data/filename
+  std::string path = "data/" + filename;
+  includeHomeDir(path); // %AppData%/Aseprite/data/filename
+  includeBinDir(path);  // $BINDIR/data/filename
 
 #elif __APPLE__
 
-  std::snprintf(buf, sizeof(buf), "data/%s", filename);
-  includeUserDir(buf); // $HOME/Library/Application Support/Aseprite/data/filename
-  includeBinDir(buf);  // $BINDIR/data/filename (outside the bundle)
+  std::string path = "data/" + filename;
+  includeUserDir(path); // $HOME/Library/Application Support/Aseprite/data/filename
+  includeBinDir(path);  // $BINDIR/data/filename (outside the bundle)
 
-  std::snprintf(buf, sizeof(buf), "../Resources/data/%s", filename);
-  includeBinDir(buf); // $BINDIR/../Resources/data/filename (inside a bundle)
+  path = "../Resources/data/" + filename;
+  includeBinDir(path); // $BINDIR/../Resources/data/filename (inside a bundle)
 
 #else
 
   // $HOME/.config/aseprite/filename
-  std::snprintf(buf, sizeof(buf), "aseprite/data/%s", filename);
-  includeHomeConfigDir(buf);
+  std::string path = "aseprite/data/" + filename;
+  includeHomeConfigDir(path);
 
   // $BINDIR/data/filename
-  std::snprintf(buf, sizeof(buf), "data/%s", filename);
-  includeBinDir(buf);
+  path = "data/" + filename;
+  includeBinDir(path);
 
   // $BINDIR/../share/aseprite/data/filename (installed in /usr/ or /usr/local/)
-  std::snprintf(buf, sizeof(buf), "../share/aseprite/data/%s", filename);
-  includeBinDir(buf);
+  path = "../share/aseprite/data/" + filename;
+  includeBinDir(path);
 
 #endif
 }
 
-void ResourceFinder::includeHomeDir(const char* filename)
+void ResourceFinder::includeHomeDir(const std::string& filename)
 {
 #ifdef _WIN32
 
@@ -133,12 +128,10 @@ void ResourceFinder::includeHomeDir(const char* filename)
 #else
 
   char* env = std::getenv("HOME");
-  char buf[4096];
 
   if ((env) && (*env)) {
     // $HOME/filename
-    std::snprintf(buf, sizeof(buf), "%s/%s", env, filename);
-    addPath(buf);
+    addPath(base::join_path(env, filename));
   }
   else {
     LOG("FIND: You don't have set $HOME variable\n");
@@ -151,7 +144,7 @@ void ResourceFinder::includeHomeDir(const char* filename)
 #if !defined(_WIN32) && !defined(__APPLE__)
 
 // For Linux: It's $XDG_CONFIG_HOME or $HOME/.config
-void ResourceFinder::includeHomeConfigDir(const char* filename)
+void ResourceFinder::includeHomeConfigDir(const std::string& filename)
 {
   char* configHome = std::getenv("XDG_CONFIG_HOME");
   if (configHome && *configHome) {
@@ -160,13 +153,13 @@ void ResourceFinder::includeHomeConfigDir(const char* filename)
   }
   else {
     // $HOME/.config/filename
-    includeHomeDir(base::join_path(std::string(".config"), filename).c_str());
+    includeHomeDir(base::join_path(".config", filename));
   }
 }
 
 #endif // !defined(_WIN32) && !defined(__APPLE__)
 
-void ResourceFinder::includeUserDir(const char* filename)
+void ResourceFinder::includeUserDir(const std::string& filename)
 {
 #ifdef _WIN32
 
@@ -194,13 +187,12 @@ void ResourceFinder::includeUserDir(const char* filename)
 
     // $HOME/Library/Application Support/Aseprite/filename
     addPath(
-      base::join_path(base::join_path(base::get_lib_app_support_path(), get_app_name()), filename)
-        .c_str());
+      base::join_path(base::join_path(base::get_lib_app_support_path(), get_app_name()), filename));
 
   #else // !__APPLE__
 
     // $HOME/.config/aseprite/filename
-    includeHomeConfigDir((std::string("aseprite/") + filename).c_str());
+    includeHomeConfigDir("aseprite/" + filename);
 
   #endif
   }
@@ -208,7 +200,7 @@ void ResourceFinder::includeUserDir(const char* filename)
 #endif // end Unix-like
 }
 
-void ResourceFinder::includeDesktopDir(const char* filename)
+void ResourceFinder::includeDesktopDir(const std::string& filename)
 {
 #ifdef _WIN32
 
@@ -225,7 +217,7 @@ void ResourceFinder::includeDesktopDir(const char* filename)
 
   // TODO get the desktop folder
   // $HOME/Desktop/filename
-  includeHomeDir(base::join_path(std::string("Desktop"), filename).c_str());
+  includeHomeDir(base::join_path("Desktop", filename));
 
 #else
 
@@ -236,7 +228,7 @@ void ResourceFinder::includeDesktopDir(const char* filename)
   }
   else {
     // $HOME/Desktop/filename
-    includeHomeDir(base::join_path(std::string("Desktop"), filename).c_str());
+    includeHomeDir(base::join_path("Desktop", filename));
   }
 
 #endif

--- a/src/app/resource_finder.h
+++ b/src/app/resource_finder.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2021  Igara Studio S.A.
+// Copyright (C) 2019-present Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -38,13 +38,13 @@ public:
 
   // These functions add possible full paths to find files.
   void addPath(const std::string& path);
-  void includeBinDir(const char* filename);
-  void includeDataDir(const char* filename);
-  void includeHomeDir(const char* filename);
+  void includeBinDir(const std::string& filename);
+  void includeDataDir(const std::string& filename);
+  void includeHomeDir(const std::string& filename);
 
 #if !defined(_WIN32) && !defined(__APPLE__)
   // For Linux: It's $XDG_CONFIG_HOME or $HOME/.config
-  void includeHomeConfigDir(const char* filename);
+  void includeHomeConfigDir(const std::string& filename);
 #endif
 
   // Tries to add the given filename in these locations:
@@ -59,9 +59,9 @@ public:
   //   %AppData% location
   // For Unix-like platforms:
   // - The filename will be in $HOME/.config/aseprite/
-  void includeUserDir(const char* filename);
+  void includeUserDir(const std::string& filename);
 
-  void includeDesktopDir(const char* filename);
+  void includeDesktopDir(const std::string& filename);
 
   // Returns the first file found or creates the whole directory
   // structure to create the file in its default location.

--- a/src/app/script/dialog_class.cpp
+++ b/src/app/script/dialog_class.cpp
@@ -867,7 +867,8 @@ int Dialog_entry(lua_State* L)
     lua_pop(L, 1);
   }
 
-  auto widget = new ui::Entry(4096, text.c_str());
+  auto widget = new ui::Entry(4096);
+  widget->setText(text);
 
   if (lua_istable(L, 2)) {
     int type = lua_getfield(L, 2, "onchange");

--- a/src/app/ui/editor/writing_text_state.cpp
+++ b/src/app/ui/editor/writing_text_state.cpp
@@ -81,7 +81,7 @@ public:
   };
 
   TextEditor(Editor* editor, const Site& site, const gfx::Rect& bounds)
-    : Entry(4096, "")
+    : Entry(4096)
     , m_editor(editor)
     , m_doc(site.document())
     , m_extraCel(new ExtraCel)

--- a/src/app/ui/expr_entry.cpp
+++ b/src/app/ui/expr_entry.cpp
@@ -21,7 +21,7 @@
 
 namespace app {
 
-ExprEntry::ExprEntry() : ui::Entry(1024, ""), m_decimals(0)
+ExprEntry::ExprEntry() : ui::Entry(1024), m_decimals(0)
 {
 }
 

--- a/src/app/ui/filename_field.cpp
+++ b/src/app/ui/filename_field.cpp
@@ -32,7 +32,7 @@ FilenameField::FilenameButton::FilenameButton(const std::string& text) : ButtonS
 }
 
 FilenameField::FilenameField(const Type type, const std::string& pathAndFilename)
-  : m_entry(type == EntryAndButton ? new ui::Entry(1024, "") : nullptr)
+  : m_entry(type == EntryAndButton ? new ui::Entry(1024) : nullptr)
   , m_button(type == EntryAndButton ? Strings::select_file_browse() : Strings::select_file_text())
   , m_askOverwrite(true)
 {

--- a/src/app/ui/hex_color_entry.cpp
+++ b/src/app/ui/hex_color_entry.cpp
@@ -21,7 +21,7 @@ namespace app {
 
 using namespace ui;
 
-HexColorEntry::CustomEntry::CustomEntry() : Entry(16, "")
+HexColorEntry::CustomEntry::CustomEntry() : Entry(16)
 {
 }
 

--- a/src/app/ui/search_entry.cpp
+++ b/src/app/ui/search_entry.cpp
@@ -27,7 +27,7 @@ using namespace app::skin;
 using namespace gfx;
 using namespace ui;
 
-SearchEntry::SearchEntry() : Entry(256, ""), m_clearOnEsc(false), m_debounceMs(0)
+SearchEntry::SearchEntry() : Entry(256), m_clearOnEsc(false), m_debounceMs(0)
 {
 }
 

--- a/src/app/ui/select_shortcut.cpp
+++ b/src/app/ui/select_shortcut.cpp
@@ -23,7 +23,7 @@ using namespace ui;
 
 class SelectShortcut::KeyField : public ui::Entry {
 public:
-  KeyField(const Shortcut& shortcut) : ui::Entry(256, "")
+  KeyField(const Shortcut& shortcut) : ui::Entry(256)
   {
     setId("key_field");
     setTranslateDeadKeys(false);

--- a/src/app/ui/slider2.cpp
+++ b/src/app/ui/slider2.cpp
@@ -19,10 +19,11 @@ namespace app {
 
 // TODO merge this code with ColorEntry in color_sliders.cpp
 Slider2::Slider2Entry::Slider2Entry(ui::Slider* slider)
-  : ui::Entry(4, "0")
+  : ui::Entry(4)
   , m_slider(slider)
   , m_recentFocus(false)
 {
+  setText("0");
 }
 
 bool Slider2::Slider2Entry::onProcessMessage(ui::Message* msg)

--- a/src/app/ui/status_bar.cpp
+++ b/src/app/ui/status_bar.cpp
@@ -612,7 +612,7 @@ private:
 // This widget is used to show the current frame.
 class GotoFrameEntry : public Entry {
 public:
-  GotoFrameEntry() : Entry(4, "") {}
+  GotoFrameEntry() : Entry(4) {}
 
   bool onProcessMessage(Message* msg) override
   {

--- a/src/app/widget_loader.cpp
+++ b/src/app/widget_loader.cpp
@@ -217,7 +217,7 @@ Widget* WidgetLoader::convertXmlElementToWidget(const XMLElement* elem,
     const char* decimals = elem->Attribute("decimals");
     const bool readonly = bool_attr(elem, "readonly", false);
 
-    widget = (elem_name == "expr" ? new ExprEntry : new Entry(strtol(maxsize, nullptr, 10), ""));
+    widget = (elem_name == "expr" ? new ExprEntry : new Entry(strtol(maxsize, nullptr, 10)));
 
     if (readonly)
       ((Entry*)widget)->setReadOnly(true);

--- a/src/ui/combobox.cpp
+++ b/src/ui/combobox.cpp
@@ -40,7 +40,7 @@ public:
 
 class ComboBoxEntry : public Entry {
 public:
-  ComboBoxEntry(ComboBox* comboBox) : Entry(256, ""), m_comboBox(comboBox) {}
+  ComboBoxEntry(ComboBox* comboBox) : Entry(256), m_comboBox(comboBox) {}
 
 protected:
   bool onProcessMessage(Message* msg) override;

--- a/src/ui/entry.cpp
+++ b/src/ui/entry.cpp
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2018-2025  Igara Studio S.A.
+// Copyright (C) 2018-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -27,9 +27,6 @@
 #include "ui/widget.h"
 
 #include <algorithm>
-#include <cctype>
-#include <cstdarg>
-#include <cstdio>
 #include <memory>
 
 namespace ui {
@@ -48,7 +45,7 @@ static inline bool is_word_char(int ch)
   return (ch && !std::isspace(ch) && !std::ispunct(ch));
 }
 
-Entry::Entry(const int maxsize, const char* format, ...)
+Entry::Entry(const int maxsize)
   : Widget(kEntryWidget)
   , m_maxsize(maxsize)
   , m_caret(0)
@@ -64,24 +61,6 @@ Entry::Entry(const int maxsize, const char* format, ...)
   , m_scale(1.0f, 1.0f)
 {
   enableFlags(CTRL_RIGHT_CLICK);
-
-  // formatted string
-  char buf[4096]; // TODO buffer overflow
-  if (format) {
-    va_list ap;
-    va_start(ap, format);
-    std::vsnprintf(buf, sizeof(buf), format, ap);
-    va_end(ap);
-  }
-  // empty string
-  else {
-    buf[0] = 0;
-  }
-
-  // TODO support for text alignment and multi-line
-  // widget->align = LEFT | MIDDLE;
-  setText(buf);
-
   setFocusStop(true);
   initTheme();
 }

--- a/src/ui/entry.h
+++ b/src/ui/entry.h
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2018-2025  Igara Studio S.A.
+// Copyright (C) 2018-present  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -31,10 +31,10 @@ public:
     void reset() { from = to = -1; }
   };
 
-  Entry(const int maxsize, const char* format, ...);
-  ~Entry();
+  explicit Entry(int maxsize);
+  ~Entry() override;
 
-  void setMaxTextLength(const int maxsize);
+  void setMaxTextLength(int maxsize);
 
   bool isReadOnly() const;
   void setReadOnly(bool state);

--- a/src/ui/int_entry.cpp
+++ b/src/ui/int_entry.cpp
@@ -34,7 +34,7 @@ namespace ui {
 using namespace gfx;
 
 IntEntry::IntEntry(int min, int max, SliderDelegate* sliderDelegate)
-  : Entry(int(std::floor(std::log10(double(max)))) + 1, "")
+  : Entry(int(std::floor(std::log10(double(max)))) + 1)
   , m_min(min)
   , m_max(max)
   , m_popupWindow(nullptr)

--- a/src/ui/widget.cpp
+++ b/src/ui/widget.cpp
@@ -158,11 +158,8 @@ void Widget::setTextf(const char* format, ...)
   if (format) {
     va_list ap;
     va_start(ap, format);
-    char buf[4096];
-    std::vsnprintf(buf, sizeof(buf), format, ap);
+    setText(base::string_vprintf(format, ap));
     va_end(ap);
-
-    setText(buf);
   }
   // empty string
   else {


### PR DESCRIPTION
Updated Entry: removed the format parameter entirely since nothing was using it, and did a small refactor of ResourceFinder to switch it over to std::string instead of raw strings.