### PR TITLE
Fix crash when undoing transactions involving MovingPixels

### DIFF
--- a/src/app/doc.cpp
+++ b/src/app/doc.cpp
@@ -362,6 +362,12 @@ void Doc::notifySliceDuplicated(Slice* slice)
   notify_observers<DocEvent&>(&DocObserver::onSliceDuplicated, ev);
 }
 
+void Doc::notifyBeforeCommitTransaction()
+{
+  DocEvent ev(this);
+  notify_observers<DocEvent&>(&DocObserver::onBeforeCommitTransaction, ev);
+}
+
 bool Doc::isModified() const
 {
   return !m_undo->isInSavedStateOrSimilar();

--- a/src/app/doc.h
+++ b/src/app/doc.h
@@ -145,6 +145,7 @@ public:
   void notifyAfterAddTile(LayerTilemap* layer, frame_t frame, tile_index ti);
   void notifyBeforeSlicesDuplication();
   void notifySliceDuplicated(Slice* slice);
+  void notifyBeforeCommitTransaction();
 
   //////////////////////////////////////////////////////////////////////
   // File related properties

--- a/src/app/doc_observer.h
+++ b/src/app/doc_observer.h
@@ -124,6 +124,9 @@ public:
   // Warning: This must be triggered from the UI thread (because
   // scripts will listen this event).
   virtual void onAfterAddTile(DocEvent& ev) {}
+
+  // When we are about to commit a transaction
+  virtual void onBeforeCommitTransaction(DocEvent& ev) {}
 };
 
 } // namespace app

--- a/src/app/transaction.cpp
+++ b/src/app/transaction.cpp
@@ -88,6 +88,8 @@ void Transaction::commit()
   ASSERT(m_cmds);
   TX_TRACE("TX: Commit <%s>\n", m_cmds->label().c_str());
 
+  m_doc->notifyBeforeCommitTransaction();
+
   m_cmds->updateSpritePositionAfter();
   const SpritePosition sprPos = m_cmds->spritePositionAfterExecute();
 

--- a/src/app/ui/editor/editor.cpp
+++ b/src/app/ui/editor/editor.cpp
@@ -2648,6 +2648,12 @@ void Editor::onSliceDuplicated(DocEvent& ev)
   selectSlice(ev.slice());
 }
 
+void Editor::onBeforeCommitTransaction(DocEvent& ev)
+{
+  if (ev.document() == m_document && isMovingPixels())
+    dropMovingPixels();
+}
+
 void Editor::setCursor(const gfx::Point& mouseDisplayPos)
 {
   bool used = false;

--- a/src/app/ui/editor/editor.h
+++ b/src/app/ui/editor/editor.h
@@ -353,6 +353,7 @@ protected:
   void onBeforeLayerEditableChange(DocEvent& ev, bool newState) override;
   void onBeforeSlicesDuplication(DocEvent& ev) override;
   void onSliceDuplicated(DocEvent& ev) override;
+  void onBeforeCommitTransaction(DocEvent& ev) override;
 
   // ActiveToolObserver impl
   void onActiveToolChange(tools::Tool* tool) override;


### PR DESCRIPTION
Undoing or other transaction actions involving MovingPixels could end up with a crash or other strange behavior, this adds a new doc observer that monitors transactions and drops the pixels before any commits.

Repro script:
```lua
local sprite = Sprite(128, 128)
app.transaction("Crash me on undo", function()
    sprite.selection:selectAll()
    app.command.MoveMask{quantity = 10, target = "content", direction = "down"}
    sprite.selection = Selection()
end)
-- Time to crash
app.command.Undo()
```