### PR TITLE
Make Command tooltips consistent when inside transactions (fix #5862)

### DIFF
--- a/src/app/commands/cmd_duplicate_slice.cpp
+++ b/src/app/commands/cmd_duplicate_slice.cpp
@@ -82,10 +82,15 @@ void DuplicateSliceCommand::onExecute(Context* context)
   }
 
   ContextWriter writer(context);
-  Tx tx(writer, "Duplicate Slice");
   Sprite* sprite = writer.site().sprite();
-
   Doc* doc = static_cast<Doc*>(sprite->document());
+
+  // Show the tooltip feedback only if we are not inside a transaction
+  // (e.g. we can be already in a transaction if we are running in a
+  // Lua script app.transaction()).
+  const bool showTooltip = (doc->transaction() == nullptr);
+
+  Tx tx(writer, Strings::commands_DuplicateSlice());
   doc->notifyBeforeSlicesDuplication();
   for (auto* s : selectedSlices) {
     Slice* slice = new Slice(*s);
@@ -102,14 +107,12 @@ void DuplicateSliceCommand::onExecute(Context* context)
   if (selectedSlices.size() == 1)
     sliceName = selectedSlices[0]->name();
 
-  StatusBar::instance()->invalidate();
-  if (!sliceName.empty()) {
-    StatusBar::instance()->showTip(1000, Strings::duplicate_slice_x_duplicated(sliceName));
-  }
-  else {
-    StatusBar::instance()->showTip(
-      1000,
-      Strings::duplicate_slice_n_slices_duplicated(selectedSlices.size()));
+  auto* statusBar = StatusBar::instance();
+  if (showTooltip && statusBar && context->isUIAvailable()) {
+    if (!sliceName.empty())
+      statusBar->showTip(1000, Strings::duplicate_slice_x_duplicated(sliceName));
+    else
+      statusBar->showTip(1000, Strings::duplicate_slice_n_slices_duplicated(selectedSlices.size()));
   }
 }
 

--- a/src/app/commands/cmd_remove_layer.cpp
+++ b/src/app/commands/cmd_remove_layer.cpp
@@ -132,8 +132,14 @@ void RemoveLayerCommand::onExecute(Context* context)
   ContextWriter writer(context);
   Doc* document(writer.document());
   Sprite* sprite(writer.sprite());
+
+  // Show the tooltip feedback only if we are not inside a transaction
+  // (e.g. we can be already in a transaction if we are running in a
+  // Lua script app.transaction()).
+  const bool showTooltip = (document->transaction() == nullptr);
+
   {
-    Tx tx(writer, "Remove Layer");
+    Tx tx(writer, Strings::commands_RemoveLayer());
     DocApi api = document->getApi(tx);
     // We need to remove all the tilesets after the tilemaps are deleted
     // and in descending tileset index order, otherwise the tileset indexes
@@ -162,6 +168,9 @@ void RemoveLayerCommand::onExecute(Context* context)
                                              tsiToDelete)) {
         return;
       }
+
+      if (deletedTopLevelLayers <= 1 && selLayers.size() == 1)
+        layerName = (*selLayers.begin())->name();
 
       for (Layer* layer : selLayers) {
         api.removeLayer(layer);
@@ -200,12 +209,12 @@ void RemoveLayerCommand::onExecute(Context* context)
   if (context->isUIAvailable()) {
     update_screen_for_document(document);
 
-    StatusBar::instance()->invalidate();
-    if (!layerName.empty()) {
-      StatusBar::instance()->showTip(1000, Strings::remove_layer_x_removed(layerName));
-    }
-    else {
-      StatusBar::instance()->showTip(1000, Strings::remove_layer_layers_removed());
+    auto* statusBar = StatusBar::instance();
+    if (showTooltip && statusBar) {
+      if (!layerName.empty())
+        statusBar->showTip(1000, Strings::remove_layer_x_removed(layerName));
+      else
+        statusBar->showTip(1000, Strings::remove_layer_layers_removed());
     }
   }
 }

--- a/src/app/commands/cmd_remove_slice.cpp
+++ b/src/app/commands/cmd_remove_slice.cpp
@@ -98,7 +98,7 @@ void RemoveSliceCommand::onExecute(Context* context)
     ContextWriter writer(reader);
     Doc* document(writer.document());
     Sprite* sprite(writer.sprite());
-    Tx tx(writer, "Remove Slice");
+    Tx tx(writer, Strings::commands_RemoveSlice());
 
     for (auto slice : slicesToDelete.iterateAs<Slice>()) {
       ASSERT(slice);
@@ -117,15 +117,12 @@ void RemoveSliceCommand::onExecute(Context* context)
     document->notifyGeneralUpdate();
   }
 
-  if (context->isUIAvailable()) {
-    StatusBar::instance()->invalidate();
-    if (!sliceName.empty()) {
-      StatusBar::instance()->showTip(1000, Strings::remove_slice_x_removed(sliceName));
-    }
-    else {
-      StatusBar::instance()->showTip(1000,
-                                     Strings::remove_slice_n_slices_removed(slicesToDelete.size()));
-    }
+  auto* statusBar = StatusBar::instance();
+  if (statusBar && context->isUIAvailable()) {
+    if (!sliceName.empty())
+      statusBar->showTip(1000, Strings::remove_slice_x_removed(sliceName));
+    else
+      statusBar->showTip(1000, Strings::remove_slice_n_slices_removed(slicesToDelete.size()));
   }
 }
 

--- a/src/app/commands/cmd_undo.cpp
+++ b/src/app/commands/cmd_undo.cpp
@@ -96,17 +96,16 @@ void UndoCommand::onExecute(Context* context)
   else
     docRangeStream = undo->nextRedoDocRange();
 
-  StatusBar* statusbar = StatusBar::instance();
-  if (statusbar) {
+  if (auto* statusBar = StatusBar::instance()) {
     std::string msg;
     if (m_type == Undo)
       msg = "Undid " + undo->nextUndoLabel();
     else
       msg = "Redid " + undo->nextRedoLabel();
     if (Preferences::instance().undo.showTooltip())
-      statusbar->showTip(1000, msg);
+      statusBar->showTip(1000, msg);
     else
-      statusbar->setStatusText(0, msg);
+      statusBar->setStatusText(0, msg);
   }
 
   // Effectively undo/redo.


### PR DESCRIPTION
Fixes #5862 and other instances of this happening, I've also taken the liberty of fixing an instance of potential `StatusBar` use when no UI is available, localized strings for transactions and improved the Remove Layer tooltip when coming from a timeline right click > remove.