### PR TITLE
Fix RunCommand matching regression

### DIFF
--- a/src/app/commands/cmd_run_command.cpp
+++ b/src/app/commands/cmd_run_command.cpp
@@ -522,7 +522,7 @@ void RunCommandCommand::loadDatabase()
         base::split_string(base::string_to_lower(key->triggerString()), labelWords, " ");
 
         const RunnerDB::Item item{
-          key->triggerString(), labelWords,     searchableStringStream.str(),
+          key->triggerString(), labelWords,     base::string_to_lower(searchableStringStream.str()),
           shortcutString,       key->command(), key->params()
         };
         items.try_emplace(itemKey, item);


### PR DESCRIPTION
Fix a regression introduced with commit a2459af, I had assumed the searchable text was already pre-lowercased so I changed the call to the faster function and... well, it wasn't lowercase 💀