### PR TITLE
Implement "power of two sheet size" UI (#2289, #5529)

### DIFF
--- a/data/pref.xml
+++ b/data/pref.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Aseprite -->
-<!-- Copyright (C) 2018-2025  Igara Studio S.A. -->
+<!-- Copyright (C) 2018-present  Igara Studio S.A. -->
 <!-- Copyright (C) 2014-2018  David Capello -->
 <preferences>
 
@@ -606,6 +606,7 @@
       <option id="extrude" type="bool" default="false" />
       <option id="merge_duplicates" type="bool" default="false" />
       <option id="ignore_empty" type="bool" default="false" />
+      <option id="power_of_two_size" type="bool" default="false" />
       <option id="open_generated" type="bool" default="false" />
       <option id="layer" type="std::string" />
       <option id="layer_index" type="int" default ="-1" />

--- a/data/strings/en.ini
+++ b/data/strings/en.ini
@@ -742,6 +742,8 @@ merge_dups = Merge Duplicates
 merge_dups_tooltip = Similar frames can use the same sprite sheet rectangular area
 ignore_empty = Ignore Empty
 ignore_empty_tooltip = Do not include empty/transparent frames in the sprite sheet
+power_of_two_size = Size=x²
+power_of_two_size_tooltip = Round up the width and height of the sprite sheet to the nearest power of 2
 source = Source:
 layers = Layers:
 split_layers = Split Layers

--- a/data/widgets/export_sprite_sheet.xml
+++ b/data/widgets/export_sprite_sheet.xml
@@ -1,5 +1,5 @@
 <!-- Aseprite -->
-<!-- Copyright (C) 2019-2024  Igara Studio S.A. -->
+<!-- Copyright (C) 2019-present  Igara Studio S.A. -->
 <!-- Copyright (C) 2001-2018  David Capello -->
 <gui>
   <window id="export_sprite_sheet" text="@.title" help="sprite-sheet#export">
@@ -40,6 +40,7 @@
       <hbox cell_hspan="3">
         <check id="merge_dups" text="@.merge_dups" tooltip="@.merge_dups_tooltip" />
         <check id="ignore_empty" text="@.ignore_empty" tooltip="@.ignore_empty_tooltip" />
+        <check id="power_of_two_size" text="@.power_of_two_size" tooltip="@.power_of_two_size_tooltip" />
       </hbox>
     </grid>
 

--- a/src/app/commands/cmd_export_sprite_sheet.cpp
+++ b/src/app/commands/cmd_export_sprite_sheet.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2025  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -183,6 +183,7 @@ Doc* generate_sprite_sheet_from_params(DocExporter& exporter,
   const bool extrude = params.extrude();
   const bool ignoreEmpty = params.ignoreEmpty();
   const bool mergeDuplicates = params.mergeDuplicates();
+  const bool powerOfTwoSize = params.powerOfTwoSize();
   const bool splitLayers = params.splitLayers();
   const bool splitTags = params.splitTags();
   const bool splitGrid = params.splitGrid();
@@ -270,6 +271,7 @@ Doc* generate_sprite_sheet_from_params(DocExporter& exporter,
   exporter.setSplitTags(splitTags);
   exporter.setIgnoreEmptyCels(ignoreEmpty);
   exporter.setMergeDuplicates(mergeDuplicates);
+  exporter.setPowerOfTwoSize(powerOfTwoSize);
   if (listLayers)
     exporter.setListLayers(true);
   if (listTags)
@@ -395,6 +397,7 @@ public:
     extrudeEnabled()->setSelected(params.extrude());
     mergeDups()->setSelected(params.mergeDuplicates());
     ignoreEmpty()->setSelected(params.ignoreEmpty());
+    powerOfTwoSize()->setSelected(params.powerOfTwoSize());
 
     borderPadding()->setTextf("%d", params.borderPadding());
     shapePadding()->setTextf("%d", params.shapePadding());
@@ -449,6 +452,7 @@ public:
     extrudeEnabled()->Click.connect([this] { generatePreview(); });
     mergeDups()->Click.connect([this] { generatePreview(); });
     ignoreEmpty()->Click.connect([this] { generatePreview(); });
+    powerOfTwoSize()->Click.connect([this] { generatePreview(); });
 
     imageEnabled()->Click.connect(
       [this] { onOutputFieldEnabledChange(imageFilename(), imageEnabled()->isSelected()); });
@@ -549,6 +553,7 @@ public:
     params.extrude(extrudeValue());
     params.mergeDuplicates(mergeDupsValue());
     params.ignoreEmpty(ignoreEmptyValue());
+    params.powerOfTwoSize(powerOfTwoSizeValue());
     params.openGenerated(openGeneratedValue());
     params.layer(layerValue());
     params.layerIndex(layerIndex());
@@ -763,6 +768,8 @@ private:
   bool listTagsValue() const { return listTags()->isSelected(); }
 
   bool listSlicesValue() const { return listSlices()->isSelected(); }
+
+  bool powerOfTwoSizeValue() const { return powerOfTwoSize()->isSelected(); }
 
   void onExport()
   {
@@ -1249,6 +1256,8 @@ void ExportSpriteSheetCommand::onExecute(Context* context)
         params.mergeDuplicates(defPref.spriteSheet.mergeDuplicates());
       if (!params.ignoreEmpty.isSet())
         params.ignoreEmpty(defPref.spriteSheet.ignoreEmpty());
+      if (!params.powerOfTwoSize.isSet())
+        params.powerOfTwoSize(defPref.spriteSheet.powerOfTwoSize());
       if (!params.openGenerated.isSet())
         params.openGenerated(defPref.spriteSheet.openGenerated());
       if (!params.layer.isSet())
@@ -1308,6 +1317,7 @@ void ExportSpriteSheetCommand::onExecute(Context* context)
     docPref.spriteSheet.extrude(params.extrude());
     docPref.spriteSheet.mergeDuplicates(params.mergeDuplicates());
     docPref.spriteSheet.ignoreEmpty(params.ignoreEmpty());
+    docPref.spriteSheet.powerOfTwoSize(params.powerOfTwoSize());
     docPref.spriteSheet.openGenerated(params.openGenerated());
     docPref.spriteSheet.layer(params.layer());
     docPref.spriteSheet.layerIndex(params.layerIndex());

--- a/src/app/commands/cmd_export_sprite_sheet.h
+++ b/src/app/commands/cmd_export_sprite_sheet.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2022-2024  Igara Studio S.A.
+// Copyright (C) 2022-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -44,6 +44,7 @@ struct ExportSpriteSheetParams : public NewParams {
   Param<bool> extrude{ this, false, "extrude" };
   Param<bool> ignoreEmpty{ this, false, "ignoreEmpty" };
   Param<bool> mergeDuplicates{ this, false, "mergeDuplicates" };
+  Param<bool> powerOfTwoSize{ this, false, "powerOfTwoSize" };
   Param<bool> openGenerated{ this, false, "openGenerated" };
   Param<std::string> layer{ this, std::string(), "layer" };
   // TODO The layerIndex parameter is for internal use only, layers

--- a/src/app/doc_exporter.cpp
+++ b/src/app/doc_exporter.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2026  Igara Studio S.A.
+// Copyright (C) 2018-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -711,7 +711,6 @@ public:
 DocExporter::DocExporter()
   : m_docBuf(std::make_shared<doc::ImageBuffer>())
   , m_sampleBuf(std::make_shared<doc::ImageBuffer>())
-  , m_powerOfTwoSize(false)
 {
   m_cache.spriteId = doc::NullId;
   reset();
@@ -734,6 +733,7 @@ void DocExporter::reset()
   m_innerPadding = 0;
   m_ignoreEmptyCels = false;
   m_mergeDuplicates = false;
+  m_powerOfTwoSize = false;
   m_trimSprite = false;
   m_trimCels = false;
   m_trimByGrid = false;

--- a/src/app/doc_exporter.h
+++ b/src/app/doc_exporter.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2026  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -59,12 +59,12 @@ public:
   void setTextureFilename(const std::string& filename) { m_textureFilename = filename; }
   void setTextureWidth(int width) { m_textureWidth = width; }
   void setTextureHeight(int height) { m_textureHeight = height; }
-  void setPowerOfTwoSize(bool power2Size) { m_powerOfTwoSize = power2Size; }
   void setTextureColumns(int columns) { m_textureColumns = columns; }
   void setTextureRows(int rows) { m_textureRows = rows; }
   void setSpriteSheetType(SpriteSheetType type) { m_sheetType = type; }
   void setIgnoreEmptyCels(bool ignore) { m_ignoreEmptyCels = ignore; }
   void setMergeDuplicates(bool merge) { m_mergeDuplicates = merge; }
+  void setPowerOfTwoSize(bool power2Size) { m_powerOfTwoSize = power2Size; }
   void setBorderPadding(int padding) { m_borderPadding = padding; }
   void setShapePadding(int padding) { m_shapePadding = padding; }
   void setInnerPadding(int padding) { m_innerPadding = padding; }
@@ -163,6 +163,7 @@ private:
   int m_innerPadding;
   bool m_ignoreEmptyCels;
   bool m_mergeDuplicates;
+  bool m_powerOfTwoSize;
   bool m_trimSprite;
   bool m_trimCels;
   bool m_trimByGrid;
@@ -173,7 +174,6 @@ private:
   bool m_listLayers;
   bool m_listLayerHierarchy;
   bool m_listSlices;
-  bool m_powerOfTwoSize;
   Items m_documents;
 
   // Buffers used


### PR DESCRIPTION
I was just trying to fix this compiler warning:
```
src/app/doc_exporter.cpp:713:5: warning: field 'm_sampleBuf' will be initialized after field 'm_powerOfTwoSize' [-Wreorder-ctor]
  712 |   : m_docBuf(std::make_shared<doc::ImageBuffer>())
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |     m_powerOfTwoSize(false)
  713 |   , m_sampleBuf(std::make_shared<doc::ImageBuffer>())
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |     m_docBuf(std::make_shared<doc::ImageBuffer>())
  714 |   , m_powerOfTwoSize(false)
      |     ~~~~~~~~~~~~~~~~~~~~~~~
      |     m_sampleBuf(std::make_shared<doc::ImageBuffer>())
```
But after realizing that it'd make sense to move `m_powerOfTwoSize = false` to the `DocExporter::reset()` function, I ended up implementing the complete UI for this option:

<img width="1866" height="330" alt="image" src="https://github.com/user-attachments/assets/90862f87-84da-4b85-bc53-444fe3ece97e" />


