### PR TITLE
Use https in URLs on all platforms

### DIFF
--- a/src/ver/info.c
+++ b/src/ver/info.c
@@ -10,20 +10,14 @@
 #define PACKAGE   "Aseprite"
 #define COPYRIGHT "Copyright (C) 2001-2025 Igara Studio S.A."
 
-#if defined(_WIN32) || defined(__APPLE__)
-  #define HTTP "https"
-#else
-  #define HTTP "http"
-#endif
-
 #ifdef CUSTOM_WEBSITE_URL
   #define WEBSITE CUSTOM_WEBSITE_URL /* To test web server */
 #else
-  #define WEBSITE HTTP "://www.aseprite.org/"
+  #define WEBSITE "https://www.aseprite.org/"
 #endif
 #define WEBSITE_DOWNLOAD     WEBSITE "download/"
 #define WEBSITE_CONTRIBUTORS WEBSITE "contributors/"
-#define WEBSITE_NEWS_RSS     HTTP "://blog.aseprite.org/rss"
+#define WEBSITE_NEWS_RSS     "https://blog.aseprite.org/rss"
 #define WEBSITE_UPDATE       WEBSITE "update/?xml=1"
 
 const char* get_app_name()


### PR DESCRIPTION
When passing the --data argument to the CLI, the generated .json file has a small difference between Windows/macOS and Linux. The .meta.app URL uses https on macOS and Windows, but http on Linux. This means developers working on the same projects across multiple OSes end up with a permanent diff on those files when they are generated.

I declare that my contributions are not co-authored using a generative AI technology.

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing

Fixes #5340