### PR TITLE
[lua] Fix Tile_get_color() returning wrong tile indexes (fix #5838)

### DIFF
--- a/src/app/script/tile_class.cpp
+++ b/src/app/script/tile_class.cpp
@@ -83,10 +83,7 @@ int Tile_get_color(lua_State* L)
 
   auto& ud = ts->getTileData(tile->ti);
   doc::color_t docColor = ud.color();
-  app::Color appColor = app::Color::fromRgb(doc::rgba_getr(docColor),
-                                            doc::rgba_getg(docColor),
-                                            doc::rgba_getb(docColor),
-                                            doc::rgba_geta(docColor));
+  app::Color appColor = app::Color::fromTile(doc::tile(tile->ti, 0));
   if (appColor.getAlpha() == 0)
     appColor = app::Color::fromMask();
   push_obj<app::Color>(L, appColor);


### PR DESCRIPTION
Fix #5838

The `Tile_get_color()` function was converting tile data to RGB color using `fromRgb()`, which lost the tile index information. This caused `tilemapLayer.tileset:tile(N).color.index` to return 0 or incorrect values instead of the actual tile index N.

Changed the implementation to use `fromTile()` to preserve the tile index, matching the behavior of `Color{ tile = N }.index`.