### PR TITLE
[ui] Split Widget flags into WidgetFlags / WidgetAlign enums

### DIFF
--- a/src/app/script/dialog_class.cpp
+++ b/src/app/script/dialog_class.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2025  Igara Studio S.A.
+// Copyright (C) 2018-present  Igara Studio S.A.
 // Copyright (C) 2018  David Capello
 //
 // This program is distributed under the terms of
@@ -64,8 +64,8 @@ namespace app { namespace script {
 
 using namespace ui;
 
-static constexpr const int kDefaultAutofit = ui::LEFT | ui::TOP;
-static constexpr const int kDefaultLabelAlign = ui::LEFT | ui::CENTER;
+static constexpr const WidgetAlign kDefaultAutofit = ui::LEFT | ui::TOP;
+static constexpr const WidgetAlign kDefaultLabelAlign = ui::LEFT | ui::CENTER;
 
 namespace {
 
@@ -130,7 +130,7 @@ struct Dialog {
   std::map<std::string, ui::Widget*, std::less<>> dataWidgets;
   std::map<std::string, ui::Widget*, std::less<>> labelWidgets;
   int currentRadioGroup = 0;
-  int autofit = kDefaultAutofit;
+  WidgetAlign autofit = kDefaultAutofit;
 
   // Member used to hold current state about the creation of a tabs
   // widget. After creation it is reset to null to be ready for the
@@ -216,10 +216,10 @@ struct Dialog {
       it->second->setText(text);
   }
 
-  void setAutofit(int align)
+  void setAutofit(const WidgetAlign align)
   {
     // Accept both 0 or a valid subset of align parameters.
-    if (align == 0 || (align & (ui::LEFT | ui::RIGHT | ui::TOP | ui::BOTTOM)))
+    if (align == ui::NOALIGN || (align & (ui::LEFT | ui::RIGHT | ui::TOP | ui::BOTTOM)))
       autofit = align;
   }
 
@@ -348,7 +348,7 @@ int Dialog_new(lua_State* L)
   ui::Window::Type windowType = ui::Window::WithTitleBar;
   std::string title = "Script";
   bool sizeable = true;
-  int autofit = kDefaultAutofit;
+  WidgetAlign autofit = kDefaultAutofit;
   if (lua_isstring(L, 1)) {
     title = lua_tostring(L, 1);
   }
@@ -370,7 +370,7 @@ int Dialog_new(lua_State* L)
 
     type = lua_getfield(L, 1, "autofit");
     if (type != LUA_TNIL) {
-      autofit = lua_tointeger(L, -1);
+      autofit = (WidgetAlign)lua_tointeger(L, -1);
     }
     lua_pop(L, 1);
   }
@@ -592,7 +592,7 @@ int Dialog_add_widget(lua_State* L, Widget* widget)
 {
   auto dlg = get_obj<Dialog>(L, 1);
   const char* label = nullptr;
-  int labelAlign = kDefaultLabelAlign;
+  WidgetAlign labelAlign = kDefaultLabelAlign;
   std::string id;
   bool visible = true;
   bool hexpand = true;
@@ -631,7 +631,7 @@ int Dialog_add_widget(lua_State* L, Widget* widget)
       const int v = lua_tointeger(L, -1) &
                     (ui::CENTER | ui::LEFT | ui::RIGHT | ui::TOP | ui::BOTTOM);
       if (v)
-        labelAlign = v;
+        labelAlign = (ui::WidgetAlign)v;
     }
     lua_pop(L, 1);
 
@@ -676,9 +676,9 @@ int Dialog_add_widget(lua_State* L, Widget* widget)
       }
     }
 
-    auto hbox = new ui::HBox;
+    auto* hbox = new ui::HBox;
     if (widget->type() == ui::kButtonWidget)
-      hbox->enableFlags(ui::HOMOGENEOUS);
+      hbox->enableAlign(ui::HOMOGENEOUS);
 
     // For tabs and unlabeled separators, we don't want the empty space of an unspecified label, so
     // span 2 columns.
@@ -1696,7 +1696,7 @@ int Dialog_modify(lua_State* L)
     if (relayout && !dlg->window.isResizing()) {
       dlg->window.layout();
 
-      if (dlg->autofit > 0) {
+      if (dlg->autofit != ui::NOALIGN) {
         const gfx::Rect oldBounds = dlg->window.bounds();
 
         // There is a ^ (XOR) logical operator because if TOP and BOTTOM (for example) are "true"
@@ -2005,7 +2005,7 @@ int Dialog_get_autofit(lua_State* L)
 int Dialog_set_autofit(lua_State* L)
 {
   auto dlg = get_obj<Dialog>(L, 1);
-  dlg->setAutofit(lua_tointeger(L, 2));
+  dlg->setAutofit((ui::WidgetAlign)lua_tointeger(L, 2));
   return 0;
 }
 

--- a/src/app/ui/separator_in_view.h
+++ b/src/app/ui/separator_in_view.h
@@ -16,7 +16,7 @@ namespace app {
 
 class SeparatorInView : public ui::Separator {
 public:
-  SeparatorInView(const std::string& text = std::string(), int align = ui::HORIZONTAL)
+  SeparatorInView(const std::string& text = std::string(), ui::WidgetAlign align = ui::HORIZONTAL)
     : Separator(text, align)
   {
     InitTheme.connect([this] {

--- a/src/app/ui/skin/skin_theme.cpp
+++ b/src/app/ui/skin/skin_theme.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2025  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -976,7 +976,7 @@ void SkinTheme::loadXml(BackwardCompatibility* backward)
         const char* stateValue = xmlLayer->Attribute("state");
         if (stateValue) {
           std::string state(stateValue);
-          int flags = 0;
+          ui::Style::Layer::StyleFlags flags = ui::Style::Layer::kNoFlag;
           if (state.find("disabled") != std::string::npos)
             flags |= ui::Style::Layer::kDisabled;
           if (state.find("selected") != std::string::npos)
@@ -994,7 +994,7 @@ void SkinTheme::loadXml(BackwardCompatibility* backward)
         const char* alignValue = xmlLayer->Attribute("align");
         if (alignValue) {
           std::string alignString(alignValue);
-          int align = 0;
+          WidgetAlign align = NOALIGN;
           if (alignString.find("left") != std::string::npos)
             align |= LEFT;
           if (alignString.find("center") != std::string::npos)
@@ -1649,7 +1649,7 @@ void SkinTheme::paintMenuItem(ui::PaintEvent& ev)
     // Draw the keyboard shortcut
     else if (AppMenuItem* appMenuItem = dynamic_cast<AppMenuItem*>(widget)) {
       if (appMenuItem->key() && !appMenuItem->key()->shortcuts().empty()) {
-        int old_align = appMenuItem->align();
+        WidgetAlign old_align = appMenuItem->align();
 
         pos = bounds;
         pos.w -= widget->childSpacing() / 4;

--- a/src/app/ui/workspace_panel.cpp
+++ b/src/app/ui/workspace_panel.cpp
@@ -245,7 +245,7 @@ DropViewAtResult WorkspacePanel::dropViewAt(const gfx::Point& screenPos,
   if (!clone && from == this && m_views.size() == 1)
     return DropViewAtResult::NOTHING;
 
-  int splitterAlign = 0;
+  WidgetAlign splitterAlign = NOALIGN;
   if (dropArea & (LEFT | RIGHT))
     splitterAlign = HORIZONTAL;
   else if (dropArea & (TOP | BOTTOM))

--- a/src/app/widget_loader.cpp
+++ b/src/app/widget_loader.cpp
@@ -53,7 +53,7 @@ using namespace app::skin;
 using namespace tinyxml2;
 using namespace ui;
 
-static int convert_align_value_to_flags(const char* value);
+static WidgetAlign convert_align_string_to_enum(const char* value);
 static int int_attr(const XMLElement* elem, const char* attribute_name, int default_value);
 
 WidgetLoader::WidgetLoader() : m_tooltipManager(NULL)
@@ -120,9 +120,9 @@ Widget* WidgetLoader::convertXmlElementToWidget(const XMLElement* elem,
       widget = new Panel();
   }
   else if (elem_name == "box") {
-    bool horizontal = bool_attr(elem, "horizontal", false);
-    bool vertical = bool_attr(elem, "vertical", false);
-    int align = (horizontal ? HORIZONTAL : vertical ? VERTICAL : 0);
+    const bool horizontal = bool_attr(elem, "horizontal", false);
+    const bool vertical = bool_attr(elem, "vertical", false);
+    const WidgetAlign align = (horizontal ? HORIZONTAL : vertical ? VERTICAL : NOALIGN);
 
     if (!widget)
       widget = new Box(align);
@@ -328,7 +328,10 @@ Widget* WidgetLoader::convertXmlElementToWidget(const XMLElement* elem,
     Splitter::Type type = (by && strcmp(by, "pixel") == 0 ? Splitter::ByPixel :
                                                             Splitter::ByPercentage);
 
-    Splitter* splitter = new Splitter(type, horizontal ? HORIZONTAL : vertical ? VERTICAL : 0);
+    Splitter* splitter = new Splitter(type,
+                                      horizontal ? HORIZONTAL :
+                                      vertical   ? VERTICAL :
+                                                   NOALIGN);
     if (position) {
       splitter->setPosition(strtod(position, NULL) * (type == Splitter::ByPixel ? guiscale() : 1));
     }
@@ -358,15 +361,16 @@ Widget* WidgetLoader::convertXmlElementToWidget(const XMLElement* elem,
                      (top ? TOP : (bottom ? BOTTOM : MIDDLE)));
   }
   else if (elem_name == "separator") {
-    bool center = bool_attr(elem, "center", false);
-    bool right = bool_attr(elem, "right", false);
-    bool middle = bool_attr(elem, "middle", false);
-    bool bottom = bool_attr(elem, "bottom", false);
-    bool horizontal = bool_attr(elem, "horizontal", false);
-    bool vertical = bool_attr(elem, "vertical", false);
-    int align = (horizontal ? HORIZONTAL : 0) | (vertical ? VERTICAL : 0) |
-                (center ? CENTER : (right ? RIGHT : LEFT)) |
-                (middle ? MIDDLE : (bottom ? BOTTOM : TOP));
+    const bool center = bool_attr(elem, "center", false);
+    const bool right = bool_attr(elem, "right", false);
+    const bool middle = bool_attr(elem, "middle", false);
+    const bool bottom = bool_attr(elem, "bottom", false);
+    const bool horizontal = bool_attr(elem, "horizontal", false);
+    const bool vertical = bool_attr(elem, "vertical", false);
+    const WidgetAlign align = (horizontal ? HORIZONTAL : NOALIGN) |
+                              (vertical ? VERTICAL : NOALIGN) |
+                              (center ? CENTER : (right ? RIGHT : LEFT)) |
+                              (middle ? MIDDLE : (bottom ? BOTTOM : TOP));
 
     if (!widget) {
       widget = new Separator(m_xmlTranslator(elem, "text"), align);
@@ -395,18 +399,18 @@ Widget* WidgetLoader::convertXmlElementToWidget(const XMLElement* elem,
     const char* text = (elem->GetText() ? elem->GetText() : "");
     bool wordwrap = bool_attr(elem, "wordwrap", false);
     const char* text_align = elem->Attribute("text_align");
-    int align = text_align ? convert_align_value_to_flags(text_align) : 0;
+    WidgetAlign align = (text_align ? convert_align_string_to_enum(text_align) : NOALIGN);
 
     if (!widget)
-      widget = new TextBox(text, 0);
+      widget = new TextBox(text, NOALIGN);
     else
       widget->setText(text);
 
     if (wordwrap)
-      widget->setAlign(widget->align() | WORDWRAP);
+      widget->enableAlign(WORDWRAP);
 
     if (align)
-      widget->setAlign(widget->align() | align);
+      widget->enableAlign(align);
   }
   else if (elem_name == "view") {
     if (!widget)
@@ -508,7 +512,7 @@ Widget* WidgetLoader::convertXmlElementToWidget(const XMLElement* elem,
           os::SurfaceRef sur = os::System::instance()->loadRgbaSurface(rf.filename().c_str());
           if (sur) {
             sur->setImmutable();
-            widget = new ImageView(sur, 0);
+            widget = new ImageView(sur, NOALIGN);
           }
         }
         catch (...) {
@@ -518,7 +522,7 @@ Widget* WidgetLoader::convertXmlElementToWidget(const XMLElement* elem,
       else if (icon) {
         SkinPartPtr part = SkinTheme::instance()->getPartById(std::string(icon));
         if (part) {
-          widget = new ImageView(part->bitmapRef(0), 0);
+          widget = new ImageView(part->bitmapRef(0), NOALIGN);
         }
       }
     }
@@ -730,7 +734,7 @@ void WidgetLoader::fillWidgetWithXmlElementAttributesWithChildren(const XMLEleme
         const char* cell_align = childElem->Attribute("cell_align");
         int hspan = cell_hspan ? strtol(cell_hspan, NULL, 10) : 1;
         int vspan = cell_vspan ? strtol(cell_vspan, NULL, 10) : 1;
-        int align = cell_align ? convert_align_value_to_flags(cell_align) : 0;
+        const WidgetAlign align = (cell_align ? convert_align_string_to_enum(cell_align) : NOALIGN);
         auto grid = dynamic_cast<ui::Grid*>(widget);
         ASSERT(grid != nullptr);
 
@@ -757,43 +761,43 @@ void WidgetLoader::fillWidgetWithXmlElementAttributesWithChildren(const XMLEleme
   }
 }
 
-static int convert_align_value_to_flags(const char* value)
+static WidgetAlign convert_align_string_to_enum(const char* value)
 {
   char *tok, *ptr = base_strdup(value);
-  int flags = 0;
+  WidgetAlign align = NOALIGN;
 
   for (tok = strtok(ptr, " "); tok != NULL; tok = strtok(NULL, " ")) {
     if (strcmp(tok, "horizontal") == 0) {
-      flags |= HORIZONTAL;
+      align |= HORIZONTAL;
     }
     else if (strcmp(tok, "vertical") == 0) {
-      flags |= VERTICAL;
+      align |= VERTICAL;
     }
     else if (strcmp(tok, "left") == 0) {
-      flags |= LEFT;
+      align |= LEFT;
     }
     else if (strcmp(tok, "center") == 0) {
-      flags |= CENTER;
+      align |= CENTER;
     }
     else if (strcmp(tok, "right") == 0) {
-      flags |= RIGHT;
+      align |= RIGHT;
     }
     else if (strcmp(tok, "top") == 0) {
-      flags |= TOP;
+      align |= TOP;
     }
     else if (strcmp(tok, "middle") == 0) {
-      flags |= MIDDLE;
+      align |= MIDDLE;
     }
     else if (strcmp(tok, "bottom") == 0) {
-      flags |= BOTTOM;
+      align |= BOTTOM;
     }
     else if (strcmp(tok, "homogeneous") == 0) {
-      flags |= HOMOGENEOUS;
+      align |= HOMOGENEOUS;
     }
   }
 
   base_free(ptr);
-  return flags;
+  return align;
 }
 
 static int int_attr(const XMLElement* elem, const char* attribute_name, int default_value)

--- a/src/ui/alert.cpp
+++ b/src/ui/alert.cpp
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2019-2024  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -65,9 +65,9 @@ Alert::Alert() : Window(WithTitleBar), m_progress(nullptr), m_progressPlaceholde
   m_buttonsPlaceholder = box3;
 
   // Pseudo separators (only to fill blank space)
-  auto box4 = new Box(0);
-  auto box5 = new Box(0);
-  m_progressPlaceholder = new Box(0);
+  auto* box4 = new VBox;
+  auto* box5 = new VBox;
+  m_progressPlaceholder = new VBox;
 
   box4->setExpansive(true);
   box5->setExpansive(true);
@@ -93,7 +93,7 @@ void Alert::setTitle(const std::string& title)
   setText(title);
 }
 
-void Alert::addLabel(const std::string& text, const int align)
+void Alert::addLabel(const std::string& text, const WidgetAlign align)
 {
   auto label = new Label(text);
   label->setAlign(align);
@@ -200,7 +200,7 @@ void Alert::processString(std::string& buf)
   bool label = false;
   bool separator = false;
   bool button = false;
-  int align = 0;
+  WidgetAlign align = NOALIGN;
 
   // Process buffer
   int c = 0;
@@ -235,7 +235,7 @@ void Alert::processString(std::string& buf)
       else {
         title = label = separator = button = false;
         beg = c + 2;
-        align = 0;
+        align = NOALIGN;
 
         switch (buf[c]) {
           case '<':

--- a/src/ui/alert.h
+++ b/src/ui/alert.h
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2019  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -29,7 +29,7 @@ public:
   Alert();
 
   void setTitle(const std::string& title);
-  void addLabel(const std::string& text, const int align);
+  void addLabel(const std::string& text, WidgetAlign align);
   void addSeparator();
   void addButton(const std::string& text);
 

--- a/src/ui/base.h
+++ b/src/ui/base.h
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2018-2020  Igara Studio S.A.
+// Copyright (C) 2018-present  Igara Studio S.A.
 // Copyright (C) 2001-2016  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -9,48 +9,78 @@
 #define UI_BASE_H_INCLUDED
 #pragma once
 
+#include "base/enum_flags.h"
+#include "base/ints.h"
+
 namespace ui {
 
-// Widget flags
-enum {
-  HIDDEN = 0x00000001,       // Is hidden (not visible, not clickeable).
-  SELECTED = 0x00000002,     // Is selected.
-  DISABLED = 0x00000004,     // Is disabled (not usable).
-  HAS_FOCUS = 0x00000008,    // Has the input focus.
-  HAS_MOUSE = 0x00000010,    // Has the mouse.
-  HAS_CAPTURE = 0x00000020,  // Captured the mouse .
-  FOCUS_STOP = 0x00000040,   // The widget support the focus on it.
-  FOCUS_MAGNET = 0x00000080, // The widget wants the focus by default (e.g. when the dialog is shown
-                             // by first time).
-  EXPANSIVE = 0x00000100,    // Is expansive (want more space).
-  DECORATIVE = 0x00000200,   // To decorate windows.
-  INITIALIZED = 0x00000400,  // The widget was already initialized by a theme.
-  DIRTY = 0x00000800,        // The widget (or one child) is dirty (update_region != empty).
-  HAS_TEXT = 0x00001000,     // The widget has text (at least setText() was called one time).
-  DOUBLE_BUFFERED = 0x00002000, // The widget is painted in a back-buffer and then flipped to the
-                                // main display
-  TRANSPARENT = 0x00004000, // The widget has transparent parts that needs the background painted
-                            // before
-  CTRL_RIGHT_CLICK = 0x00008000, // The widget should transform Ctrl+click to right-click on OS X.
-  ALLOW_DROP = 0x40000000,       // The widget can participate as a drop target in a drag & drop
-                                 // operation.
-  IGNORE_MOUSE = 0x80000000,     // Don't process mouse messages for this widget (useful for labels,
-                                 // boxes, grids, etc.)
-  PROPERTIES_MASK = 0xC000ffff,
+// clang-format off
 
-  HORIZONTAL = 0x00010000,
-  VERTICAL = 0x00020000,
-  LEFT = 0x00040000,
-  CENTER = 0x00080000,
-  RIGHT = 0x00100000,
-  TOP = 0x00200000,
-  MIDDLE = 0x00400000,
-  BOTTOM = 0x00800000,
-  HOMOGENEOUS = 0x01000000,
-  WORDWRAP = 0x02000000,
-  CHARWRAP = 0x04000000,
-  ALIGN_MASK = 0x3fff0000,
+enum WidgetFlags : uint32_t {
+  NOFLAGS          = 0x00000000,
+  HIDDEN           = 0x00000001, // Is hidden (not visible, not clickeable).
+  SELECTED         = 0x00000002, // Is selected.
+  DISABLED         = 0x00000004, // Is disabled (not usable).
+  HAS_FOCUS        = 0x00000008, // Has the input focus.
+  HAS_MOUSE        = 0x00000010, // Has the mouse.
+  HAS_CAPTURE      = 0x00000020, // Captured the mouse .
+  FOCUS_STOP       = 0x00000040, // The widget support the focus on it.
+  FOCUS_MAGNET     = 0x00000080, // The widget wants the focus by default (e.g. when the dialog is shown
+                                 // by first time).
+  EXPANSIVE        = 0x00000100, // Is expansive (want more space).
+  DECORATIVE       = 0x00000200, // To decorate windows.
+  INITIALIZED      = 0x00000400, // The widget was already initialized by a theme.
+  DIRTY            = 0x00000800, // The widget (or one child) is dirty (update_region != empty).
+  HAS_TEXT         = 0x00001000, // The widget has text (at least setText() was called one time).
+  DOUBLE_BUFFERED  = 0x00002000, // The widget is painted in a back-buffer and then flipped to the
+                                 // main display
+  TRANSPARENT      = 0x00004000, // The widget has transparent parts that needs the background painted
+                                 // before
+  CTRL_RIGHT_CLICK = 0x00008000, // The widget should transform Ctrl+click to right-click on OS X.
+  ALLOW_DROP       = 0x00010000, // The widget can participate as a drop target in a drag & drop
+                                 // operation.
+  IGNORE_MOUSE     = 0x00020000, // Don't process mouse messages for this widget (useful for labels,
+                                 // boxes, grids, etc.)
+  FLAGS_MASK       = 0x000fffff,
 };
+
+enum WidgetAlign : uint16_t {
+  NOALIGN     = 0x0000,
+  HORIZONTAL  = 0x0001,
+  VERTICAL    = 0x0002,
+  LEFT        = 0x0004,
+  CENTER      = 0x0008,
+  RIGHT       = 0x0010,
+  TOP         = 0x0020,
+  MIDDLE      = 0x0040,
+  BOTTOM      = 0x0080,
+  HOMOGENEOUS = 0x0100,
+  WORDWRAP    = 0x0200,
+  CHARWRAP    = 0x0400,
+  ALIGN_MASK  = 0x0fff,
+};
+
+// clang-format on
+
+LAF_ENUM_FLAGS(WidgetFlags)
+LAF_ENUM_FLAGS(WidgetAlign)
+
+using fa_t = uint32_t; // fa = flags + alignment
+
+constexpr fa_t make_fa(const WidgetFlags flags, const WidgetAlign align)
+{
+  return (flags & FLAGS_MASK) | ((align & ALIGN_MASK) << 20);
+}
+
+constexpr WidgetFlags get_flags_from_fa(const fa_t fa)
+{
+  return (WidgetFlags)(fa & FLAGS_MASK);
+}
+
+constexpr WidgetAlign get_align_from_fa(const fa_t fa)
+{
+  return (WidgetAlign)((fa >> 20) & ALIGN_MASK);
+}
 
 } // namespace ui
 

--- a/src/ui/box.cpp
+++ b/src/ui/box.cpp
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2018-2025  Igara Studio S.A.
+// Copyright (C) 2018-present  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -23,7 +23,7 @@ namespace ui {
 
 using namespace gfx;
 
-Box::Box(int align) : Widget(kBoxWidget)
+Box::Box(WidgetAlign align) : Widget(kBoxWidget)
 {
   enableFlags(IGNORE_MOUSE);
   setAlign(align);

--- a/src/ui/box.h
+++ b/src/ui/box.h
@@ -1,4 +1,5 @@
 // Aseprite UI Library
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -14,7 +15,7 @@ namespace ui {
 
 class Box : public Widget {
 public:
-  Box(int align);
+  Box(WidgetAlign align);
 
 protected:
   // Events

--- a/src/ui/fit_bounds.cpp
+++ b/src/ui/fit_bounds.cpp
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2019-2024  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2016  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -35,7 +35,7 @@ static const std::vector<gfx::Rect> get_all_workareas()
   return workareas;
 }
 
-int fit_bounds(Display* display, int arrowAlign, const gfx::Rect& target, gfx::Rect& bounds)
+int fit_bounds(Display* display, WidgetAlign arrowAlign, const gfx::Rect& target, gfx::Rect& bounds)
 {
   bounds.x = target.x;
   bounds.y = target.y;

--- a/src/ui/fit_bounds.h
+++ b/src/ui/fit_bounds.h
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2019-2021  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2016  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "gfx/fwd.h"
+#include "ui/base.h"
 
 #include <functional>
 
@@ -19,7 +20,7 @@ class Display;
 class Widget;
 class Window;
 
-int fit_bounds(Display* display, int arrowAlign, const gfx::Rect& target, gfx::Rect& bounds);
+int fit_bounds(Display* display, WidgetAlign arrowAlign, const gfx::Rect& target, gfx::Rect& bounds);
 
 // Fits a possible rectangle for the given window fitting it with a
 // special logic. It works for both cases:

--- a/src/ui/graphics.cpp
+++ b/src/ui/graphics.cpp
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2019-2025  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -476,7 +476,7 @@ void Graphics::drawAlignedUIText(const std::string& str,
                                  gfx::Color fg,
                                  gfx::Color bg,
                                  const gfx::Rect& rc,
-                                 const int align)
+                                 const WidgetAlign align)
 {
   doUIStringAlgorithm(str, fg, bg, rc, align, true);
 }
@@ -490,7 +490,7 @@ gfx::Size Graphics::measureText(const std::string& str)
     .size();
 }
 
-gfx::Size Graphics::fitString(const std::string& str, int maxWidth, int align)
+gfx::Size Graphics::fitString(const std::string& str, const int maxWidth, const WidgetAlign align)
 {
   return doUIStringAlgorithm(str,
                              gfx::ColorNone,
@@ -501,11 +501,11 @@ gfx::Size Graphics::fitString(const std::string& str, int maxWidth, int align)
 }
 
 gfx::Size Graphics::doUIStringAlgorithm(const std::string& str,
-                                        gfx::Color fg,
-                                        gfx::Color bg,
+                                        const gfx::Color fg,
+                                        const gfx::Color bg,
                                         const gfx::Rect& rc,
-                                        int align,
-                                        bool draw)
+                                        const WidgetAlign align,
+                                        const bool draw)
 {
   ASSERT(m_font);
 

--- a/src/ui/graphics.h
+++ b/src/ui/graphics.h
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2019-2025  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -19,6 +19,7 @@
 #include "text/font.h"
 #include "text/fwd.h"
 #include "text/shaper_features.h"
+#include "ui/base.h"
 #include "ui/layer.h"
 #include "ui/paint.h"
 
@@ -144,10 +145,10 @@ public:
                          gfx::Color fg,
                          gfx::Color bg,
                          const gfx::Rect& rc,
-                         const int align);
+                         WidgetAlign align);
 
   gfx::Size measureText(const std::string& str);
-  gfx::Size fitString(const std::string& str, int maxWidth, int align);
+  gfx::Size fitString(const std::string& str, int maxWidth, WidgetAlign align);
 
   // Can be used in case that you've accessed/changed the
   // getInternalSurface() directly and need to specify which area
@@ -159,7 +160,7 @@ private:
                                 gfx::Color fg,
                                 gfx::Color bg,
                                 const gfx::Rect& rc,
-                                int align,
+                                WidgetAlign align,
                                 bool draw);
   void dirty(const gfx::Rect& bounds);
 

--- a/src/ui/grid.cpp
+++ b/src/ui/grid.cpp
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2018-2025  Igara Studio S.A.
+// Copyright (C) 2018-present  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -34,7 +34,7 @@ Grid::Cell::Cell()
   child = nullptr;
   hspan = 0;
   vspan = 0;
-  align = 0;
+  align = NOALIGN;
   w = 0;
   h = 0;
 }
@@ -90,7 +90,7 @@ Grid::~Grid()
  * - BOTTOM: Sets vertical alignment to the end of the cell.
  * - None: Uses the whole vertical space of the cell.
  */
-void Grid::addChildInCell(Widget* child, int hspan, int vspan, int align)
+void Grid::addChildInCell(Widget* child, const int hspan, const int vspan, const WidgetAlign align)
 {
   ASSERT(hspan > 0);
   ASSERT(vspan > 0);
@@ -299,7 +299,9 @@ void Grid::calculateSize()
   }
 }
 
-void Grid::calculateStripSize(std::vector<Strip>& colstrip, std::vector<Strip>& rowstrip, int align)
+void Grid::calculateStripSize(std::vector<Strip>& colstrip,
+                              std::vector<Strip>& rowstrip,
+                              const WidgetAlign align)
 {
   Cell* cell;
 
@@ -494,7 +496,7 @@ void Grid::distributeStripSize(std::vector<Strip>& colstrip,
   }
 }
 
-bool Grid::putWidgetInCell(Widget* child, int hspan, int vspan, int align)
+bool Grid::putWidgetInCell(Widget* child, int hspan, int vspan, const WidgetAlign align)
 {
   int col, row, colbeg, colend, rowend;
   Cell *cell, *parentcell;

--- a/src/ui/grid.h
+++ b/src/ui/grid.h
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2023  Igara Studio S.A.
+// Copyright (C) 2023-present  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -27,7 +27,7 @@ public:
   Grid(int columns, bool same_width_columns);
   ~Grid();
 
-  void addChildInCell(Widget* child, int hspan, int vspan, int align);
+  void addChildInCell(Widget* child, int hspan, int vspan, WidgetAlign align);
   Info getChildInfo(Widget* child);
   void setGap(const gfx::Size& gap);
   void setStyle(Style* style) override;
@@ -49,7 +49,7 @@ private:
     Widget* child;
     int hspan;
     int vspan;
-    int align;
+    WidgetAlign align;
     int w, h;
 
     Cell();
@@ -63,7 +63,9 @@ private:
   void sumStripSize(const std::vector<Strip>& strip, int& size);
   void calculateCellSize(int start, int span, const std::vector<Strip>& strip, int& size);
   void calculateSize();
-  void calculateStripSize(std::vector<Strip>& colstrip, std::vector<Strip>& rowstrip, int align);
+  void calculateStripSize(std::vector<Strip>& colstrip,
+                          std::vector<Strip>& rowstrip,
+                          WidgetAlign align);
   void expandStrip(std::vector<Strip>& colstrip,
                    std::vector<Strip>& rowstrip,
                    void (Grid::*incCol)(int, int));
@@ -72,7 +74,7 @@ private:
                            int rect_size,
                            int border_size,
                            bool same_width);
-  bool putWidgetInCell(Widget* child, int hspan, int vspan, int align);
+  bool putWidgetInCell(Widget* child, int hspan, int vspan, WidgetAlign align);
   void expandRows(int rows);
   void incColSize(int col, int size);
   void incRowSize(int row, int size);

--- a/src/ui/grid_ui_tests.cpp
+++ b/src/ui/grid_ui_tests.cpp
@@ -1,4 +1,5 @@
 // Aseprite UI Library
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2016  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -22,8 +23,8 @@ TEST(Grid, Simple2x1Grid)
   w1->setMinSize(gfx::Size(10, 10));
   w2->setMinSize(gfx::Size(10, 10));
 
-  grid->addChildInCell(w1, 1, 1, 0);
-  grid->addChildInCell(w2, 1, 1, 0);
+  grid->addChildInCell(w1, 1, 1, NOALIGN);
+  grid->addChildInCell(w2, 1, 1, NOALIGN);
 
   // Test request-size
   Size reqSize = grid->sizeHint();
@@ -59,7 +60,7 @@ TEST(Grid, Expand2ndWidget)
   w1->setMinSize(gfx::Size(20, 20));
   w2->setMinSize(gfx::Size(10, 10));
 
-  grid->addChildInCell(w1, 1, 1, 0);
+  grid->addChildInCell(w1, 1, 1, NOALIGN);
   grid->addChildInCell(w2, 1, 1, HORIZONTAL | TOP);
 
   // Test request size
@@ -92,8 +93,8 @@ TEST(Grid, SameWidth2x1Grid)
   w1->setMinSize(gfx::Size(20, 20));
   w2->setMinSize(gfx::Size(10, 10));
 
-  grid->addChildInCell(w1, 1, 1, 0);
-  grid->addChildInCell(w2, 1, 1, 0);
+  grid->addChildInCell(w1, 1, 1, NOALIGN);
+  grid->addChildInCell(w2, 1, 1, NOALIGN);
 
   // Test request size
   Size reqSize = grid->sizeHint();
@@ -158,7 +159,7 @@ TEST(Grid, Intrincate2x2Grid)
   w3->setMinSize(gfx::Size(10, 10));
   w4->setMinSize(gfx::Size(10, 10));
 
-  grid->addChildInCell(w1, 1, 1, 0);
+  grid->addChildInCell(w1, 1, 1, NOALIGN);
   grid->addChildInCell(w2, 2, 1, HORIZONTAL);
   grid->addChildInCell(w3, 2, 2, HORIZONTAL | VERTICAL);
   grid->addChildInCell(w4, 1, 2, VERTICAL);

--- a/src/ui/image_view.cpp
+++ b/src/ui/image_view.cpp
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2020  Igara Studio S.A.
+// Copyright (C) 2020-present  Igara Studio S.A.
 // Copyright (C) 2001-2016  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -21,7 +21,9 @@
 
 namespace ui {
 
-ImageView::ImageView(const os::SurfaceRef& sur, int align) : Widget(kImageViewWidget), m_sur(sur)
+ImageView::ImageView(const os::SurfaceRef& sur, const WidgetAlign align)
+  : Widget(kImageViewWidget)
+  , m_sur(sur)
 {
   setAlign(align);
 }

--- a/src/ui/image_view.h
+++ b/src/ui/image_view.h
@@ -1,4 +1,5 @@
 // Aseprite UI Library
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2016  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -19,7 +20,7 @@ namespace ui {
 
 class ImageView : public Widget {
 public:
-  ImageView(const os::Ref<os::Surface>& sur, int align);
+  ImageView(const os::Ref<os::Surface>& sur, WidgetAlign align);
 
 protected:
   void onSizeHint(SizeHintEvent& ev) override;

--- a/src/ui/scroll_bar.cpp
+++ b/src/ui/scroll_bar.cpp
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2019-2022  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -25,7 +25,7 @@ int ScrollBar::m_wherepos = 0;
 int ScrollBar::m_whereclick = 0;
 bool ScrollBar::m_dragging = false;
 
-ScrollBar::ScrollBar(int align, ScrollableViewDelegate* delegate)
+ScrollBar::ScrollBar(const WidgetAlign align, ScrollableViewDelegate* delegate)
   : Widget(kViewScrollbarWidget)
   , m_delegate(delegate)
   , m_thumbStyle(nullptr)

--- a/src/ui/scroll_bar.h
+++ b/src/ui/scroll_bar.h
@@ -1,4 +1,5 @@
 // Aseprite UI Library
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -22,7 +23,7 @@ public:
 
 class ScrollBar : public Widget {
 public:
-  ScrollBar(int align, ScrollableViewDelegate* delegate);
+  ScrollBar(WidgetAlign align, ScrollableViewDelegate* delegate);
 
   Style* thumbStyle() { return m_thumbStyle; }
   void setThumbStyle(Style* style) { m_thumbStyle = style; }

--- a/src/ui/separator.cpp
+++ b/src/ui/separator.cpp
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2018-2025  Igara Studio S.A.
+// Copyright (C) 2018-present  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -22,7 +22,7 @@ namespace ui {
 
 using namespace gfx;
 
-Separator::Separator(const std::string& text, int align) : Widget(kSeparatorWidget)
+Separator::Separator(const std::string& text, const WidgetAlign align) : Widget(kSeparatorWidget)
 {
   enableFlags(IGNORE_MOUSE);
   setAlign(align);

--- a/src/ui/separator.h
+++ b/src/ui/separator.h
@@ -1,4 +1,5 @@
 // Aseprite UI Library
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -14,7 +15,7 @@ namespace ui {
 
 class Separator : public Widget {
 public:
-  Separator(const std::string& text, int align);
+  Separator(const std::string& text, WidgetAlign align);
 
 protected:
   void onSizeHint(SizeHintEvent& ev) override;

--- a/src/ui/splitter.cpp
+++ b/src/ui/splitter.cpp
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2019-2025  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -28,7 +28,7 @@ namespace ui {
 
 using namespace gfx;
 
-Splitter::Splitter(Type type, int align)
+Splitter::Splitter(const Type type, const WidgetAlign align)
   : Widget(kSplitterWidget)
   , m_type(type)
   , m_userPos(50)

--- a/src/ui/splitter.h
+++ b/src/ui/splitter.h
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2021  Igara Studio S.A.
+// Copyright (C) 2021-present  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -17,7 +17,7 @@ class Splitter : public Widget {
 public:
   enum Type { ByPercentage, ByPixel };
 
-  Splitter(Type type, int align);
+  Splitter(Type type, WidgetAlign align);
 
   double getPosition() const { return m_userPos; }
   void setPosition(double pos);

--- a/src/ui/style.h
+++ b/src/ui/style.h
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2020-2025  Igara Studio S.A.
+// Copyright (C) 2020-present  Igara Studio S.A.
 // Copyright (C) 2017  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -9,6 +9,8 @@
 #define UI_STYLE_H_INCLUDED
 #pragma once
 
+#include "base/enum_flags.h"
+#include "base/ints.h"
 #include "gfx/border.h"
 #include "gfx/color.h"
 #include "gfx/point.h"
@@ -43,27 +45,23 @@ public:
     };
 
     // Flags (in which state the widget must be to show this layer)
-    enum { kMouse = 1, kFocus = 2, kSelected = 4, kDisabled = 8, kCapture = 16 };
+    enum StyleFlags : uint8_t {
+      kNoFlag = 0,
+      kMouse = 1,
+      kFocus = 2,
+      kSelected = 4,
+      kDisabled = 8,
+      kCapture = 16
+    };
 
     class IconSurfaceProvider {
     public:
       virtual os::Surface* iconSurface() const = 0;
     };
 
-    Layer()
-      : m_type(Type::kNone)
-      , m_flags(0)
-      , m_align(CENTER | MIDDLE)
-      , m_color(gfx::ColorNone)
-      , m_icon(nullptr)
-      , m_spriteSheet(nullptr)
-      , m_offset(0, 0)
-    {
-    }
-
     Type type() const { return m_type; }
-    int flags() const { return m_flags; }
-    int align() const { return m_align; }
+    StyleFlags flags() const { return m_flags; }
+    WidgetAlign align() const { return m_align; }
 
     gfx::Color color() const { return m_color; }
     os::Surface* icon() const { return m_icon.get(); }
@@ -73,8 +71,8 @@ public:
     const gfx::Point& offset() const { return m_offset; }
 
     void setType(const Type type) { m_type = type; }
-    void setFlags(const int flags) { m_flags = flags; }
-    void setAlign(const int align) { m_align = align; }
+    void setFlags(const StyleFlags flags) { m_flags = flags; }
+    void setAlign(const WidgetAlign align) { m_align = align; }
     void setColor(gfx::Color color) { m_color = color; }
     void setIcon(const os::SurfaceRef& icon) { m_icon = icon; }
     void setSpriteSheet(const os::SurfaceRef& spriteSheet) { m_spriteSheet = spriteSheet; }
@@ -83,15 +81,15 @@ public:
     void setOffset(const gfx::Point& offset) { m_offset = offset; }
 
   private:
-    Type m_type;
-    int m_flags;
-    int m_align;
-    gfx::Color m_color;
-    os::SurfaceRef m_icon;
-    os::SurfaceRef m_spriteSheet;
+    Type m_type = Type::kNone;
+    StyleFlags m_flags = kNoFlag;
+    WidgetAlign m_align = CENTER | MIDDLE;
+    gfx::Color m_color = gfx::ColorNone;
+    os::SurfaceRef m_icon = nullptr;
+    os::SurfaceRef m_spriteSheet = nullptr;
     gfx::Rect m_spriteBounds;
     gfx::Rect m_slicesBounds;
-    gfx::Point m_offset;
+    gfx::Point m_offset = gfx::Point(0, 0);
   };
 
   typedef std::vector<Layer> Layers;
@@ -171,6 +169,8 @@ private:
   text::FontRef m_font;
   bool m_mnemonics;
 };
+
+LAF_ENUM_FLAGS(Style::Layer::StyleFlags)
 
 } // namespace ui
 

--- a/src/ui/textbox.cpp
+++ b/src/ui/textbox.cpp
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2019-2025  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2016  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -25,7 +25,7 @@
 
 namespace ui {
 
-TextBox::TextBox(const std::string& text, int align) : Widget(kTextBoxWidget)
+TextBox::TextBox(const std::string& text, const WidgetAlign align) : Widget(kTextBoxWidget)
 {
   setBgColor(gfx::ColorNone);
   setFocusStop(true);

--- a/src/ui/textbox.h
+++ b/src/ui/textbox.h
@@ -1,4 +1,5 @@
 // Aseprite UI Library
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2013  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -14,7 +15,7 @@ namespace ui {
 
 class TextBox : public Widget {
 public:
-  TextBox(const std::string& text, int align);
+  TextBox(const std::string& text, WidgetAlign align);
 
 protected:
   bool onProcessMessage(Message* msg) override;

--- a/src/ui/widget.cpp
+++ b/src/ui/widget.cpp
@@ -68,7 +68,7 @@ WidgetType register_widget_type()
 
 Widget::Widget(WidgetType type)
   : m_type(type)
-  , m_flags(0)
+  , m_fa(0)
   , m_theme(get_theme())
   , m_style(nullptr)
   , m_font(nullptr)

--- a/src/ui/widget.h
+++ b/src/ui/widget.h
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2018-2025  Igara Studio S.A.
+// Copyright (C) 2018-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -67,13 +67,16 @@ public:
   const std::string& id() const { return m_id; }
   void setId(const char* id) { m_id = id; }
 
-  int flags() const { return m_flags; }
-  bool hasFlags(int flags) const { return ((m_flags & flags) == flags); }
-  void enableFlags(int flags) { m_flags |= flags; }
-  void disableFlags(int flags) { m_flags &= ~flags; }
+  WidgetFlags flags() const { return get_flags_from_fa(m_fa); }
+  WidgetAlign align() const { return get_align_from_fa(m_fa); }
 
-  int align() const { return (m_flags & ALIGN_MASK); }
-  void setAlign(int align) { m_flags = ((m_flags & PROPERTIES_MASK) | (align & ALIGN_MASK)); }
+  bool hasFlags(const WidgetFlags f) const { return (m_fa & f) == f; }
+  void enableFlags(const WidgetFlags f) { m_fa = make_fa(flags() | f, align()); }
+  void disableFlags(const WidgetFlags f) { m_fa = make_fa(flags() & ~f, align()); }
+
+  void setAlign(const WidgetAlign a) { m_fa = make_fa(flags(), a); }
+  void enableAlign(const WidgetAlign a) { m_fa = make_fa(flags(), align() | a); }
+  void disableAlign(const WidgetAlign a) { m_fa = make_fa(flags(), align() & ~a); }
 
   // Text property.
 
@@ -459,7 +462,7 @@ private:
 
   WidgetType m_type; // Widget's type
   std::string m_id;  // Widget's id
-  int m_flags;       // Special boolean properties (see flags in ui/base.h)
+  fa_t m_fa;         // Properties/status (WidgetFlags) + alignment/layout flags (WidgetAlign)
   Theme* m_theme;    // Widget's theme
   Style* m_style;
   std::string m_text;               // Widget text


### PR DESCRIPTION
Split `ui::Widget` flags+align into two enums: `ui::WidgetFlags` / `ui::WidgetAlign`.

In [this comment](https://github.com/aseprite/aseprite/pull/5842#discussion_r3366655529) it was discussed that `m_fa` might not be the best name, but I wanted to use something short to specify flags+align, and in a a similar fashion to `rgba`, or `graya`, etc.