### PR TITLE
[lua] Add Dialog:folder, onchange event values, fix onresize event

### DIFF
--- a/data/strings/en.ini
+++ b/data/strings/en.ini
@@ -778,6 +778,7 @@ list_view_button_tooltip = List View
 small_icon_view_button_tooltip = Small Icons View
 big_icon_view_button_tooltip = Big Icons View
 file_name = File name:
+folder_name = Folder name:
 file_type = File type:
 pinned_folders = Pinned Folders
 recent_folders = Recent Folders

--- a/data/widgets/file_selector.xml
+++ b/data/widgets/file_selector.xml
@@ -27,10 +27,10 @@
     </box>
     <vbox id="file_view_placeholder" expansive="true" />
     <grid columns="2">
-      <label text="@.file_name" for="file_name" />
+      <label text="@.file_name" id="file_name_label" for="file_name" />
       <box id="file_name_placeholder" cell_align="horizontal" />
 
-      <label text="@.file_type" for="file_type" />
+      <label text="@.file_type" id="file_type_label" for="file_type" />
       <hbox cell_align="horizontal">
         <combobox id="file_type" minwidth="70" />
         <boxfiller />

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -671,6 +671,7 @@ target_sources(app-lib PRIVATE
   ui/palette_popup.cpp
   ui/palette_view.cpp
   ui/palettes_listbox.cpp
+  ui/path_field.cpp
   ui/popup_window_pin.cpp
   ui/pref_widget.cpp
   ui/preview_editor.cpp

--- a/src/app/file_selector.cpp
+++ b/src/app/file_selector.cpp
@@ -29,7 +29,7 @@ namespace app {
 bool show_file_selector(const std::string& title,
                         const std::string& initialPath,
                         const base::paths& extensions,
-                        FileSelectorType type,
+                        const FileSelectorType type,
                         base::paths& output)
 {
   const os::SystemRef system = os::System::instance();
@@ -74,6 +74,7 @@ bool show_file_selector(const std::string& title,
       switch (type) {
         case FileSelectorType::Open:         nativeType = dlgs::FileDialog::Type::OpenFile; break;
         case FileSelectorType::OpenMultiple: nativeType = dlgs::FileDialog::Type::OpenFiles; break;
+        case FileSelectorType::OpenFolder:   nativeType = dlgs::FileDialog::Type::OpenFolder; break;
         case FileSelectorType::Save:         nativeType = dlgs::FileDialog::Type::SaveFile; break;
       }
       dlg->setType(nativeType);

--- a/src/app/file_selector.h
+++ b/src/app/file_selector.h
@@ -20,7 +20,7 @@ class ComboBox;
 
 namespace app {
 
-enum class FileSelectorType { Open, OpenMultiple, Save };
+enum class FileSelectorType { Open, OpenMultiple, OpenFolder, Save };
 
 bool show_file_selector(const std::string& title,
                         const std::string& initialPath,

--- a/src/app/script/dialog_class.cpp
+++ b/src/app/script/dialog_class.cpp
@@ -11,28 +11,27 @@
 
 #include "app/app.h"
 #include "app/color.h"
-#include "app/color_utils.h"
 #include "app/context.h"
 #include "app/doc.h"
 #include "app/file_selector.h"
+#include "app/i18n/strings.h"
 #include "app/script/canvas_widget.h"
 #include "app/script/engine.h"
 #include "app/script/graphics_context.h"
 #include "app/script/keys.h"
 #include "app/script/luacpp.h"
 #include "app/script/tabs_widget.h"
-#include "app/ui/button_set.h"
 #include "app/ui/color_button.h"
 #include "app/ui/color_shades.h"
 #include "app/ui/editor/editor.h"
 #include "app/ui/expr_entry.h"
 #include "app/ui/filename_field.h"
 #include "app/ui/main_window.h"
+#include "app/ui/path_field.h"
+#include "app/ui/skin/skin_theme.h"
 #include "app/ui/window_with_hand.h"
 #include "base/fs.h"
 #include "base/paths.h"
-#include "base/remove_from_container.h"
-#include "os/screen.h"
 #include "os/system.h"
 #include "ui/app_state.h"
 #include "ui/box.h"
@@ -46,6 +45,7 @@
 #include "ui/manager.h"
 #include "ui/menu.h"
 #include "ui/message.h"
+#include "ui/resize_event.h"
 #include "ui/scale.h"
 #include "ui/scroll_window.h"
 #include "ui/separator.h"
@@ -405,8 +405,9 @@ int Dialog_new(lua_State* L)
 
     type = lua_getfield(L, 1, "onresize");
     if (type == LUA_TFUNCTION) {
-      Dialog_connect_signal(L, -2, dlg->window.Resize, [](lua_State*, ResizeEvent&) {
-        // Do nothing
+      Dialog_connect_signal(L, -2, dlg->window.Resize, [](lua_State* L, ResizeEvent& event) {
+        push_obj(L, event.bounds());
+        lua_setfield(L, -2, "size");
       });
     }
     lua_pop(L, 1);
@@ -873,8 +874,9 @@ int Dialog_entry(lua_State* L)
   if (lua_istable(L, 2)) {
     int type = lua_getfield(L, 2, "onchange");
     if (type == LUA_TFUNCTION) {
-      Dialog_connect_signal(L, 1, widget->Change, [](lua_State* L) {
-        // Do nothing
+      Dialog_connect_signal(L, 1, widget->Change, [widget](lua_State* L) {
+        lua_pushstring(L, widget->text().c_str());
+        lua_setfield(L, -2, "value");
       });
     }
     lua_pop(L, 1);
@@ -908,10 +910,21 @@ int Dialog_number(lua_State* L)
     }
     lua_pop(L, 1);
 
+    type = lua_getfield(L, 2, "placeholder");
+    if (type == LUA_TSTRING) {
+      if (auto p = lua_tostring(L, -1))
+        widget->setPlaceholder(p);
+    }
+    lua_pop(L, 1);
+
     type = lua_getfield(L, 2, "onchange");
     if (type == LUA_TFUNCTION) {
-      Dialog_connect_signal(L, 1, widget->Change, [](lua_State* L) {
-        // Do nothing
+      Dialog_connect_signal(L, 1, widget->Change, [widget](lua_State* L) {
+        if (widget->decimals() == 0)
+          lua_pushinteger(L, widget->textInt());
+        else
+          lua_pushnumber(L, widget->textDouble());
+        lua_setfield(L, -2, "value");
       });
     }
     lua_pop(L, 1);
@@ -951,16 +964,18 @@ int Dialog_slider(lua_State* L)
   if (lua_istable(L, 2)) {
     int type = lua_getfield(L, 2, "onchange");
     if (type == LUA_TFUNCTION) {
-      Dialog_connect_signal(L, 1, widget->Change, [](lua_State* L) {
-        // Do nothing
+      Dialog_connect_signal(L, 1, widget->Change, [widget](lua_State* L) {
+        lua_pushnumber(L, widget->getValue());
+        lua_setfield(L, -2, "value");
       });
     }
     lua_pop(L, 1);
 
     type = lua_getfield(L, 2, "onrelease");
     if (type == LUA_TFUNCTION) {
-      Dialog_connect_signal(L, 1, widget->SliderReleased, [](lua_State* L) {
-        // Do nothing
+      Dialog_connect_signal(L, 1, widget->SliderReleased, [widget](lua_State* L) {
+        lua_pushnumber(L, widget->getValue());
+        lua_setfield(L, -2, "value");
       });
     }
     lua_pop(L, 1);
@@ -997,8 +1012,12 @@ int Dialog_combobox(lua_State* L)
 
     type = lua_getfield(L, 2, "onchange");
     if (type == LUA_TFUNCTION) {
-      Dialog_connect_signal(L, 1, widget->Change, [](lua_State* L) {
-        // Do nothing
+      Dialog_connect_signal(L, 1, widget->Change, [widget](lua_State* L) {
+        const auto* selectedItem = widget->getSelectedItem();
+        lua_pushstring(L, selectedItem ? selectedItem->text().c_str() : "");
+        lua_setfield(L, -2, "value");
+        lua_pushinteger(L, widget->getSelectedItemIndex() + 1);
+        lua_setfield(L, -2, "index");
       });
     }
     lua_pop(L, 1);
@@ -1089,7 +1108,7 @@ int Dialog_shades(lua_State* L)
 
 int Dialog_file(lua_State* L)
 {
-  std::string title = "Open File";
+  std::string title = Strings::open_file_title();
   std::string path;
   std::string fn;
   base::paths exts;
@@ -1105,7 +1124,7 @@ int Dialog_file(lua_State* L)
     int type = lua_getfield(L, 2, "save");
     if (type == LUA_TBOOLEAN && lua_toboolean(L, -1)) {
       dlgType = FileSelectorType::Save;
-      title = "Save File";
+      title = Strings::save_file_title();
     }
     lua_pop(L, 1);
 
@@ -1143,9 +1162,17 @@ int Dialog_file(lua_State* L)
   if (lua_istable(L, 2)) {
     int type = lua_getfield(L, 2, "onchange");
     if (type == LUA_TFUNCTION) {
-      Dialog_connect_signal(L, 1, widget->Change, [](lua_State* L) {
-        // Do nothing
+      Dialog_connect_signal(L, 1, widget->Change, [widget](lua_State* L) {
+        lua_pushstring(L, base::normalize_path(widget->fullFilename()).c_str());
+        lua_setfield(L, -2, "value");
       });
+    }
+    lua_pop(L, 1);
+
+    type = lua_getfield(L, 2, "placeholder");
+    if (type == LUA_TSTRING) {
+      if (const auto* p = lua_tostring(L, -1))
+        widget->setPlaceholder(p);
     }
     lua_pop(L, 1);
   }
@@ -1171,13 +1198,63 @@ int Dialog_file(lua_State* L)
   widget->setDocFilename(fn);
   widget->setFilename(fn);
 
-  widget->SelectOutputFile.connect([=]() -> std::string {
+  widget->SelectOutputFile.connect([widget, title, exts, dlgType] {
     base::paths newfilename;
     if (app::show_file_selector(title, widget->fullFilename(), exts, dlgType, newfilename))
       return newfilename.front();
     else
       return widget->fullFilename();
   });
+  return Dialog_add_widget(L, widget);
+}
+
+int Dialog_folder(lua_State* L)
+{
+  std::string title = Strings::open_file_title();
+  std::string path;
+
+  if (lua_istable(L, 2)) {
+    int type = lua_getfield(L, 2, "title");
+    if (type == LUA_TSTRING)
+      title = lua_tostring(L, -1);
+    lua_pop(L, 1);
+
+    type = lua_getfield(L, 2, "path");
+    if (type == LUA_TSTRING) {
+      path = lua_tostring(L, -1);
+    }
+    lua_pop(L, 1);
+  }
+
+  auto* widget = new PathField(title, path);
+
+  if (lua_istable(L, 2)) {
+    int type = lua_getfield(L, 2, "onchange");
+    if (type == LUA_TFUNCTION) {
+      Dialog_connect_signal(L, 1, widget->Change, [](lua_State* L, const std::string& selected) {
+        lua_pushstring(L, selected.c_str());
+        lua_setfield(L, -2, "value");
+      });
+    }
+    lua_pop(L, 1);
+
+    type = lua_getfield(L, 2, "onselect");
+    if (type == LUA_TFUNCTION) {
+      Dialog_connect_signal(L, 1, widget->Selected, [](lua_State* L, const std::string& selected) {
+        lua_pushstring(L, selected.c_str());
+        lua_setfield(L, -2, "value");
+      });
+    }
+    lua_pop(L, 1);
+
+    type = lua_getfield(L, 2, "placeholder");
+    if (type == LUA_TSTRING) {
+      if (const auto* p = lua_tostring(L, -1))
+        widget->getEntryWidget()->setPlaceholder(p);
+    }
+    lua_pop(L, 1);
+  }
+
   return Dialog_add_widget(L, widget);
 }
 
@@ -1674,6 +1751,14 @@ int Dialog_modify(lua_State* L)
     }
     lua_pop(L, 1);
 
+    type = lua_getfield(L, 2, "path");
+    if (auto p = lua_tostring(L, -1)) {
+      if (auto pathSelector = dynamic_cast<PathField*>(widget)) {
+        pathSelector->setPath(p);
+      }
+    }
+    lua_pop(L, 1);
+
     type = lua_getfield(L, 2, "mouseCursor");
     if (type == LUA_TNIL) {
       lua_pop(L, 1);
@@ -1862,11 +1947,14 @@ int Dialog_get_data(lua_State* L)
           }
         }
         else if (auto filenameField = dynamic_cast<const FilenameField*>(widget)) {
-          lua_pushstring(L, filenameField->fullFilename().c_str());
+          lua_pushstring(L, base::normalize_path(filenameField->fullFilename()).c_str());
         }
         else if (auto tabs = dynamic_cast<const app::script::Tabs*>(widget)) {
           std::string tabStr = tabs->tabId(tabs->selectedTab());
           lua_pushstring(L, tabStr.c_str());
+        }
+        else if (auto* pathSelector = dynamic_cast<const PathField*>(widget)) {
+          lua_pushstring(L, base::normalize_path(pathSelector->path()).c_str());
         }
         else {
           lua_pushnil(L);
@@ -1964,6 +2052,10 @@ int Dialog_set_data(lua_State* L)
             tabs->selectTab(tabIndex);
           }
         }
+        else if (auto pathSelector = dynamic_cast<PathField*>(widget)) {
+          if (auto p = lua_tostring(L, -1))
+            pathSelector->setPath(p);
+        }
         break;
     }
 
@@ -2041,6 +2133,7 @@ const luaL_Reg Dialog_methods[] = {
   { "color",     Dialog_color     },
   { "shades",    Dialog_shades    },
   { "file",      Dialog_file      },
+  { "folder",    Dialog_folder    },
   { "canvas",    Dialog_canvas    },
   { "tab",       Dialog_tab       },
   { "endtabs",   Dialog_endtabs   },

--- a/src/app/ui/file_selector.cpp
+++ b/src/app/ui/file_selector.cpp
@@ -428,12 +428,20 @@ bool FileSelector::show(const std::string& title,
     else
       exts = preferred_open_extensions[k];
   }
-  else {
-    ASSERT(m_type == FileSelectorType::Save);
+  else if (m_type == FileSelectorType::Save) {
     if (!initialExtension.empty())
       exts = base::paths{ initialExtension };
     else
       exts = allExtensions;
+  }
+  else {
+    ASSERT(m_type == FileSelectorType::OpenFolder);
+    fileNameLabel()->setText(Strings::file_selector_folder_name());
+    fileTypeLabel()->setVisible(false);
+    fileType()->setVisible(false);
+    // Hacky way to have the file dialog only show folders without changing the fileList code
+    m_defExtension = "</DIR_EXTENSION/>";
+    exts = { m_defExtension };
   }
   m_fileList->setMultipleSelection(m_type == FileSelectorType::OpenMultiple);
   m_fileList->setExtensions(exts);
@@ -448,41 +456,42 @@ bool FileSelector::show(const std::string& title,
   updateLocation();
   updateNavigationButtons();
 
-  // fill file-type combo-box
-  fileType()->deleteAllItems();
-
   // Get the default extension from the given initial file name
   if (m_defExtension.empty())
     m_defExtension = initialExtension;
 
-  // File type for all formats
-  fileType()->addItem(
-    new CustomFileExtensionItem(Strings::file_selector_all_formats(), allExtensions));
+  if (m_type != FileSelectorType::OpenFolder) {
+    // fill file-type combo-box
+    fileType()->deleteAllItems();
 
-  // One file type for each supported image format
-  for (const auto& e : allExtensions) {
-    // If the default extension is empty, use the first filter
-    if (m_defExtension.empty())
-      m_defExtension = e;
+    // File type for all formats
+    fileType()->addItem(
+      new CustomFileExtensionItem(Strings::file_selector_all_formats(), allExtensions));
 
-    fileType()->addItem(new CustomFileExtensionItem(e + " files", base::paths{ e }));
+    // One file type for each supported image format
+    for (const auto& e : allExtensions) {
+      // If the default extension is empty, use the first filter
+      if (m_defExtension.empty())
+        m_defExtension = e;
+
+      fileType()->addItem(new CustomFileExtensionItem(e + " files", base::paths{ e }));
+    }
+    // All files
+    fileType()->addItem(new CustomFileExtensionItem(Strings::file_selector_all_files(),
+                                                    base::paths())); // Empty extensions means "*.*"
+    for (Widget* wItem : *fileType()) {
+      auto item = dynamic_cast<CustomFileExtensionItem*>(wItem);
+      ASSERT(item);
+      if (item && item->extensions() == exts) {
+        fileType()->setSelectedItem(item);
+        break;
+      }
+    }
   }
-  // All files
-  fileType()->addItem(new CustomFileExtensionItem(Strings::file_selector_all_files(),
-                                                  base::paths())); // Empty extensions means "*.*"
 
   // file name entry field
   m_fileName->setValue(base::get_file_name(initialPath).c_str());
   m_fileName->getEntryWidget()->selectText(0, -1);
-
-  for (Widget* wItem : *fileType()) {
-    auto item = dynamic_cast<CustomFileExtensionItem*>(wItem);
-    ASSERT(item);
-    if (item && item->extensions() == exts) {
-      fileType()->setSelectedItem(item);
-      break;
-    }
-  }
 
   // setup the title of the window
   setText(title.c_str());
@@ -582,6 +591,10 @@ again:
         enter_folder = fs->getFileItemFromPath(buf);
       }
     }
+
+    // Not the ideal way to do it but I'd rather leave the old logic alone
+    if (m_type == FileSelectorType::OpenFolder)
+      enter_folder = nullptr;
 
     // did we find a folder to enter?
     if (enter_folder && enter_folder->isFolder() && enter_folder->isBrowsable()) {
@@ -955,13 +968,25 @@ void FileSelector::onFileTypeChange()
 
 void FileSelector::onFileListFileSelected()
 {
-  IFileItem* fileitem = m_fileList->selectedFileItem();
+  const IFileItem* fileitem = m_fileList->selectedFileItem();
 
-  if (fileitem && !fileitem->isFolder()) {
-    std::string filename = base::get_file_name(fileitem->fileName());
-
+  if (m_type == FileSelectorType::OpenFolder) {
+    if (!fileitem) {
+      m_fileName->setValue(m_fileList->currentFolder() ?
+                             base::get_file_name(m_fileList->currentFolder()->fileName()) :
+                             "");
+    }
+    else {
+      if (fileitem->isFolder())
+        m_fileName->setValue(base::get_file_name(fileitem->fileName()));
+      else
+        m_fileName->setValue(std::string());
+    }
+  }
+  else if (fileitem && !fileitem->isFolder()) {
+    const std::string filename = base::get_file_name(fileitem->fileName());
     if (m_type != FileSelectorType::OpenMultiple || m_fileList->selectedFileItems().size() == 1)
-      m_fileName->setValue(filename.c_str());
+      m_fileName->setValue(filename);
     else
       m_fileName->setValue(std::string());
   }

--- a/src/app/ui/filename_field.h
+++ b/src/app/ui/filename_field.h
@@ -27,7 +27,7 @@ class FilenameField : public ui::HBox {
 public:
   enum Type { EntryAndButton, ButtonOnly };
 
-  FilenameField(const Type type, const std::string& pathAndFilename);
+  FilenameField(Type type, const std::string& pathAndFilename);
 
   std::string filepath() const { return m_path; }
   std::string filename() const { return m_file; }
@@ -44,6 +44,7 @@ public:
     m_button.setEnabled(!readOnly);
   }
   bool isReadOnly() const { return m_entry->isReadOnly(); }
+  void setPlaceholder(const std::string& placeholder) { m_entry->setPlaceholder(placeholder); }
   void onUpdateText();
 
   obs::signal<std::string()> SelectOutputFile;

--- a/src/app/ui/path_field.cpp
+++ b/src/app/ui/path_field.cpp
@@ -1,0 +1,80 @@
+// Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
+//
+// This program is distributed under the terms of
+// the End-User License Agreement for Aseprite.
+
+#ifdef HAVE_CONFIG_H
+  #include "config.h"
+#endif
+
+#include "app/ui/path_field.h"
+
+#include "app/app.h"
+#include "app/file_selector.h"
+#include "app/i18n/strings.h"
+#include "app/pref/preferences.h"
+#include "base/fs.h"
+
+namespace app {
+
+using namespace ui;
+
+PathField::PathField(const std::string& title, const std::string& path) : m_title(title)
+{
+  m_entry = new Entry(256);
+  m_entry->setExpansive(true);
+  m_entry->setText(path);
+  m_entry->Change.connect([this] { Change(m_entry->text()); });
+  m_lastPath = path;
+
+  m_button = new ButtonSet(1);
+  m_button->ItemChange.connect(&PathField::onClickBrowse, this);
+  m_button->addItem(Strings::select_file_browse());
+
+  addChild(m_entry);
+  addChild(m_button);
+
+  InitTheme.connect([this] { setChildSpacing(0); });
+  initTheme();
+}
+
+void PathField::setPath(const std::string& path)
+{
+  m_entry->setText(path);
+  Change(path);
+}
+
+std::string PathField::path() const
+{
+  return m_entry->text();
+}
+
+void PathField::onClickBrowse(ButtonSet::Item*)
+{
+  m_button->setSelectedItem(nullptr);
+
+  std::string initialPath;
+  if (!m_entry->text().empty() && base::is_directory(m_entry->text())) {
+    initialPath = m_entry->text();
+  }
+  else {
+    initialPath = m_lastPath;
+  }
+
+  base::paths out;
+  if (show_file_selector(m_title, initialPath, {}, FileSelectorType::OpenFolder, out)) {
+    if (out.empty())
+      return;
+
+    const std::string& path = out.front();
+    m_entry->setText(path);
+
+    if (base::is_directory(path))
+      m_lastPath = path;
+
+    Selected(path);
+    Change(path);
+  }
+}
+} // namespace app

--- a/src/app/ui/path_field.h
+++ b/src/app/ui/path_field.h
@@ -1,0 +1,47 @@
+// Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
+//
+// This program is distributed under the terms of
+// the End-User License Agreement for Aseprite.
+
+#ifndef APP_UI_FOLDER_FIELD_H_INCLUDED
+#define APP_UI_FOLDER_FIELD_H_INCLUDED
+#pragma once
+
+#include "app/ui/button_set.h"
+#include "obs/signal.h"
+#include "ui/box.h"
+#include "ui/entry.h"
+
+#include <string>
+
+namespace app {
+
+using namespace ui;
+
+class PathField : public ::ui::HBox {
+public:
+  PathField(const std::string& title, const std::string& path);
+
+  void setPath(const std::string& path);
+
+  std::string path() const;
+  Entry* getEntryWidget() const { return m_entry; }
+
+  obs::signal<void(const std::string&)> Selected;
+  obs::signal<void(const std::string&)> Change;
+
+protected:
+  virtual void onClickBrowse(ButtonSet::Item*);
+
+private:
+  std::string m_title;
+  std::string m_lastPath;
+
+  Entry* m_entry;
+  ButtonSet* m_button;
+};
+
+} // namespace app
+
+#endif

--- a/src/ui/window.cpp
+++ b/src/ui/window.cpp
@@ -554,6 +554,10 @@ bool Window::onProcessMessage(Message* msg)
 
             moveWindow(rect, false);
             invalidate();
+
+            // Send a "fake" resize event since this resize didn't come from the window manager
+            ResizeEvent ev(this, rect);
+            Resize(ev);
           }
         }
       }


### PR DESCRIPTION
Fixes #5399, adds a new Dialog widget, the folder widget with the following API:

```lua
:folder{
    id="string",
    title="string",
    placeholder="string!",
    onchange=function,
    onselected=function
}
```
<img width="139" height="45" alt="image" src="https://github.com/user-attachments/assets/735f9114-de35-4bc2-8c52-29d6aaee6d2c" />

It looks basically just like the file selector but with no option to hide the entry. I'm looking at this as the first step towards #5395, starting from a more traditional base and then iterating towards a version of this where we can keep the old functionality.

In order to implement it I had to do some modifications to the Aseprite file picker to add a folder-only mode, I tried to keep the code modifications to a minimum. It'd be good to have t[he companion LAF PR](https://github.com/aseprite/laf/pull/183) merged before we merge this but it doesn't depend on code from it, it'll just not work on linux and work a bit weird on OS X.

Along with it and to encourage API consistency, I've added a `value` parameter to all of the `onchange` and other signals for Dialog widgets.

While doing some testing for this I also noticed that the Dialog onresize event was not firing for resizes that occur when we're in single-window mode, because the code path is different, so I added a little "fake" event to trigger the signal regardless.

Here's a script for testing:
```lua
local dlg = Dialog{
    onresize=function(ev)
        print("dialog resize:", ev.size)
    end
}
dlg:entry{
    id="entry",
    placeholder="Entry!",
    onchange=function(ev)
        print("entry change:", ev.value)
    end
}
:newrow()
:number{
    id="number",
    placeholder="Number!",
    onchange=function(ev)
        print("number change:", ev.value)
    end
}
:newrow()
:slider{
    id="slider",
    onchange=function(ev)
        print("slider change:", ev.value)
    end,
    onrelease=function(ev)
        print("slider release:", ev.value)
    end
}
:newrow()
:combobox{
    id="combobox",
    options={ "one", "two", "three" },
    onchange=function(ev)
        print("combobox change:", ev.index, " - ", ev.value)
    end
}
:newrow()
:file{ 
    id="file",
    title="File",
    placeholder="File!",
    open=true,
    entry=true,
    onchange=function(ev)
        print("file change:", ev.value)
    end
}
:newrow()
:folder{ 
    id="the_folder",
    title="Folder",
    placeholder="Folder!",
    onchange=function(ev)
        print("folder change:", ev.value)
    end,
    onselected=function(ev)
        print("folder selected:", ev.value)
    end
}
dlg:show()
print("Folder at exit:", dlg.data.the_folder)
dlg:modify{ id="the_folder", path="/another/folder" }
print("Folder after dlg.modify:", dlg.data.the_folder)
dlg.data = { the_folder = "/again/another/folder" }
dlg:show()
```