### PR TITLE
Add test to check that closing a sprite delete its SpriteEvents

### DIFF
--- a/src/app/script/engine.cpp
+++ b/src/app/script/engine.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2024  Igara Studio S.A.
+// Copyright (C) 2018-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -37,6 +37,7 @@
 #include "ui/base.h"
 #include "ui/cursor_type.h"
 #include "ui/mouse_button.h"
+#include "ui/system.h"
 
 #include <fstream>
 #include <sstream>
@@ -630,7 +631,20 @@ SpriteEvents* Engine::spriteEvents(const Sprite* sprite)
   auto* spriteEvents = new SpriteEvents(L, sprite);
   auto id = sprite->id();
   m_spriteEvents[id].reset(spriteEvents);
-  spriteEvents->SpriteClosed.connect([this, id] { m_spriteEvents.erase(id); });
+
+  spriteEvents->SpriteClosed.connect([this, id] {
+    auto it = m_spriteEvents.find(id);
+    if (it != m_spriteEvents.end()) {
+      // We cannot delete the SpriteEvent here because we are
+      // iterating the same SpriteClosed connection of this
+      // SpriteEvent.
+      m_deletedSpriteEvents.push_back(std::move(it->second));
+      m_spriteEvents.erase(it);
+
+      ui::execute_from_ui_thread([this] { m_deletedSpriteEvents.clear(); });
+    }
+  });
+
   return spriteEvents;
 }
 

--- a/src/app/script/engine.h
+++ b/src/app/script/engine.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2025  Igara Studio S.A.
+// Copyright (C) 2018-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -132,6 +132,7 @@ private:
   std::unique_ptr<AppEvents> m_appEvents;
   std::unique_ptr<WindowEvents> m_windowEvents;
   std::map<doc::ObjectId, std::unique_ptr<SpriteEvents>> m_spriteEvents;
+  std::vector<std::unique_ptr<SpriteEvents>> m_deletedSpriteEvents;
 
   // Holds the base "entry point" of this engine, the last filename with which evalUserFile was
   // called, remains after execution has finished, for any events/dialogs that might need to run

--- a/src/app/script/engine_tests.cpp
+++ b/src/app/script/engine_tests.cpp
@@ -267,6 +267,25 @@ TEST(Engine, LingeringObjects)
   EXPECT_FALSE(engine->hasLingeringObjects());
 }
 
+TEST(Engine, LingeringSpriteEvents)
+{
+  INIT_ENGINE_TEST()
+
+  auto engine = std::make_shared<Engine>();
+
+  EXPECT_FALSE(engine->hasLingeringObjects());
+
+  engine->evalCode(R"(
+  sprite = Sprite(128, 128)
+  listener = sprite.events:on('filenamechange', function() end))");
+
+  EXPECT_TRUE(engine->hasLingeringObjects());
+
+  engine->evalCode("sprite:close()");
+
+  EXPECT_FALSE(engine->hasLingeringObjects());
+}
+
 TEST(Engine, MemoryLimit)
 {
   INIT_ENGINE_TEST()


### PR DESCRIPTION
Trying to test/fix #5859

The possible given solution is to move the `unique_ptr<SpriteEvent>` to a temporal vector of `SpriteEvents` to be deleted after the `SpriteClosed` signal is fully processed (as we cannot delete the `SpriteEvents` that we iterating).