### PR TITLE
Ensure the console is always parented to the main window (fix #5872)

### DIFF
--- a/src/app/console.cpp
+++ b/src/app/console.cpp
@@ -53,6 +53,8 @@ public:
     // the initialization.
     if (auto* mainWin = App::instance()->mainWindow()) {
       m_mainWindowClosedConn = mainWin->Close.connect([this] { closeWindow(nullptr); });
+      // Ensure we are parented to the main window when we are opened
+      setParentDisplay(mainWin->display());
     }
 
     // When the window is closed, we clear the text


### PR DESCRIPTION
Fixes #5872, the window was getting automatically parented to the current foreground window when shown, which could be an ephemeral script dialog.