### PR TITLE
Avoid updating pref value from <check pref="..." /> if user didn't interact w/the widget (#5219)

### DIFF
--- a/data/widgets/options.xml
+++ b/data/widgets/options.xml
@@ -83,10 +83,12 @@
           <check id="show_aseprite_file_dialog"
                  text="@.show_aseprite_file_dialog" />
           <check id="show_home"
-                 text="@.show_home" />
+                 text="@.show_home"
+                 pref="general.show_home" />
           <check id="expand_menubar_on_mouseover"
                  text="@.expand_menu_bar_items_on_mouseover"
-                 tooltip="@.expand_menu_bar_items_on_mouseover_tooltip" />
+                 tooltip="@.expand_menu_bar_items_on_mouseover_tooltip"
+                 pref="general.expand_menubar_on_mouseover" />
           <check id="color_bar_entries_separator"
                  text="@.color_bar_entries_separator"
                  tooltip="@.color_bar_entries_separator"
@@ -128,7 +130,8 @@
             <boxfiller />
             <check id="show_full_path"
                    text="@.show_full_path"
-                   tooltip="@.show_full_path_tooltip" />
+                   tooltip="@.show_full_path_tooltip"
+                   pref="general.show_full_path" />
           </grid>
 
           <separator text="@.recover_files" horizontal="true" />
@@ -244,11 +247,15 @@
                  pref="editor.zoom_with_wheel" />
           <check text="@.slide_zoom" id="slide_zoom"
                  pref="editor.zoom_with_slide" />
-          <check text="@.zoom_from_center_with_wheel" id="zoom_from_center_with_wheel" />
-          <check text="@.zoom_from_center_with_keys" id="zoom_from_center_with_keys" />
-          <check text="@.show_scrollbars" id="show_scrollbars" tooltip="@.show_scrollbars_tooltip" />
+          <check text="@.zoom_from_center_with_wheel" id="zoom_from_center_with_wheel"
+                 pref="editor.zoom_from_center_with_wheel" />
+          <check text="@.zoom_from_center_with_keys" id="zoom_from_center_with_keys"
+                 pref="editor.zoom_from_center_with_keys" />
+          <check text="@.show_scrollbars" id="show_scrollbars" tooltip="@.show_scrollbars_tooltip"
+                 pref="editor.show_scrollbars" />
           <vbox>
-            <check text="@.auto_scroll" id="auto_scroll" />
+            <check text="@.auto_scroll" id="auto_scroll"
+                   pref="editor.auto_scroll" />
             <hbox id="auto_scroll_speed_placeholder" indent="check_box">
               <label text="@.auto_scroll_speed" id="auto_scroll_speed_label" />
               <slider id="auto_scroll_speed" min="10" max="500" value="100" width="128" />
@@ -256,8 +263,10 @@
           </vbox>
           <check text="@.auto_fit" id="auto_fit"
                  pref="editor.auto_fit" />
-          <check text="@.straight_line_preview" id="straight_line_preview" tooltip="@.straight_line_preview_tooltip" />
-          <check text="@.discard_brush" id="discard_brush" />
+          <check text="@.straight_line_preview" id="straight_line_preview" tooltip="@.straight_line_preview_tooltip"
+                 pref="editor.straight_line_preview" />
+          <check text="@.discard_brush" id="discard_brush"
+                 pref="eyedropper.discard_brush" />
           <hbox id="sampling_placeholder" />
           <hbox>
             <label text="@.right_click" for="right_click_behavior" />
@@ -268,12 +277,18 @@
         <!-- Selection -->
         <vbox id="section_selection">
           <separator text="@.editor_selection" horizontal="true" />
-          <check text="@.auto_opaque" id="auto_opaque" tooltip="@.auto_opaque_tooltip" />
-          <check text="@.keep_selection_after_clear" id="keep_selection_after_clear" tooltip="@.keep_selection_after_clear_tooltip" />
-          <check text="@.auto_show_selection_edges" id="auto_show_selection_edges" tooltip="@.auto_show_selection_edges_tooltip" />
-          <check text="@.move_edges" id="move_edges" tooltip="@.move_edges_tooltip" />
-          <check text="@.modifiers_disable_handles" id="modifiers_disable_handles" tooltip="@.modifiers_disable_handles_tooltip" />
-          <check text="@.move_on_add_mode" id="move_on_add_mode" tooltip="@.move_on_add_mode_tooltip" />
+          <check text="@.auto_opaque" id="auto_opaque" tooltip="@.auto_opaque_tooltip"
+                 pref="selection.auto_opaque" />
+          <check text="@.keep_selection_after_clear" id="keep_selection_after_clear" tooltip="@.keep_selection_after_clear_tooltip"
+                 pref="selection.keep_selection_after_clear" />
+          <check text="@.auto_show_selection_edges" id="auto_show_selection_edges" tooltip="@.auto_show_selection_edges_tooltip"
+                 pref="selection.auto_show_selection_edges" />
+          <check text="@.move_edges" id="move_edges" tooltip="@.move_edges_tooltip"
+                 pref="selection.move_edges" />
+          <check text="@.modifiers_disable_handles" id="modifiers_disable_handles" tooltip="@.modifiers_disable_handles_tooltip"
+                 pref="selection.modifiers_disable_handles" />
+          <check text="@.move_on_add_mode" id="move_on_add_mode" tooltip="@.move_on_add_mode_tooltip"
+                 pref="selection.move_on_add_mode" />
           <check text="@.select_tile_with_double_click" id="select_tile_with_double_click"
                  pref="selection.doubleclick_select_tile" />
           <check text="@.snap_to_grid_selection"
@@ -484,9 +499,11 @@
           <vbox>
             <check id="undo_goto_modified"
                    text="@.undo_goto_modified"
-                   tooltip="@.undo_goto_modified_tooltip" />
+                   tooltip="@.undo_goto_modified_tooltip"
+                   pref="undo.goto_modified" />
             <check id="undo_allow_nonlinear_history"
-                   text="@.undo_allow_nonlinear_history" />
+                   text="@.undo_allow_nonlinear_history"
+                   pref="undo.allow_nonlinear_history" />
             <check text="@.undo_show_tooltip" id="undo_show_tooltip"
                    pref="undo.show_tooltip" />
           </vbox>
@@ -629,8 +646,10 @@
           <check id="tint_shade_tone_hue_with_sat_value"
                  text="@.hue_with_sat_value"
                  pref="experimental.hue_with_sat_value_for_color_selector" />
-          <check id="flash_layer" text="@.flash_selected_layer" />
-          <check id="use_selection_tool_loop" text="@.use_selection_tool_loop" />
+          <check id="flash_layer" text="@.flash_selected_layer"
+                 pref="experimental.flash_layer" />
+          <check id="use_selection_tool_loop" text="@.use_selection_tool_loop"
+                 pref="experimental.use_selection_tool_loop" />
           <hbox>
             <label for="tooltip_delay" text="@.tooltip_delay" />
             <expr id="tooltip_delay" suffix="@.tooltip_delay_unit" />

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -2,26 +2,8 @@
 # Copyright (C) 2018-present  Igara Studio S.A.
 # Copyright (C) 2001-2018  David Capello
 
-# Generate a ui::Widget for each widget in a XML file
-file(GLOB widget_files ${SOURCE_DATA_DIR}/widgets/*.xml)
-foreach(widget_file ${widget_files})
-  get_filename_component(widget_name ${widget_file} NAME_WE)
-  set(output_fn ${CMAKE_CURRENT_BINARY_DIR}/${widget_name}.xml.h)
-
-  add_custom_command(
-    OUTPUT ${output_fn}
-    COMMAND ${GEN_EXE} --input ${widget_file} --widgetid ${widget_name} > ${output_fn}.tmp
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${output_fn}.tmp ${output_fn}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    MAIN_DEPENDENCY ${widget_file}
-    DEPENDS ${GEN_DEP})
-
-  list(APPEND generated_files ${output_fn})
-endforeach()
-
 # Generate preference types from data/pref.xml
 set(pref_xml ${SOURCE_DATA_DIR}/pref.xml)
-
 set(output_fn ${CMAKE_CURRENT_BINARY_DIR}/pref.xml.h)
 add_custom_command(
   OUTPUT ${output_fn}
@@ -41,6 +23,23 @@ add_custom_command(
   MAIN_DEPENDENCY ${pref_xml}
   DEPENDS ${GEN_DEP})
 list(APPEND generated_files ${output_fn})
+
+# Generate a ui::Widget for each widget in a XML file
+file(GLOB widget_files ${SOURCE_DATA_DIR}/widgets/*.xml)
+foreach(widget_file ${widget_files})
+  get_filename_component(widget_name ${widget_file} NAME_WE)
+  set(output_fn ${CMAKE_CURRENT_BINARY_DIR}/${widget_name}.xml.h)
+
+  add_custom_command(
+    OUTPUT ${output_fn}
+    COMMAND ${GEN_EXE} --input ${widget_file} --widgetid ${widget_name} --pref-file "${pref_xml}" > ${output_fn}.tmp
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${output_fn}.tmp ${output_fn}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    MAIN_DEPENDENCY ${widget_file}
+    DEPENDS ${GEN_DEP})
+
+  list(APPEND generated_files ${output_fn})
+endforeach()
 
 # Generate theme.xml.h from data/extensions/aseprite-theme/theme.xml
 set(theme_xml ${SOURCE_DATA_DIR}/extensions/aseprite-theme/theme.xml)

--- a/src/app/commands/cmd_options.cpp
+++ b/src/app/commands/cmd_options.cpp
@@ -761,8 +761,6 @@ public:
     firstFrame()->setTextf("%d", m_globPref.timeline.firstFrame());
 
     // Others
-    expandMenubarOnMouseover()->setSelected(m_pref.general.expandMenubarOnMouseover());
-
     enableDataRecovery()->setSelected(m_pref.general.dataRecovery());
 
     if (m_pref.general.dataRecovery() && m_pref.general.keepEditedSpriteData())
@@ -773,7 +771,6 @@ public:
     }
 
     keepClosedSpriteOnMemory()->setSelected(m_pref.general.keepClosedSpriteOnMemory());
-    showFullPath()->setSelected(m_pref.general.showFullPath());
 
     dataRecoveryPeriod()->setSelectedItemIndex(dataRecoveryPeriod()->findItemIndexByValue(
       base::convert_to<std::string>(m_pref.general.dataRecoveryPeriod())));
@@ -784,15 +781,6 @@ public:
     keepClosedSpriteOnMemoryFor()->setSelectedItemIndex(
       keepClosedSpriteOnMemoryFor()->findItemIndexByValue(
         base::convert_to<std::string>(m_pref.general.keepClosedSpriteOnMemoryFor())));
-
-    zoomFromCenterWithWheel()->setSelected(m_pref.editor.zoomFromCenterWithWheel());
-    zoomFromCenterWithKeys()->setSelected(m_pref.editor.zoomFromCenterWithKeys());
-    autoOpaque()->setSelected(m_pref.selection.autoOpaque());
-    keepSelectionAfterClear()->setSelected(m_pref.selection.keepSelectionAfterClear());
-    autoShowSelectionEdges()->setSelected(m_pref.selection.autoShowSelectionEdges());
-    moveEdges()->setSelected(m_pref.selection.moveEdges());
-    modifiersDisableHandles()->setSelected(m_pref.selection.modifiersDisableHandles());
-    moveOnAddMode()->setSelected(m_pref.selection.moveOnAddMode());
 
     // If the platform supports native cursors...
     if ((int(m_system->capabilities()) & int(os::Capabilities::CustomMouseCursor)) != 0) {
@@ -825,23 +813,17 @@ public:
     }
 #endif
 
-    useSelectionToolLoop()->setSelected(m_pref.experimental.useSelectionToolLoop());
-    flashLayer()->setSelected(m_pref.experimental.flashLayer());
     nonactiveLayersOpacity()->setValue(m_pref.experimental.nonactiveLayersOpacity());
 
     m_rgbmapAlgorithmSelector.algorithm(m_pref.quantization.rgbmapAlgorithm());
     m_bestFitCriteriaSelector.criteria(m_pref.quantization.fitCriteria());
 
-    showScrollbars()->setSelected(m_pref.editor.showScrollbars());
-    autoScroll()->setSelected(m_pref.editor.autoScroll());
     autoScrollSpeed()->setValue(m_pref.editor.autoScrollSpeed());
     autoScrollSpeedPlaceholder()->setVisible(autoScroll()->isSelected());
     autoScroll()->Click.connect([this] {
       autoScrollSpeedPlaceholder()->setVisible(autoScroll()->isSelected());
       layout();
     });
-    straightLinePreview()->setSelected(m_pref.editor.straightLinePreview());
-    discardBrush()->setSelected(m_pref.eyedropper.discardBrush());
 
     // Update the one/multiple window buttonset (and keep in on sync
     // with the old/experimental checkbox)
@@ -859,17 +841,12 @@ public:
     if (m_system->menus())
       showMenuBar()->setSelected(m_pref.general.showMenuBar());
 
-    showHome()->setSelected(m_pref.general.showHome());
-
     // Right-click
     rightClickBehavior()->setSelectedItemIndex((int)m_pref.editor.rightClickMode());
 
     // Undo preferences
     limitUndo()->setSelected(m_pref.undo.sizeLimit() != 0);
     onLimitUndoCheck();
-
-    undoGotoModified()->setSelected(m_pref.undo.gotoModified());
-    undoAllowNonlinearHistory()->setSelected(m_pref.undo.allowNonlinearHistory());
 
     onChangeBgScope();
     onChangeGridScope();
@@ -905,7 +882,6 @@ public:
     }
 
     m_globPref.timeline.firstFrame(firstFrame()->textInt());
-    m_pref.general.showFullPath(showFullPath()->isSelected());
     m_pref.saveFile.defaultExtension(getExtension(defaultExtension()));
     m_pref.exportFile.imageDefaultExtension(getExtension(exportImageDefaultExtension()));
     m_pref.exportFile.animationDefaultExtension(getExtension(exportAnimationDefaultExtension()));
@@ -916,8 +892,7 @@ public:
       App::instance()->recentFiles()->setLimit(limit);
     }
 
-    bool expandOnMouseover = expandMenubarOnMouseover()->isSelected();
-    m_pref.general.expandMenubarOnMouseover(expandOnMouseover);
+    const bool expandOnMouseover = expandMenubarOnMouseover()->isSelected();
     ui::MenuBar::setExpandOnMouseover(expandOnMouseover);
 
     std::string warnings;
@@ -951,13 +926,7 @@ public:
                   Strings::alerts_restart_by_preferences_keep_closed_sprite_on_memory_for();
     }
 
-    m_pref.editor.zoomFromCenterWithWheel(zoomFromCenterWithWheel()->isSelected());
-    m_pref.editor.zoomFromCenterWithKeys(zoomFromCenterWithKeys()->isSelected());
-    m_pref.editor.showScrollbars(showScrollbars()->isSelected());
-    m_pref.editor.autoScroll(autoScroll()->isSelected());
     m_pref.editor.autoScrollSpeed(autoScrollSpeed()->getValue());
-    m_pref.editor.straightLinePreview(straightLinePreview()->isSelected());
-    m_pref.eyedropper.discardBrush(discardBrush()->isSelected());
     m_pref.editor.rightClickMode(
       static_cast<app::gen::RightClickMode>(rightClickBehavior()->getSelectedItemIndex()));
     if (m_samplingSelector)
@@ -969,12 +938,6 @@ public:
       static_cast<app::gen::BrushPreview>(brushPreview()->getSelectedItemIndex()));
     m_pref.cursor.useNativeCursor(nativeCursor()->isSelected());
     m_pref.cursor.cursorScale(base::convert_to<int>(cursorScale()->getValue()));
-    m_pref.selection.autoOpaque(autoOpaque()->isSelected());
-    m_pref.selection.keepSelectionAfterClear(keepSelectionAfterClear()->isSelected());
-    m_pref.selection.autoShowSelectionEdges(autoShowSelectionEdges()->isSelected());
-    m_pref.selection.moveEdges(moveEdges()->isSelected());
-    m_pref.selection.modifiersDisableHandles(modifiersDisableHandles()->isSelected());
-    m_pref.selection.moveOnAddMode(moveOnAddMode()->isSelected());
     m_pref.guides.layerEdgesColor(layerEdgesColor()->getColor());
     m_pref.guides.autoGuidesColor(autoGuidesColor()->getColor());
     m_pref.slices.defaultColor(defaultSliceColor()->getColor());
@@ -1057,15 +1020,11 @@ public:
     undo_size_limit_value = std::clamp(undo_size_limit_value, 0, 999999);
 
     m_pref.undo.sizeLimit(undo_size_limit_value);
-    m_pref.undo.gotoModified(undoGotoModified()->isSelected());
-    m_pref.undo.allowNonlinearHistory(undoAllowNonlinearHistory()->isSelected());
 
     // Aseprite format preferences
     m_pref.asepriteFormat.celFormat(gen::CelContentFormat(celFormat()->getSelectedItemIndex()));
 
     // Experimental features
-    m_pref.experimental.useSelectionToolLoop(useSelectionToolLoop()->isSelected());
-    m_pref.experimental.flashLayer(flashLayer()->isSelected());
     m_pref.experimental.nonactiveLayersOpacity(nonactiveLayersOpacity()->getValue());
     m_pref.quantization.rgbmapAlgorithm(m_rgbmapAlgorithmSelector.algorithm());
     m_pref.quantization.fitCriteria(m_bestFitCriteriaSelector.criteria());
@@ -1161,8 +1120,6 @@ public:
     if (m_system->menus() && m_pref.general.showMenuBar() != showMenuBar()->isSelected()) {
       m_pref.general.showMenuBar(showMenuBar()->isSelected());
     }
-
-    m_pref.general.showHome(showHome()->isSelected());
 
     m_pref.save();
 

--- a/src/app/ui/pref_widget.h
+++ b/src/app/ui/pref_widget.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2018  David Capello
 //
 // This program is distributed under the terms of
@@ -62,14 +63,22 @@ protected:
     if (msg->type() == kSavePreferencesMessage) {
       ASSERT(m_option);
 
-      // Update Option value.
-      (*m_option)(this->isSelected());
+      // Update the Option value only if the user touched the widget.
+      if (m_modifiedByUser)
+        (*m_option)(this->isSelected());
     }
     return Base::onProcessMessage(msg);
   }
 
+  void onClick() override
+  {
+    Base::onClick();
+    m_modifiedByUser = true;
+  }
+
 private:
   Option<bool>* m_option;
+  bool m_modifiedByUser = false;
 };
 
 } // namespace app

--- a/src/gen/CMakeLists.txt
+++ b/src/gen/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Aseprite Code Generator
+# Copyright (C) 2026-present  Igara Studio S.A.
 # Copyright (C) 2014-2017  David Capello
 
 add_executable(gen
@@ -18,4 +19,5 @@ endif()
 target_link_libraries(gen
   laf-base
   cfg-lib
-  ${TINYXML_LIBRARY})
+  ${TINYXML_LIBRARY}
+  fmt)

--- a/src/gen/LICENSE.txt
+++ b/src/gen/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (C) 2019-2021  Igara Studio S.A.
+Copyright (C) 2019-present  Igara Studio S.A.
 Copyright (C) 2014-2018  David Capello
 
 Permission is hereby granted, free of charge, to any person obtaining

--- a/src/gen/gen.cpp
+++ b/src/gen/gen.cpp
@@ -1,10 +1,11 @@
 // Aseprite Code Generator
-// Copyright (c) 2021-2024 Igara Studio S.A.
+// Copyright (c) 2021-present Igara Studio S.A.
 // Copyright (c) 2014-2017 David Capello
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
 
+#include "base/exception.h"
 #include "base/file_handle.h"
 #include "base/fs.h"
 #include "base/program_options.h"
@@ -22,6 +23,21 @@
 using PO = base::ProgramOptions;
 using namespace tinyxml2;
 
+static std::unique_ptr<XMLDocument> load_xml_doc(const std::string& filename)
+{
+  base::FileHandle inputFile(base::open_file(filename, "rb"));
+  if (!inputFile)
+    throw base::Exception(filename + " not found");
+
+  auto doc = std::make_unique<XMLDocument>();
+  if (doc->LoadFile(inputFile.get()) != XML_SUCCESS) {
+    std::cerr << filename << ":" << doc->ErrorLineNum() << ": "
+              << "error " << int(doc->ErrorID()) << ": " << doc->ErrorStr() << "\n";
+    throw std::runtime_error("invalid xml file");
+  }
+  return doc;
+}
+
 static void run(int argc, const char* argv[])
 {
   PO po;
@@ -35,26 +51,26 @@ static void run(int argc, const char* argv[])
   PO::Option& widgetsDir = po.add("widgets-dir").requiresValue("<dir>");
   PO::Option& stringsDir = po.add("strings-dir").requiresValue("<dir>");
   PO::Option& guiFile = po.add("gui-file").requiresValue("<filename>");
+  PO::Option& prefFile = po.add("pref-file").requiresValue("<filename>");
   po.parse(argc, argv);
 
-  // Try to load the XML file
+  // Try to load the input XML file (pref.xml, theme.xml, widget.xml, etc.)
   std::unique_ptr<XMLDocument> doc;
-
   std::string inputFilename = po.value_of(inputOpt);
-  if (!inputFilename.empty() && base::get_file_extension(inputFilename) == "xml") {
-    base::FileHandle inputFile(base::open_file(inputFilename, "rb"));
-    doc = std::make_unique<XMLDocument>();
-    if (doc->LoadFile(inputFile.get()) != XML_SUCCESS) {
-      std::cerr << inputFilename << ":" << doc->ErrorLineNum() << ": "
-                << "error " << int(doc->ErrorID()) << ": " << doc->ErrorStr() << "\n";
-      throw std::runtime_error("invalid input file");
-    }
-  }
+  if (!inputFilename.empty() && base::get_file_extension(inputFilename) == "xml")
+    doc = load_xml_doc(inputFilename);
 
   if (doc) {
     // Generate widget class
-    if (po.enabled(widgetId))
-      gen_ui_class(doc.get(), inputFilename, po.value_of(widgetId));
+    if (po.enabled(widgetId)) {
+      std::unique_ptr<XMLDocument> prefDoc;
+      if (const auto prefFn = po.value_of(prefFile); !prefFn.empty())
+        prefDoc = load_xml_doc(prefFn);
+      else
+        throw base::Exception("please specify --pref-file option when using --widgetid");
+
+      gen_ui_class(doc.get(), prefDoc.get(), inputFilename, po.value_of(widgetId));
+    }
     // Generate preference header file
     else if (po.enabled(prefH))
       gen_pref_header(doc.get(), inputFilename);

--- a/src/gen/ui_class.cpp
+++ b/src/gen/ui_class.cpp
@@ -1,5 +1,5 @@
 // Aseprite Code Generator
-// Copyright (c) 2021-2024 Igara Studio S.A.
+// Copyright (c) 2021-present Igara Studio S.A.
 // Copyright (c) 2014-2018 David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -10,7 +10,9 @@
 #include "base/exception.h"
 #include "base/file_handle.h"
 #include "base/fs.h"
+#include "base/split_string.h"
 #include "base/string.h"
+#include "fmt/format.h"
 #include "gen/common.h"
 
 #include <iostream>
@@ -27,10 +29,16 @@ struct Item {
   std::string cppid;
   std::string type;
   std::string incl;
-  const Item& typeIncl(const char* type, const char* incl)
+  std::string pref;
+  Item& typeIncl(const char* type, const char* incl)
   {
     this->type = type;
     this->incl = incl;
+    return *this;
+  }
+  Item& prefCheck(const char* pref)
+  {
+    this->pref = pref;
     return *this;
   }
 };
@@ -89,8 +97,8 @@ static Item convert_to_item(XMLElement* elem)
   if (name == "buttonset")
     return item.typeIncl("app::ButtonSet", "app/ui/button_set.h");
   if (name == "check") {
-    if (elem->Attribute("pref") != nullptr)
-      return item.typeIncl("BoolPrefWidget<ui::CheckBox>", "app/ui/pref_widget.h");
+    if (const char* pref = elem->Attribute("pref"))
+      return item.typeIncl("BoolPrefWidget<ui::CheckBox>", "app/ui/pref_widget.h").prefCheck(pref);
     else
       return item.typeIncl("ui::CheckBox", "ui/button.h");
   }
@@ -156,7 +164,41 @@ static Item convert_to_item(XMLElement* elem)
   throw base::Exception("Unknown widget name: " + name);
 }
 
-void gen_ui_class(XMLDocument* doc, const std::string& inputFn, const std::string& widgetId)
+static bool check_pref(XMLDocument* prefDoc, const std::string& sectionOption)
+{
+  std::vector<std::string> parts;
+  base::split_string(sectionOption, parts, ".");
+
+  if (parts.size() != 2)
+    throw base::Exception(
+      fmt::format("Invalid pref=\"{}\", format \"section.option\" expected ", sectionOption));
+
+  XMLHandle handle(prefDoc);
+  XMLElement* child = handle.FirstChildElement("preferences")
+                        .FirstChildElement("global")
+                        .FirstChildElement("section")
+                        .ToElement();
+
+  while (child) {
+    if (child->Attribute("id") == parts[0]) {
+      child = child->FirstChildElement("option");
+      while (child) {
+        if (child->Attribute("id") == parts[1])
+          return true; // Option found
+        child = child->NextSiblingElement();
+      }
+      break;
+    }
+    child = child->NextSiblingElement();
+  }
+
+  return false;
+}
+
+void gen_ui_class(XMLDocument* doc,
+                  XMLDocument* prefDoc,
+                  const std::string& inputFn,
+                  const std::string& widgetId)
 {
   std::cout << "// Don't modify, generated file from " << inputFn << "\n"
             << "\n";
@@ -178,7 +220,14 @@ void gen_ui_class(XMLDocument* doc, const std::string& inputFn, const std::strin
       const char* id = elem->Attribute("id");
       if (!id)
         continue;
-      items.push_back(convert_to_item(elem));
+
+      Item item = convert_to_item(elem);
+      if (prefDoc && !item.pref.empty()) {
+        if (!check_pref(prefDoc, item.pref))
+          throw base::Exception(fmt::format("Invalid pref=\"{}\" not found", item.pref));
+      }
+
+      items.push_back(item);
 
       if (!hasTooltips && elem->Attribute("tooltip"))
         hasTooltips = true;

--- a/src/gen/ui_class.h
+++ b/src/gen/ui_class.h
@@ -1,5 +1,5 @@
 // Aseprite Code Generator
-// Copyright (c) 2024 Igara Studio S.A.
+// Copyright (c) 2024-present Igara Studio S.A.
 // Copyright (c) 2014-2016 David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -13,6 +13,7 @@
 #include <string>
 
 void gen_ui_class(tinyxml2::XMLDocument* doc,
+                  tinyxml2::XMLDocument* prefDoc,
                   const std::string& inputFn,
                   const std::string& widgetId);
 


### PR DESCRIPTION
We should try to avoid saving modified values of preferences when the user didn't change those parameters.

This doesn't fully fix #5219 in the sense that we're not offering a way to export the Aseprite.ini file, but probably something to add in the Preferences dialog in a near future.