### PR TITLE
Fix JSON for tileset exporting (fix #4474)

### DIFF
--- a/src/app/commands/cmd_export_sprite_sheet.cpp
+++ b/src/app/commands/cmd_export_sprite_sheet.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2025  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -464,7 +464,10 @@ public:
     trimSpriteEnabled()->Click.connect([this] { onTrimEnabledChange(); });
     trimEnabled()->Click.connect([this] { onTrimEnabledChange(); });
     gridTrimEnabled()->Click.connect([this] { generatePreview(); });
-    source()->Change.connect([this] { generatePreview(); });
+    source()->Change.connect([this] {
+      updateDefaultDataFilenameFormat();
+      generatePreview();
+    });
     layers()->Change.connect([this] { generatePreview(); });
     splitLayers()->Click.connect([this] { onSplitLayersOrFrames(); });
     splitTags()->Click.connect([this] { onSplitLayersOrFrames(); });
@@ -925,11 +928,14 @@ private:
 
   void updateDefaultDataFilenameFormat()
   {
-    m_filenameFormatDefault = get_default_filename_format_for_sheet(
-      m_site.document()->filename(),
-      m_site.document()->sprite()->totalFrames() > 0,
-      splitLayersValue(),
-      splitTagsValue());
+    if (source()->getSelectedItemIndex() == int(kSource_Tilesets))
+      m_filenameFormatDefault = get_default_filename_format_for_tilesets();
+    else
+      m_filenameFormatDefault = get_default_filename_format_for_sheet(
+        m_site.document()->filename(),
+        m_site.document()->sprite()->totalFrames() > 0,
+        splitLayersValue(),
+        splitTagsValue());
 
     if (m_filenameFormat.empty()) {
       dataFilenameFormat()->setText(m_filenameFormatDefault);

--- a/src/app/doc_exporter.cpp
+++ b/src/app/doc_exporter.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2026  Igara Studio S.A.
+// Copyright (C) 2018-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -744,6 +744,7 @@ void DocExporter::reset()
   m_listLayers = false;
   m_listLayerHierarchy = false;
   m_listSlices = false;
+  m_isSourceTilesets = false;
   m_documents.clear();
 }
 
@@ -966,6 +967,8 @@ int DocExporter::addDocumentSamples(Doc* doc,
 
 int DocExporter::addTilesetsSamples(Doc* doc, const doc::SelectedLayers* selLayers)
 {
+  m_isSourceTilesets = true;
+
   LayerList layers;
   if (selLayers)
     layers = selLayers->toAllLayersList();
@@ -979,8 +982,13 @@ int DocExporter::addTilesetsSamples(Doc* doc, const doc::SelectedLayers* selLaye
       Tileset* ts = dynamic_cast<LayerTilemap*>(layer)->tileset();
 
       if (alreadyExported.find(ts->id()) == alreadyExported.end()) {
+        int tileIdx = 0;
         for (const auto& tile : *ts) {
           addImage(doc, tile.image);
+          m_documents.back().layerName = layer->name();
+          m_documents.back().tilesetName = ts->name();
+          m_documents.back().tileIndex = tileIdx;
+          ++tileIdx;
           ++items;
         }
         alreadyExported.insert(ts->id());
@@ -1018,10 +1026,13 @@ void DocExporter::captureSamples(Samples& samples, base::task_token& token)
 
     std::string format = m_filenameFormat;
     if (format.empty()) {
-      format = get_default_filename_format_for_sheet(doc->filename(),
-                                                     (frames > 1),       // Has frames
-                                                     (layer != nullptr), // Has layer
-                                                     (tag != nullptr));  // Has tag
+      if (m_isSourceTilesets)
+        format = get_default_filename_format_for_tilesets();
+      else
+        format = get_default_filename_format_for_sheet(doc->filename(),
+                                                       (frames > 1),       // Has frames
+                                                       (layer != nullptr), // Has layer
+                                                       (tag != nullptr));  // Has tag
     }
 
     gfx::Rect spriteBounds;
@@ -1063,12 +1074,14 @@ void DocExporter::captureSamples(Samples& samples, base::task_token& token)
       const Tag* outerTag = sprite->tags().outerTag(frame);
       FilenameInfo fnInfo;
       fnInfo.filename(doc->filename())
-        .layerName(layer ? layer->name() : "")
+        .layerName(m_isSourceTilesets ? item.layerName : (layer ? layer->name() : ""))
         .groupName(layer && layer->parent() != sprite->root() ? layer->parent()->name() : "")
         .innerTagName(innerTag ? innerTag->name() : "")
         .outerTagName(outerTag ? outerTag->name() : "")
         .frame(outputFrame)
         .tagFrame(innerTag ? frame - innerTag->fromFrame() : outputFrame)
+        .tilesetName(item.tilesetName)
+        .tile(item.tileIndex)
         .duration(sprite->frameDuration(frame));
       ++outputFrame;
 
@@ -1472,12 +1485,26 @@ void DocExporter::createDataFile(const Samples& samples, std::ostream& os, doc::
       break;
   }
 
-  os << "{ \"frames\": " << frames_begin << "\n";
+  os << "{ \"" << (m_isSourceTilesets ? "tiles" : "frames") << "\": " << frames_begin << "\n";
   for (Samples::const_iterator it = samples.begin(), end = samples.end(); it != end;) {
     const Sample& sample = *it;
-    gfx::Size srcSize = sample.originalSize();
-    gfx::Rect spriteSourceBounds = sample.trimmedBounds();
     gfx::Rect frameBounds = sample.inTextureBounds();
+    const char* sourceSizeLabel;
+    const char* sizeLabel;
+    gfx::Rect sourceBounds;
+    gfx::Size sourceSize;
+    if (m_isSourceTilesets) {
+      sourceSizeLabel = "tilesetSourceSize";
+      sizeLabel = "tileSize";
+      sourceBounds = gfx::Rect(0, 0, texture->width(), texture->height());
+      sourceSize = sample.originalSize();
+    }
+    else {
+      sourceSizeLabel = "spriteSourceSize";
+      sizeLabel = "sourceSize";
+      sourceBounds = sample.trimmedBounds();
+      sourceSize = sample.originalSize();
+    }
 
     if (filename_as_key)
       os << "   \"" << escape_for_json(sample.filename()) << "\": {\n";
@@ -1492,15 +1519,20 @@ void DocExporter::createDataFile(const Samples& samples, std::ostream& os, doc::
        << "\"h\": " << frameBounds.h + nonExtrudedSize << " },\n"
        << "    \"rotated\": false,\n"
        << "    \"trimmed\": " << (sample.trimmed() ? "true" : "false") << ",\n"
-       << "    \"spriteSourceSize\": { "
-       << "\"x\": " << spriteSourceBounds.x << ", "
-       << "\"y\": " << spriteSourceBounds.y << ", "
-       << "\"w\": " << spriteSourceBounds.w << ", "
-       << "\"h\": " << spriteSourceBounds.h << " },\n"
-       << "    \"sourceSize\": { "
-       << "\"w\": " << srcSize.w << ", "
-       << "\"h\": " << srcSize.h << " },\n"
-       << "    \"duration\": " << sample.sprite()->frameDuration(sample.frame()) << "\n"
+       << "    \"" << sourceSizeLabel << "\": { "
+       << "\"x\": " << sourceBounds.x << ", "
+       << "\"y\": " << sourceBounds.y << ", "
+       << "\"w\": " << sourceBounds.w << ", "
+       << "\"h\": " << sourceBounds.h << " },\n"
+       << "    \"" << sizeLabel << "\": { "
+       << "\"w\": " << sourceSize.w << ", "
+       << "\"h\": " << sourceSize.h << " }";
+
+    if (!m_isSourceTilesets)
+      os << ",\n"
+         << "    \"duration\": " << sample.sprite()->frameDuration(sample.frame());
+
+    os << "\n"
        << "   }";
 
     if (++it != samples.end())

--- a/src/app/doc_exporter.h
+++ b/src/app/doc_exporter.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2026  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -127,6 +127,9 @@ private:
     std::unique_ptr<doc::SelectedFrames> selFrames;
     bool splitGrid = false;
     doc::ImageRef image;
+    std::string layerName;
+    std::string tilesetName;
+    int tileIndex = -1;
 
     Item(Doc* doc,
          const doc::Tag* tag,
@@ -174,6 +177,7 @@ private:
   bool m_listLayerHierarchy;
   bool m_listSlices;
   bool m_powerOfTwoSize;
+  bool m_isSourceTilesets;
   Items m_documents;
 
   // Buffers used

--- a/src/app/filename_formatter.cpp
+++ b/src/app/filename_formatter.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2022-2023  Igara Studio S.A.
+// Copyright (C) 2022-present  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This program is distributed under the terms of
@@ -142,6 +142,7 @@ std::string filename_formatter(const std::string& format,
   base::replace_string(output, "{layer}", info.layerName());
   base::replace_string(output, "{group}", info.groupName());
   base::replace_string(output, "{slice}", info.sliceName());
+  base::replace_string(output, "{tileset}", info.tilesetName());
 
   if (replaceFrame) {
     base::replace_string(output, "{tag}", info.innerTagName());
@@ -150,6 +151,7 @@ std::string filename_formatter(const std::string& format,
     base::replace_string(output, "{duration}", std::to_string(info.duration()));
     replace_frame("{frame", info.frame(), output);
     replace_frame("{tagframe", info.tagFrame(), output);
+    replace_frame("{tile", info.tile(), output);
   }
 
   return output;
@@ -237,6 +239,11 @@ std::string get_default_filename_format_for_sheet(const std::string& filename,
 
   format += ".{extension}";
   return format;
+}
+
+std::string get_default_filename_format_for_tilesets()
+{
+  return "{title} {layer} {tileset} {tile}";
 }
 
 std::string get_default_tagname_format_for_sheet()

--- a/src/app/filename_formatter.h
+++ b/src/app/filename_formatter.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2022-2023  Igara Studio S.A.
+// Copyright (C) 2022-present  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This program is distributed under the terms of
@@ -21,8 +21,10 @@ public:
   const std::string& innerTagName() const { return m_innerTagName; }
   const std::string& outerTagName() const { return m_outerTagName; }
   const std::string& sliceName() const { return m_sliceName; }
+  const std::string& tilesetName() const { return m_tilesetName; }
   int frame() const { return m_frame; }
   int tagFrame() const { return m_tagFrame; }
+  int tile() const { return m_tile; }
   int duration() const { return m_duration; }
 
   FilenameInfo& filename(const std::string& value)
@@ -73,6 +75,18 @@ public:
     return *this;
   }
 
+  FilenameInfo& tilesetName(const std::string& value)
+  {
+    m_tilesetName = value;
+    return *this;
+  }
+
+  FilenameInfo& tile(int value)
+  {
+    m_tile = value;
+    return *this;
+  }
+
   FilenameInfo& duration(int value)
   {
     m_duration = value;
@@ -86,8 +100,10 @@ private:
   std::string m_innerTagName;
   std::string m_outerTagName;
   std::string m_sliceName;
+  std::string m_tilesetName;
   int m_frame = -1;
   int m_tagFrame = -1;
+  int m_tile = -1;
   int m_duration = 0;
 };
 
@@ -121,6 +137,8 @@ std::string get_default_filename_format_for_sheet(const std::string& filename,
                                                   const bool hasFrames,
                                                   const bool hasLayer,
                                                   const bool hasTag);
+
+std::string get_default_filename_format_for_tilesets();
 
 std::string get_default_tagname_format_for_sheet();
 


### PR DESCRIPTION
This fixes the part of "The biggest problem is that the exported JSON is useless, because the tileset sequence doesn't match with the tile index in the tilemap." in aseprite/aseprite#4474

This PR is a continuation of https://github.com/aseprite/aseprite/pull/5829#issuecomment-4612940037

Perhaps the 'filename' field, when Tilesets is the export source, could be called 'tileName'.