### PR TITLE
Fix potential crash when searching in Preferences dialog

### DIFF
--- a/src/app/commands/cmd_options.cpp
+++ b/src/app/commands/cmd_options.cpp
@@ -2291,8 +2291,10 @@ private:
 
         const auto& property = std::static_pointer_cast<SearchTextProperty>(
           widget->getProperty(SearchTextProperty::Name));
-        const auto& text = property->text();
+        if (!property)
+          continue;
 
+        const auto& text = property->text();
         if (text.empty())
           continue;
 


### PR DESCRIPTION
Fixes [ASEPRITE-4D5](https://igara-studio.sentry.io/issues/7446903411/events/69c0a224d59c4bcd21d9edff966ef9ac/), I'm not entirely sure when this could happen since we set this property at the start of the search, but it's possible there's an edge case where a widget is added dynamically while the search is going, so this should mitigate any crashes and it should've been done in this way in the first place.
