### PR TITLE
Fix Entry not initializing correctly after parameter changes

### DIFF
--- a/src/ui/entry.cpp
+++ b/src/ui/entry.cpp
@@ -47,6 +47,7 @@ static inline bool is_word_char(int ch)
 
 Entry::Entry(const int maxsize)
   : Widget(kEntryWidget)
+  , m_boxes({ CharBox() })
   , m_maxsize(maxsize)
   , m_caret(0)
   , m_scroll(0)


### PR DESCRIPTION
Fixes a regression caused by #5835, Entry needs to have at least _something_ on m_boxes and setText("") was doing that by recalculating. I don't think we need the entirety of the work of resetting it to "", just initializing an empty charbox will do.