### PR TITLE
Allow MoveMask quantity to be 0 (fix #5843)

### DIFF
--- a/src/app/commands/cmd_move_mask.cpp
+++ b/src/app/commands/cmd_move_mask.cpp
@@ -70,14 +70,20 @@ bool MoveMaskCommand::onEnabled(Context* context)
 
 void MoveMaskCommand::onExecute(Context* context)
 {
+  if (m_moveThing.quantity <= 0)
+    return;
+
   gfx::Point delta = m_moveThing.getDelta(context);
+  const auto& moveString = m_moveThing.getFriendlyString();
 
   switch (m_target) {
     case Boundaries: {
       ContextWriter writer(context);
       Doc* document(writer.document());
       {
-        Tx tx(writer, "Move Selection", DoesntModifyDocument);
+        Tx tx(writer,
+              Strings::commands_MoveMask(Strings::commands_MoveMask_Boundaries(), moveString),
+              DoesntModifyDocument);
         gfx::Point pt = document->mask()->bounds().origin();
         document->getApi(tx).setMaskPosition(pt.x + delta.x, pt.y + delta.y);
         tx.commit();
@@ -92,7 +98,8 @@ void MoveMaskCommand::onExecute(Context* context)
         ContextWriter writer(context);
         if (writer.cel()) {
           // Rotate content
-          Tx tx(writer, "Shift Pixels");
+          Tx tx(writer,
+                Strings::commands_MoveMask(Strings::commands_MoveMask_Content(), moveString));
           tx(new cmd::ShiftMaskedCel(writer.cel(), delta.x, delta.y));
           tx.commit();
         }

--- a/src/app/commands/move_thing.cpp
+++ b/src/app/commands/move_thing.cpp
@@ -52,7 +52,7 @@ void MoveThing::onLoadParams(const Params& params)
     units = ViewportHeight;
 
   int q = params.get_as<int>("quantity");
-  quantity = std::max<int>(1, q);
+  quantity = std::max<int>(0, q);
 }
 
 std::string MoveThing::getFriendlyString() const


### PR DESCRIPTION
Fixes #5843 allowing MoveMask `quantity` to be zero, where it does nothing. Recommended to test this with #5874 otherwise attempting to undo things results in weird locks.