### PR TITLE
Add Lospec palette-list integration to the palettes popup

### DIFF
--- a/.github/workflows/package-macos.yml
+++ b/.github/workflows/package-macos.yml
@@ -1,0 +1,76 @@
+name: package-macos
+on:
+  # Build a ready-to-run macOS app on every push to a feature branch,
+  # and allow triggering it manually from the Actions tab.
+  push:
+    branches:
+      - 'feature/**'
+      - 'lospec/**'
+  workflow_dispatch:
+
+jobs:
+  package-macos:
+    runs-on: macos-latest
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
+
+    - name: Install Skia
+      shell: bash
+      run: |
+        skia_url=$(source laf/misc/skia-url.sh release macos arm64 | xargs)
+        skia_file=$(basename "$skia_url")
+        curl --ssl-revoke-best-effort -L -o "$skia_file" "$skia_url"
+        unzip -q "$skia_file" -d skia
+
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2.17
+      with:
+        key: package-macos-arm64
+
+    - uses: aseprite/get-ninja@main
+
+    - name: Generating Makefiles
+      shell: bash
+      run: |
+        cmake -S . -B build -G Ninja \
+          -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          -DCMAKE_OSX_ARCHITECTURES=arm64 \
+          -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 \
+          -DENABLE_CCACHE=on \
+          -DLAF_BACKEND=skia \
+          -DSKIA_DIR=$(realpath skia) \
+          -DSKIA_LIBRARY_DIR=$(realpath skia/out/Release-arm64)
+
+    - name: Compiling
+      shell: bash
+      run: |
+        cd build && ninja aseprite
+
+    - name: Ad-hoc code signing
+      shell: bash
+      run: |
+        # Ad-hoc sign the bundle so macOS treats it as a valid (though
+        # unidentified) app. You'll still need to allow it once via
+        # right-click > Open, or by removing the quarantine attribute:
+        #   xattr -dr com.apple.quarantine Aseprite.app
+        codesign --force --deep --sign - build/bin/Aseprite.app
+        codesign --verify --verbose build/bin/Aseprite.app || true
+
+    - name: Packaging
+      shell: bash
+      run: |
+        cd build/bin
+        # Use ditto to preserve the bundle structure, symlinks and the
+        # code signature inside the zip.
+        ditto -c -k --sequesterRsrc --keepParent Aseprite.app ../../Aseprite-macOS-arm64.zip
+
+    - name: Upload app artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: Aseprite-macOS-arm64
+        path: Aseprite-macOS-arm64.zip
+        if-no-files-found: error
+        retention-days: 14

--- a/data/strings/en.ini
+++ b/data/strings/en.ini
@@ -1685,6 +1685,17 @@ alpha_channel = Create entries with alpha component
 [palette_popup]
 load = &Load
 open_folder = Open &Folder
+lospec = Lospec
+lospec_tooltip = Browse Lospec.com palettes (type a tag like "gameboy" to filter, or leave empty for popular ones)
+color_filter_tooltip = Filter palettes by number of colors
+import = &Import
+import_use = Import && &Use
+
+[lospec_listbox]
+problem_loading = Problem loading palettes, click to retry
+no_results = No palettes found (try a tag like "fantasy", "pastel" or "gameboy")
+loading = Loading palettes...
+loading_progress = Loading palettes... ({0}/{1})
 
 [palette_popup_menu]
 title = Palette

--- a/data/widgets/palette_popup.xml
+++ b/data/widgets/palette_popup.xml
@@ -5,11 +5,16 @@
   <vbox id="palette_popup">
     <hbox>
       <search id="search" magnet="true" expansive="true" debounce="250" />
+      <combobox id="color_filter" tooltip="@.color_filter_tooltip" tooltip_dir="bottom" />
       <button text="" id="refresh" style="refresh_button" />
+      <button id="lospec" text="@.lospec" tooltip="@.lospec_tooltip" tooltip_dir="bottom" />
     </hbox>
     <view id="view" expansive="true" />
+    <view id="lospec_view" expansive="true" />
     <hbox>
       <button id="load_pal" text="@.load" minwidth="80" magnet="true" />
+      <button id="import_pal" text="@.import" minwidth="80" magnet="true" />
+      <button id="import_use_pal" text="@.import_use" minwidth="100" />
       <hbox expansive="true" />
       <button id="open_folder" text="@.open_folder" minwidth="60" />
     </hbox>

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -816,6 +816,17 @@ target_include_directories(app-lib PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 
 if(REQUIRE_CURL)
   target_link_libraries(app-lib net-lib)
+
+  # Lospec palette-list integration (requires HTTP/curl).
+  target_compile_definitions(app-lib PUBLIC -DENABLE_LOSPEC)
+  target_sources(app-lib PRIVATE
+    lospec.cpp
+    ui/lospec_listbox.cpp)
+  # http_loader.cpp is also needed by the Lospec feature; only add it
+  # here if it wasn't already added by ENABLE_NEWS.
+  if(NOT ENABLE_NEWS)
+    target_sources(app-lib PRIVATE res/http_loader.cpp)
+  endif()
 endif()
 
 # Enable loading Steam API

--- a/src/app/lospec.cpp
+++ b/src/app/lospec.cpp
@@ -1,0 +1,197 @@
+// Aseprite
+// Copyright (C) 2024  Igara Studio S.A.
+//
+// This program is distributed under the terms of
+// the End-User License Agreement for Aseprite.
+
+#ifdef HAVE_CONFIG_H
+  #include "config.h"
+#endif
+
+#include "app/lospec.h"
+
+#include "base/replace_string.h"
+
+#include "json11.hpp"
+
+#include <cstdlib>
+
+namespace app {
+namespace lospec {
+
+namespace {
+
+// URL-encodes a search term in a minimal way (enough for typical
+// palette names: letters, digits, spaces and a few punctuation marks).
+std::string url_encode(const std::string& str)
+{
+  std::string out;
+  out.reserve(str.size() * 3);
+  for (const unsigned char ch : str) {
+    if ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') ||
+        ch == '-' || ch == '_' || ch == '.' || ch == '~') {
+      out.push_back(char(ch));
+    }
+    else if (ch == ' ') {
+      out.push_back('+');
+    }
+    else {
+      char buf[4];
+      std::snprintf(buf, sizeof(buf), "%%%02X", int(ch));
+      out += buf;
+    }
+  }
+  return out;
+}
+
+// Parses a "rrggbb" (or "#rrggbb") hex string into an RGBA value.
+// Returns true on success.
+bool parse_hex_color(const std::string& hex, uint32_t& out)
+{
+  std::string h = hex;
+  if (!h.empty() && h[0] == '#')
+    h = h.substr(1);
+  if (h.size() != 6)
+    return false;
+
+  char* end = nullptr;
+  const unsigned long value = std::strtoul(h.c_str(), &end, 16);
+  if (end != h.c_str() + 6)
+    return false;
+
+  const uint32_t r = (value >> 16) & 0xff;
+  const uint32_t g = (value >> 8) & 0xff;
+  const uint32_t b = (value) & 0xff;
+  out = (uint32_t(0xff) << 24) | (b << 16) | (g << 8) | r; // doc::rgba layout
+  return true;
+}
+
+// Removes icons/emoji from a palette title. Lospec titles are UTF-8 and
+// some of them include emoji (e.g. "👌31" or "👍 31"); these multi-byte
+// sequences render poorly in the list, so we drop all non-ASCII bytes
+// and collapse the resulting whitespace. Plain ASCII titles (the vast
+// majority) are left untouched.
+std::string clean_title(const std::string& title)
+{
+  std::string out;
+  out.reserve(title.size());
+  for (const unsigned char ch : title) {
+    // Keep printable ASCII only (0x20-0x7E); drop UTF-8 multi-byte
+    // bytes (>= 0x80, i.e. emoji/icons) and control characters.
+    if (ch >= 0x20 && ch < 0x7f)
+      out.push_back(char(ch));
+    else
+      out.push_back(' '); // Replace removed glyphs with a space so words don't merge.
+  }
+
+  // Collapse consecutive spaces into one.
+  std::string collapsed;
+  collapsed.reserve(out.size());
+  bool prevSpace = false;
+  for (const char ch : out) {
+    const bool isSpace = (ch == ' ');
+    if (isSpace && prevSpace)
+      continue;
+    collapsed.push_back(ch);
+    prevSpace = isSpace;
+  }
+
+  // Trim leading/trailing spaces.
+  const auto first = collapsed.find_first_not_of(' ');
+  if (first == std::string::npos)
+    return std::string();
+  const auto last = collapsed.find_last_not_of(' ');
+  return collapsed.substr(first, last - first + 1);
+}
+
+} // anonymous namespace
+
+std::string make_search_url(const std::string& query,
+                            int page,
+                            ColorFilter filter,
+                            int colorNumber)
+{
+  if (page < 1)
+    page = 1;
+
+  const char* filterType = "any";
+  switch (filter) {
+    case ColorFilter::Exact: filterType = "exact"; break;
+    case ColorFilter::Min:   filterType = "min"; break;
+    case ColorFilter::Max:   filterType = "max"; break;
+    case ColorFilter::Any:   filterType = "any"; break;
+  }
+
+  // colorNumber is only meaningful when an actual filter is selected.
+  const int number = (filter == ColorFilter::Any ? 0 : colorNumber);
+
+  // The Lospec palette-list "load" endpoint returns a JSON document
+  // with a "palettes" array. When the tag is empty it returns the
+  // most popular palettes.
+  std::string url = "https://lospec.com/palette-list/load"
+                    "?colorNumberFilterType=" +
+                    std::string(filterType) + "&colorNumber=" + std::to_string(number) +
+                    "&page=" + std::to_string(page) + "&tag=" + url_encode(query) +
+                    "&sortingType=default";
+  return url;
+}
+
+std::string make_download_url(const std::string& slug)
+{
+  return "https://lospec.com/palette-list/" + slug + ".gpl";
+}
+
+bool parse_search_result(const std::string& json,
+                         std::vector<PaletteInfo>& result,
+                         int* totalCount)
+{
+  std::string err;
+  const json11::Json doc = json11::Json::parse(json, err);
+  if (!err.empty() || !doc.is_object())
+    return false;
+
+  if (totalCount) {
+    const json11::Json& tc = doc["totalCount"];
+    if (tc.is_number())
+      *totalCount = tc.int_value();
+  }
+
+  const json11::Json& palettes = doc["palettes"];
+  if (!palettes.is_array())
+    return false;
+
+  for (const json11::Json& pal : palettes.array_items()) {
+    if (!pal.is_object())
+      continue;
+
+    PaletteInfo info;
+    info.title = clean_title(pal["title"].string_value());
+    info.slug = pal["slug"].string_value();
+
+    // Skip palettes that we wouldn't be able to download.
+    if (info.slug.empty())
+      continue;
+    // Fall back to the slug if the title was empty or consisted only
+    // of icons/emoji that were stripped out.
+    if (info.title.empty())
+      info.title = info.slug;
+
+    // "colors" (and the equivalent "colorsArray") is an array of hex
+    // strings without the leading '#'.
+    const json11::Json& colors = pal["colors"];
+    if (colors.is_array()) {
+      for (const json11::Json& c : colors.array_items()) {
+        uint32_t rgba;
+        if (c.is_string() && parse_hex_color(c.string_value(), rgba))
+          info.colors.push_back(rgba);
+      }
+    }
+
+    result.push_back(std::move(info));
+  }
+
+  return true;
+}
+
+} // namespace lospec
+} // namespace app

--- a/src/app/lospec.h
+++ b/src/app/lospec.h
@@ -1,0 +1,59 @@
+// Aseprite
+// Copyright (C) 2024  Igara Studio S.A.
+//
+// This program is distributed under the terms of
+// the End-User License Agreement for Aseprite.
+
+#ifndef APP_LOSPEC_H_INCLUDED
+#define APP_LOSPEC_H_INCLUDED
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace app {
+namespace lospec {
+
+// Information about a single palette available on the Lospec
+// palette-list (https://lospec.com/palette-list).
+struct PaletteInfo {
+  std::string title; // Human readable palette name, e.g. "Resurrect 64".
+  std::string slug;  // URL slug used to download the palette, e.g. "resurrect-64".
+  std::vector<uint32_t> colors; // RGBA colors for the on-screen preview.
+};
+
+// How the colorNumber value is applied when filtering the
+// palette-list by number of colors.
+enum class ColorFilter {
+  Any,   // No filtering (colorNumber is ignored).
+  Exact, // Palettes with exactly colorNumber colors.
+  Min,   // Palettes with at least colorNumber colors.
+  Max,   // Palettes with at most colorNumber colors.
+};
+
+// Returns the URL used to query the Lospec palette-list for the given
+// search term and (1-based) page number. The returned URL produces a
+// JSON document. The result can optionally be filtered by number of
+// colors (filter + colorNumber).
+std::string make_search_url(const std::string& query,
+                            int page,
+                            ColorFilter filter = ColorFilter::Any,
+                            int colorNumber = 0);
+
+// Returns the URL to download the given palette slug as a GIMP
+// palette (.gpl) file, which Aseprite can load natively.
+std::string make_download_url(const std::string& slug);
+
+// Parses the JSON returned by make_search_url() into a list of
+// palettes. Returns false if the JSON could not be parsed. If
+// totalCount is not null, it is set to the total number of palettes
+// available for the query (across all pages).
+bool parse_search_result(const std::string& json,
+                         std::vector<PaletteInfo>& result,
+                         int* totalCount = nullptr);
+
+} // namespace lospec
+} // namespace app
+
+#endif

--- a/src/app/ui/lospec_listbox.cpp
+++ b/src/app/ui/lospec_listbox.cpp
@@ -1,0 +1,322 @@
+// Aseprite
+// Copyright (C) 2024  Igara Studio S.A.
+//
+// This program is distributed under the terms of
+// the End-User License Agreement for Aseprite.
+
+#ifdef HAVE_CONFIG_H
+  #include "config.h"
+#endif
+
+#include "app/ui/lospec_listbox.h"
+
+#include "app/i18n/strings.h"
+#include "app/res/http_loader.h"
+#include "app/ui/skin/skin_theme.h"
+#include "base/fstream_path.h"
+#include "doc/color.h"
+#include "ui/graphics.h"
+#include "ui/listitem.h"
+#include "ui/message.h"
+#include "ui/paint_event.h"
+#include "ui/size_hint_event.h"
+#include "ui/view.h"
+
+#include <algorithm>
+#include <fstream>
+#include <sstream>
+
+namespace app {
+
+using namespace app::skin;
+using namespace ui;
+
+namespace {
+
+// A list item that shows a Lospec palette name plus a preview row of
+// its colors.
+class LospecListItem : public ListItem {
+public:
+  LospecListItem(const lospec::PaletteInfo& info) : ListItem(info.title), m_info(info) {}
+
+  const lospec::PaletteInfo& info() const { return m_info; }
+
+protected:
+  void onSizeHint(SizeHintEvent& ev) override
+  {
+    ev.setSizeHint(gfx::Size(0, (2 + 8 + 2 + 8 + 2) * guiscale()));
+  }
+
+  void onPaint(PaintEvent& ev) override
+  {
+    auto theme = SkinTheme::get(this);
+    Graphics* g = ev.graphics();
+    gfx::Rect bounds = clientBounds();
+    gfx::Color bgcolor, fgcolor;
+
+    if (isSelected()) {
+      bgcolor = theme->colors.listitemSelectedFace();
+      fgcolor = theme->colors.listitemSelectedText();
+    }
+    else {
+      bgcolor = theme->colors.listitemNormalFace();
+      fgcolor = theme->colors.listitemNormalText();
+    }
+
+    g->fillRect(bgcolor, bounds);
+
+    g->drawText(this->text(),
+                fgcolor,
+                gfx::ColorNone,
+                gfx::Point(bounds.x + 2 * guiscale(), bounds.y + 2 * guiscale()));
+
+    // Color preview row.
+    if (!m_info.colors.empty()) {
+      const int sw = 4 * guiscale();
+      gfx::Rect box(bounds.x + 2 * guiscale(),
+                    bounds.y + bounds.h - sw - 2 * guiscale(),
+                    sw,
+                    sw);
+      const int maxColors = std::min<int>(int(m_info.colors.size()),
+                                          std::max(1, (bounds.w - 4 * guiscale()) / sw));
+      for (int i = 0; i < maxColors; ++i) {
+        const doc::color_t c = m_info.colors[i];
+        g->fillRect(gfx::rgba(doc::rgba_getr(c), doc::rgba_getg(c), doc::rgba_getb(c)), box);
+        box.x += box.w;
+      }
+    }
+  }
+
+private:
+  lospec::PaletteInfo m_info;
+};
+
+// Plain message item (e.g. "No results" / "Problem loading" /
+// loading progress).
+class MessageItem : public ListItem {
+public:
+  MessageItem(const std::string& text) : ListItem(text) {}
+};
+
+} // anonymous namespace
+
+LospecListBox::LospecListBox() : m_timer(100, this), m_loader(nullptr)
+{
+  m_timer.Tick.connect(&LospecListBox::onTick, this);
+}
+
+LospecListBox::~LospecListBox()
+{
+  stopLoading();
+}
+
+void LospecListBox::search(const std::string& query,
+                          lospec::ColorFilter filter,
+                          int colorNumber)
+{
+  stopLoading();
+
+  m_query = query;
+  m_filter = filter;
+  m_colorNumber = colorNumber;
+  m_loadedCount = 0;
+  m_totalCount = -1;
+  m_progressItem = nullptr;
+  clearItems();
+
+  if (View* view = View::getView(this))
+    view->updateView();
+
+  // Start loading from the first page; the rest are fetched
+  // automatically as each page arrives.
+  m_loading = true;
+  startLoadingPage(1);
+}
+
+void LospecListBox::startLoadingPage(int page)
+{
+  m_page = page;
+  delete m_loader;
+  m_loader = new HttpLoader(lospec::make_search_url(m_query, page, m_filter, m_colorNumber));
+  if (!m_timer.isRunning())
+    m_timer.start();
+}
+
+void LospecListBox::stopLoading()
+{
+  m_loading = false;
+  if (m_timer.isRunning())
+    m_timer.stop();
+  if (m_loader) {
+    m_loader->abort();
+    delete m_loader;
+    m_loader = nullptr;
+  }
+}
+
+const lospec::PaletteInfo* LospecListBox::selectedPalette() const
+{
+  if (auto* item = dynamic_cast<LospecListItem*>(const_cast<LospecListBox*>(this)->getSelectedChild()))
+    return &item->info();
+  return nullptr;
+}
+
+void LospecListBox::clearItems()
+{
+  while (auto child = lastChild())
+    removeChild(child);
+}
+
+bool LospecListBox::onProcessMessage(ui::Message* msg)
+{
+  switch (msg->type()) {
+    case kCloseMessage:
+      if (m_loader)
+        m_loader->abort();
+      break;
+  }
+  return ListBox::onProcessMessage(msg);
+}
+
+void LospecListBox::onChange()
+{
+  // Forward double-clicks via DoubleClickItem in the popup; here we
+  // just keep default selection behavior.
+  ListBox::onChange();
+}
+
+void LospecListBox::updateProgress()
+{
+  if (!m_loading)
+    return;
+
+  std::string text;
+  if (m_totalCount > 0)
+    text = Strings::lospec_listbox_loading_progress(std::to_string(m_loadedCount),
+                                                    std::to_string(m_totalCount));
+  else
+    text = Strings::lospec_listbox_loading();
+
+  if (!m_progressItem) {
+    m_progressItem = new MessageItem(text);
+    addChild(m_progressItem);
+  }
+  else {
+    m_progressItem->setText(text);
+  }
+}
+
+void LospecListBox::onTick()
+{
+  if (!m_loader || !m_loader->isDone())
+    return;
+
+  const std::string fn = m_loader->filename();
+  delete m_loader;
+  m_loader = nullptr;
+
+  // Network/HTTP error.
+  if (fn.empty()) {
+    // If we already loaded some palettes, just stop quietly; otherwise
+    // show an error message.
+    if (m_loadedCount == 0) {
+      clearItems();
+      m_progressItem = nullptr;
+      addChild(new MessageItem(Strings::lospec_listbox_problem_loading()));
+    }
+    else if (m_progressItem) {
+      removeChild(m_progressItem);
+      delete m_progressItem;
+      m_progressItem = nullptr;
+    }
+    stopLoading();
+    if (View* view = View::getView(this))
+      view->updateView();
+    layout();
+    FinishLoading();
+    return;
+  }
+
+  const int added = parsePage(fn);
+
+  // Parse error on the very first page.
+  if (added < 0 && m_loadedCount == 0) {
+    clearItems();
+    m_progressItem = nullptr;
+    addChild(new MessageItem(Strings::lospec_listbox_problem_loading()));
+    stopLoading();
+    if (View* view = View::getView(this))
+      view->updateView();
+    layout();
+    FinishLoading();
+    return;
+  }
+
+  // No more palettes (empty page) -> we've reached the end.
+  const bool reachedEnd =
+    (added <= 0) || (m_totalCount > 0 && m_loadedCount >= m_totalCount);
+
+  if (reachedEnd) {
+    // Remove the progress indicator.
+    if (m_progressItem) {
+      removeChild(m_progressItem);
+      delete m_progressItem;
+      m_progressItem = nullptr;
+    }
+
+    if (m_loadedCount == 0)
+      addChild(new MessageItem(Strings::lospec_listbox_no_results()));
+
+    stopLoading();
+    if (View* view = View::getView(this))
+      view->updateView();
+    layout();
+    FinishLoading();
+    return;
+  }
+
+  // Otherwise keep loading the next page.
+  updateProgress();
+  if (View* view = View::getView(this))
+    view->updateView();
+  layout();
+
+  startLoadingPage(m_page + 1);
+}
+
+int LospecListBox::parsePage(const std::string& filename)
+{
+  std::string json;
+  {
+    std::ifstream f(FSTREAM_PATH(filename), std::ios::binary);
+    if (f) {
+      std::ostringstream ss;
+      ss << f.rdbuf();
+      json = ss.str();
+    }
+  }
+
+  std::vector<lospec::PaletteInfo> palettes;
+  int totalCount = -1;
+  if (json.empty() || !lospec::parse_search_result(json, palettes, &totalCount))
+    return -1;
+
+  if (totalCount >= 0)
+    m_totalCount = totalCount;
+
+  // Insert the new palettes before the progress item (which lives at
+  // the bottom of the list).
+  int insertIndex = getItemsCount();
+  if (m_progressItem)
+    --insertIndex;
+
+  for (const auto& info : palettes) {
+    auto* item = new LospecListItem(info);
+    insertChild(insertIndex++, item);
+  }
+
+  m_loadedCount += int(palettes.size());
+  return int(palettes.size());
+}
+
+} // namespace app

--- a/src/app/ui/lospec_listbox.h
+++ b/src/app/ui/lospec_listbox.h
@@ -1,0 +1,80 @@
+// Aseprite
+// Copyright (C) 2024  Igara Studio S.A.
+//
+// This program is distributed under the terms of
+// the End-User License Agreement for Aseprite.
+
+#ifndef APP_UI_LOSPEC_LISTBOX_H_INCLUDED
+#define APP_UI_LOSPEC_LISTBOX_H_INCLUDED
+#pragma once
+
+#include "app/lospec.h"
+#include "obs/signal.h"
+#include "ui/listbox.h"
+#include "ui/timer.h"
+
+#include <string>
+
+namespace app {
+
+class HttpLoader;
+
+// A list box that queries the Lospec palette-list online and shows the
+// resulting palettes (with a small color preview). All available pages
+// are fetched automatically (one after another) so the whole
+// palette-list becomes browsable. Double-clicking an item fires the
+// ImportPalette() signal so the palette can be downloaded and saved as
+// a local preset.
+class LospecListBox : public ui::ListBox {
+public:
+  LospecListBox();
+  ~LospecListBox();
+
+  // Starts an online search with the given term (empty term = all
+  // palettes, most popular first) and optional color-count filter.
+  // Cancels any in-flight request and begins loading from the first
+  // page.
+  void search(const std::string& query,
+              lospec::ColorFilter filter = lospec::ColorFilter::Any,
+              int colorNumber = 0);
+
+  // Returns the palette info for the currently selected item, or
+  // nullptr if nothing valid is selected.
+  const lospec::PaletteInfo* selectedPalette() const;
+
+  // Fired when the user picks a palette to import.
+  obs::signal<void(const lospec::PaletteInfo&)> ImportPalette;
+  // Fired when the whole search finished loading (all pages, or an
+  // error/empty result).
+  obs::signal<void()> FinishLoading;
+
+private:
+  bool onProcessMessage(ui::Message* msg) override;
+  void onTick();
+  void onChange() override;
+
+  void startLoadingPage(int page);
+  void stopLoading();
+  // Parses one downloaded page. Returns the number of palettes added,
+  // or -1 on a parse error.
+  int parsePage(const std::string& filename);
+  void clearItems();
+  void updateProgress();
+
+  std::string m_query;
+  lospec::ColorFilter m_filter = lospec::ColorFilter::Any;
+  int m_colorNumber = 0;
+  ui::Timer m_timer;
+  HttpLoader* m_loader;
+
+  // Pagination state.
+  int m_page = 0;           // Page currently being downloaded.
+  int m_loadedCount = 0;    // Number of palettes added so far.
+  int m_totalCount = -1;    // Total palettes reported by the API (-1 = unknown).
+  bool m_loading = false;   // True while we are still fetching pages.
+  ui::ListItem* m_progressItem = nullptr; // Shown at the bottom while loading.
+};
+
+} // namespace app
+
+#endif

--- a/src/app/ui/palette_popup.cpp
+++ b/src/app/ui/palette_popup.cpp
@@ -11,8 +11,10 @@
 
 #include "app/ui/palette_popup.h"
 
+#include "app/app.h"
 #include "app/commands/cmd_set_palette.h"
 #include "app/commands/commands.h"
+#include "app/i18n/strings.h"
 #include "app/launcher.h"
 #include "app/match_words.h"
 #include "app/res/palettes_loader_delegate.h"
@@ -22,6 +24,7 @@
 #include "app/ui_context.h"
 #include "ui/box.h"
 #include "ui/button.h"
+#include "ui/combobox.h"
 #include "ui/fit_bounds.h"
 #include "ui/keys.h"
 #include "ui/message.h"
@@ -29,15 +32,75 @@
 #include "ui/theme.h"
 #include "ui/view.h"
 
+#ifdef ENABLE_LOSPEC
+  #include "app/file/palette_file.h"
+  #include "app/modules/palettes.h"
+  #include "app/res/http_loader.h"
+  #include "base/fs.h"
+  #include "doc/palette.h"
+  #include "ui/alert.h"
+#endif
+
 #include "palette_popup.xml.h"
 
 namespace app {
 
 using namespace ui;
 
+#ifdef ENABLE_LOSPEC
+namespace {
+
+// Turns a Lospec palette title into a safe filename (without
+// extension) to be used as a preset name.
+std::string sanitize_preset_name(const std::string& title)
+{
+  std::string out;
+  out.reserve(title.size());
+  for (const char ch : title) {
+    if ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') ||
+        ch == ' ' || ch == '-' || ch == '_' || ch == '.' || ch == '(' || ch == ')') {
+      out.push_back(ch);
+    }
+    else {
+      out.push_back('_');
+    }
+  }
+  // Trim surrounding spaces/dots that could be problematic.
+  while (!out.empty() && (out.front() == ' ' || out.front() == '.'))
+    out.erase(out.begin());
+  while (!out.empty() && (out.back() == ' ' || out.back() == '.'))
+    out.pop_back();
+  if (out.empty())
+    out = "lospec-palette";
+  return out;
+}
+
+// Options offered in the color-count filter combo box (in order).
+struct ColorFilterOption {
+  const char* label;
+  lospec::ColorFilter filter;
+  int colorNumber;
+};
+
+const ColorFilterOption kColorFilterOptions[] = {
+  { "Any colors", lospec::ColorFilter::Any,   0  },
+  { "4 colors",   lospec::ColorFilter::Exact, 4  },
+  { "8 colors",   lospec::ColorFilter::Exact, 8  },
+  { "16 colors",  lospec::ColorFilter::Exact, 16 },
+  { "32 colors",  lospec::ColorFilter::Exact, 32 },
+  { "64 colors",  lospec::ColorFilter::Exact, 64 },
+  { "64+ colors", lospec::ColorFilter::Min,   64 },
+};
+
+} // anonymous namespace
+#endif // ENABLE_LOSPEC
+
 PalettePopup::PalettePopup()
   : PopupWindow("Palettes", ClickBehavior::CloseOnClickInOtherWindow)
   , m_popup(new gen::PalettePopup())
+#ifdef ENABLE_LOSPEC
+  , m_importTimer(100, this)
+#endif
 {
   setAutoRemap(false);
   setEnterBehavior(EnterBehavior::DoNothingOnEnter);
@@ -55,14 +118,61 @@ PalettePopup::PalettePopup()
 
   m_paletteListBox.PalChange.connect(&PalettePopup::onPalChange, this);
 
+#ifdef ENABLE_LOSPEC
+  // Lospec online mode.
+  m_popup->lospec()->Click.connect([this] { onToggleLospec(); });
+  m_popup->importPal()->Click.connect([this] { onImportPal(); });
+  m_popup->importUsePal()->Click.connect([this] { onImportUsePal(); });
+  m_popup->lospecView()->attachToView(&m_lospecListBox);
+  m_lospecListBox.DoubleClickItem.connect([this] { onImportPal(); });
+  m_lospecListBox.Change.connect([this] { onLospecSelChange(); });
+  m_lospecListBox.FinishLoading.connect([this] { onLospecSelChange(); });
+  m_lospecListBox.ImportPalette.connect(
+    [this](const lospec::PaletteInfo& info) { onImportPalette(info, false); });
+  m_importTimer.Tick.connect([this] { onTick(); });
+
+  // Populate the color-count filter combo box.
+  for (const auto& opt : kColorFilterOptions)
+    m_popup->colorFilter()->addItem(opt.label);
+  m_popup->colorFilter()->setSelectedItemIndex(0);
+  m_popup->colorFilter()->Change.connect([this] { startLospecSearch(); });
+
+  // Start in local-presets mode.
+  setLospecMode(false);
+#else
+  // No Lospec support: hide the related widgets.
+  m_popup->lospec()->setVisible(false);
+  m_popup->importPal()->setVisible(false);
+  m_popup->importUsePal()->setVisible(false);
+  m_popup->lospecView()->setVisible(false);
+  m_popup->colorFilter()->setVisible(false);
+#endif
+
   InitTheme.connect([this] { setBorder(gfx::Border(4 * guiscale())); });
   initTheme();
+}
+
+PalettePopup::~PalettePopup()
+{
+#ifdef ENABLE_LOSPEC
+  if (m_importTimer.isRunning())
+    m_importTimer.stop();
+  if (m_importLoader) {
+    m_importLoader->abort();
+    delete m_importLoader;
+    m_importLoader = nullptr;
+  }
+#endif
 }
 
 void PalettePopup::showPopup(ui::Display* display, const gfx::Rect& buttonPos)
 {
   m_popup->loadPal()->setEnabled(false);
   m_popup->openFolder()->setEnabled(false);
+#ifdef ENABLE_LOSPEC
+  m_popup->importPal()->setEnabled(false);
+  m_popup->importUsePal()->setEnabled(false);
+#endif
   m_paletteListBox.selectChild(NULL);
 
   fit_bounds(display,
@@ -98,6 +208,11 @@ bool PalettePopup::onProcessMessage(ui::Message* msg)
 
 void PalettePopup::onPalChange(const doc::Palette* palette)
 {
+#ifdef ENABLE_LOSPEC
+  if (m_lospecMode)
+    return;
+#endif
+
   const bool state = (UIContext::instance()->activeDocument() && palette != nullptr);
 
   m_popup->loadPal()->setEnabled(state);
@@ -106,6 +221,14 @@ void PalettePopup::onPalChange(const doc::Palette* palette)
 
 void PalettePopup::onSearchChange()
 {
+#ifdef ENABLE_LOSPEC
+  // In Lospec mode the search box queries the online palette list.
+  if (m_lospecMode) {
+    startLospecSearch();
+    return;
+  }
+#endif
+
   MatchWords match(m_popup->search()->text());
   bool selected = false;
 
@@ -130,6 +253,12 @@ void PalettePopup::onSearchChange()
 
 void PalettePopup::onRefresh()
 {
+#ifdef ENABLE_LOSPEC
+  if (m_lospecMode) {
+    startLospecSearch();
+    return;
+  }
+#endif
   m_paletteListBox.reload();
 }
 
@@ -156,5 +285,158 @@ void PalettePopup::onOpenFolder()
 
   launcher::open_folder(res->path());
 }
+
+// ----------------------------------------------------------------------
+// Lospec online mode
+
+#ifdef ENABLE_LOSPEC
+
+void PalettePopup::onToggleLospec()
+{
+  setLospecMode(!m_lospecMode);
+}
+
+void PalettePopup::startLospecSearch()
+{
+  int idx = m_popup->colorFilter()->getSelectedItemIndex();
+  if (idx < 0 || idx >= int(sizeof(kColorFilterOptions) / sizeof(kColorFilterOptions[0])))
+    idx = 0;
+
+  const ColorFilterOption& opt = kColorFilterOptions[idx];
+  m_lospecListBox.search(m_popup->search()->text(), opt.filter, opt.colorNumber);
+}
+
+void PalettePopup::setLospecMode(bool online)
+{
+  m_lospecMode = online;
+
+  m_popup->view()->setVisible(!online);
+  m_popup->lospecView()->setVisible(online);
+
+  // The load/open-folder buttons only make sense for local presets,
+  // while the import buttons only make sense for the online list.
+  m_popup->loadPal()->setVisible(!online);
+  m_popup->openFolder()->setVisible(!online);
+  m_popup->importPal()->setVisible(online);
+  m_popup->importUsePal()->setVisible(online);
+
+  // The color-count filter only applies to the online list.
+  m_popup->colorFilter()->setVisible(online);
+
+  m_popup->lospec()->setSelected(online);
+
+  // Clear the search box when switching modes.
+  m_popup->search()->setText("");
+
+  updateButtons();
+
+  if (online) {
+    // Reset the color filter and load the most popular palettes.
+    m_popup->colorFilter()->setSelectedItemIndex(0);
+    startLospecSearch();
+  }
+  else {
+    onSearchChange();
+  }
+
+  layout();
+}
+
+void PalettePopup::onLospecSelChange()
+{
+  updateButtons();
+}
+
+void PalettePopup::updateButtons()
+{
+  if (m_lospecMode) {
+    const bool hasSel = (m_lospecListBox.selectedPalette() != nullptr);
+    const bool idle = (m_importLoader == nullptr);
+    m_popup->importPal()->setEnabled(hasSel && idle);
+    // "Import & Use" additionally needs an active sprite to apply the
+    // palette to.
+    m_popup->importUsePal()->setEnabled(hasSel && idle &&
+                                        UIContext::instance()->activeDocument() != nullptr);
+  }
+}
+
+void PalettePopup::onImportPal()
+{
+  const lospec::PaletteInfo* info = m_lospecListBox.selectedPalette();
+  if (info)
+    onImportPalette(*info, false);
+}
+
+void PalettePopup::onImportUsePal()
+{
+  const lospec::PaletteInfo* info = m_lospecListBox.selectedPalette();
+  if (info)
+    onImportPalette(*info, true);
+}
+
+void PalettePopup::onImportPalette(const lospec::PaletteInfo& info, bool andUse)
+{
+  // Already importing something.
+  if (m_importLoader)
+    return;
+
+  m_importAndUse = andUse;
+  m_importTitle = info.title;
+  m_importLoader = new HttpLoader(lospec::make_download_url(info.slug));
+  m_importTimer.start();
+  updateButtons();
+}
+
+void PalettePopup::onTick()
+{
+  if (!m_importLoader || !m_importLoader->isDone())
+    return;
+
+  const std::string fn = m_importLoader->filename();
+  const std::string title = m_importTitle;
+
+  delete m_importLoader;
+  m_importLoader = nullptr;
+  m_importTimer.stop();
+
+  if (fn.empty()) {
+    ui::Alert::show(Strings::alerts_error_loading_file(title));
+    updateButtons();
+    return;
+  }
+
+  // Load the downloaded .gpl and save it as a preset so it shows up in
+  // the local palette list.
+  std::unique_ptr<doc::Palette> pal = load_palette(fn.c_str());
+  if (!pal) {
+    ui::Alert::show(Strings::alerts_error_loading_file(title));
+    updateButtons();
+    return;
+  }
+
+  const std::string preset = sanitize_preset_name(title);
+  const std::string presetFn = get_preset_palette_filename(preset, ".gpl");
+  if (!save_palette(presetFn.c_str(), pal.get(), 0, nullptr)) {
+    ui::Alert::show(Strings::alerts_error_saving_file(presetFn));
+    updateButtons();
+    return;
+  }
+
+  // Reload the local presets list so the new palette appears there.
+  App::instance()->PalettePresetsChange();
+
+  // Optionally apply the imported palette to the active sprite.
+  if (m_importAndUse) {
+    SetPaletteCommand* cmd = static_cast<SetPaletteCommand*>(
+      Commands::instance()->byId(CommandId::SetPalette()));
+    cmd->setPalette(pal.get());
+    UIContext::instance()->executeCommandFromMenuOrShortcut(cmd);
+  }
+
+  m_importAndUse = false;
+  updateButtons();
+}
+
+#endif // ENABLE_LOSPEC
 
 } // namespace app

--- a/src/app/ui/palette_popup.h
+++ b/src/app/ui/palette_popup.h
@@ -12,6 +12,14 @@
 #include "app/ui/palettes_listbox.h"
 #include "ui/popup_window.h"
 
+#include <string>
+
+#ifdef ENABLE_LOSPEC
+  #include "app/lospec.h"
+  #include "app/ui/lospec_listbox.h"
+  #include "ui/timer.h"
+#endif
+
 namespace ui {
 class Button;
 class View;
@@ -23,9 +31,12 @@ namespace gen {
 class PalettePopup;
 }
 
+class HttpLoader;
+
 class PalettePopup : public ui::PopupWindow {
 public:
   PalettePopup();
+  ~PalettePopup();
 
   void showPopup(ui::Display* display, const gfx::Rect& buttonPos);
 
@@ -38,9 +49,38 @@ protected:
   void onLoadPal();
   void onOpenFolder();
 
+#ifdef ENABLE_LOSPEC
+  // Lospec online mode.
+  void onToggleLospec();
+  void setLospecMode(bool online);
+  void onLospecSelChange();
+  void onImportPal();
+  void onImportUsePal();
+  void onImportPalette(const lospec::PaletteInfo& info, bool andUse);
+  void onTick();
+  void updateButtons();
+  // Reads the search term + color-count filter from the widgets and
+  // starts a new Lospec search.
+  void startLospecSearch();
+#endif
+
 private:
   gen::PalettePopup* m_popup;
   PalettesListBox m_paletteListBox;
+
+#ifdef ENABLE_LOSPEC
+  LospecListBox m_lospecListBox;
+  bool m_lospecMode = false;
+
+  // Background download of the selected Lospec palette to save it as a
+  // preset.
+  ui::Timer m_importTimer;
+  HttpLoader* m_importLoader = nullptr;
+  std::string m_importTitle;
+  // True if the downloaded palette should also be applied to the active
+  // sprite after importing it.
+  bool m_importAndUse = false;
+#endif
 };
 
 } // namespace app


### PR DESCRIPTION
## Summary

Adds an online **Lospec** mode to the palette presets popup (color bar → **PRESETS**) so users can browse and import palettes directly from [lospec.com/palette-list](https://lospec.com/palette-list) without leaving Aseprite.

## What's new

- **Lospec client** (`app/lospec.{h,cpp}`): builds the palette-list query URL and the per-slug `.gpl` download URL, and parses the JSON results using `json11`. Palette titles are cleaned of emoji/icons so they render nicely in the list.
- **`LospecListBox`** (`app/ui/lospec_listbox.{h,cpp}`): asynchronously fetches the palette list via the existing `HttpLoader`, **paginating through all pages** (with a progress indicator at the bottom), and draws a small color preview for every palette.
- **Palette popup integration** (`app/ui/palette_popup.{h,cpp}`):
  - A **Lospec** button toggles between the local presets and the online list.
  - The search box filters by **tag** (e.g. `gameboy`, `fantasy`), and a combo box filters by **number of colors** (Any / 4 / 8 / 16 / 32 / 64 / 64+).
  - **Import** downloads the selected palette and saves it as a local preset (`.gpl`).
  - **Import & Use** does the same and additionally applies the palette to the active sprite.

## Implementation notes

- Reuses existing infrastructure: `load_palette()` / `save_palette()`, the preset-directory helpers (`get_preset_palette_filename()`), and the `PalettePresetsChange` signal so imported palettes appear in the local list automatically.
- Downloads run on a background thread (`HttpLoader` + `ui::Timer`), following the same pattern as `NewsListBox`, so the UI stays responsive.
- The whole feature is gated behind a new `ENABLE_LOSPEC` compile definition, enabled when curl is available (i.e. together with `ENABLE_NEWS` / `ENABLE_UPDATER`). Builds without curl compile unchanged.

## Testing

- Built on macOS (arm64, Skia `m124`) and exercised manually: toggling the Lospec mode, tag search, the color-count filter, full pagination of all ~4300 palettes, and both Import and Import & Use.
- Verified the Lospec endpoints and parameter mappings against the live API (tag filtering, `colorNumberFilterType` = `exact`/`min`, combined tag + color-count queries).