### PR TITLE
Ensure BoolPrefWidget selection counts as modification (fix #5885)

### DIFF
--- a/src/app/ui/pref_widget.h
+++ b/src/app/ui/pref_widget.h
@@ -47,6 +47,7 @@ public:
 
       // Load option value
       this->setSelected((*m_option)());
+      m_modifiedByUser = false;
     }
   }
 
@@ -73,6 +74,12 @@ protected:
   void onClick() override
   {
     Base::onClick();
+    m_modifiedByUser = true;
+  }
+
+  void onSelect(bool selected) override
+  {
+    Base::onSelect(selected);
     m_modifiedByUser = true;
   }
 


### PR DESCRIPTION
Fixes #5885, I noticed this on my own while working on #5836 and included the fix in there but then I noticed the issue 😅, so I extracted it here. It's mainly the fault of having two different checkboxes, one in experimental and the other one in the general options, but it's probably better for consistency of setting the selection triggers the change on bool prefs.