### PR TITLE
Refactor MiniEditor enabled state to use Preferences API

### DIFF
--- a/data/pref.xml
+++ b/data/pref.xml
@@ -181,6 +181,9 @@
       <option id="allow_nonlinear_history" type="bool" default="false" />
       <option id="show_tooltip" type="bool" default="true" />
     </section>
+    <section id="miniEditor" text="Mini Editor">
+      <option id="enabled" type="bool" default="true" />
+    </section>
     <section id="editor" text="Editor">
       <option id="zoom_with_wheel" type="bool" default="true" />
       <option id="zoom_with_slide" type="bool" default="false" />

--- a/src/app/ui/preview_editor.cpp
+++ b/src/app/ui/preview_editor.cpp
@@ -188,7 +188,7 @@ PreviewEditorWindow::PreviewEditorWindow()
   setAutoRemap(false);
   setWantFocus(false);
 
-  m_isEnabled = get_config_bool("MiniEditor", "Enabled", true);
+  m_isEnabled = app::Preferences::instance().miniEditor.enabled();
 
   m_centerButton->Click.connect([this] { onCenterClicked(); });
   m_playButton->Click.connect([this] { onPlayClicked(); });
@@ -202,12 +202,15 @@ PreviewEditorWindow::PreviewEditorWindow()
 
 PreviewEditorWindow::~PreviewEditorWindow()
 {
-  set_config_bool("MiniEditor", "Enabled", m_isEnabled);
+  app::Preferences::instance().miniEditor.enabled(m_isEnabled);
+  save_window_pos(this, "MiniEditor");
 }
 
 void PreviewEditorWindow::setPreviewEnabled(bool state)
 {
   m_isEnabled = state;
+
+  app::Preferences::instance().miniEditor.enabled(state);
 
   updateUsingEditor(Editor::activeEditor());
 }
@@ -268,6 +271,9 @@ void PreviewEditorWindow::onClose(ui::CloseEvent& ev)
 
     // Redraw the tool bar because it shows the mini editor enabled
     // state. TODO abstract this event
+
+    app::Preferences::instance().miniEditor.enabled(false);
+
     ToolBar::instance()->invalidate();
 
     destroyDocView();


### PR DESCRIPTION
=### Description
This pull request migrates the "MiniEditor" configuration from the legacy ini_file system to the modern app::Preferences API. 

- Updated pref.xml to include the miniEditor section.
- Refactored src/app/ui/preview_editor.cpp to use the Preferences API for the enabled state.
- Cleaned up redundant legacy config calls, improving configuration consistency and aligning the feature with current codebase standards.

---

### Contribution Agreement
I declare that my contributions are not co-authored using a generative AI technology.

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing