### PR TITLE
i18n: move hardcoded UI strings to the strings system

### DIFF
--- a/data/strings/en.ini
+++ b/data/strings/en.ini
@@ -12,6 +12,15 @@
 [_]
 display_name = English
 
+[about]
+app_name = Aseprite
+window_title = About Aseprite
+subtitle = Animated sprite editor && pixel art tool
+credits = Authors && Credits
+translators = Translators
+licenses = Open Source Projects
+copyright = Copyright (C) 2001-2026
+
 [advanced_mode]
 title = Warning - Important
 description = You are about to enter "Advanced Mode".
@@ -564,6 +573,28 @@ opacity = Opacity:
 zindex = Z-Index:
 user_data_tooltip = User Data
 
+[area_combo]
+canvas = Canvas
+selection = Selection
+
+[color_long]
+mask = Mask
+index = Index {}
+gray = Gray {}
+out_of_range = (out of range)
+
+[color_short]
+mask = Mask
+index = Idx-{}
+gray = Gry-{}
+
+[color_shades]
+no_colors = No colors
+
+[palette_view]
+cannot_delete_empty_tile = Cannot delete the empty tile
+cannot_move_empty_tile = Cannot move the empty tile
+
 [color_curve_point]
 title = Point Properties
 x = X:
@@ -805,6 +836,7 @@ all_files = All files
 show_hidden = Show hidden
 
 [filters]
+target_index = Index
 selected_cels = Selected
 selected_cels_tooltip = Apply to the active selection in the timeline
 all_cels = All
@@ -1077,6 +1109,17 @@ title = Load Palette
 [load_selection]
 title = Load Selection (.msk file)
 
+[mac_menu]
+about = About Aseprite
+preferences = Preferences...
+hide = Hide Aseprite
+hide_others = Hide Others
+show_all = Show All
+quit = Quit Aseprite
+window = Window
+minimize = Minimize
+zoom = Zoom
+
 [main_menu]
 file = &File
 file_new = &New...
@@ -1281,6 +1324,7 @@ cancel = &Cancel
 
 [modify_selection]
 title = Modify Selection
+width_label = Width:
 circle = Circle Brush
 square = Square Brush
 
@@ -2011,6 +2055,8 @@ timeline_show = Show Timeline
 [undo_history]
 title = Undo History
 initial_state = Initial State
+undid = Undid {}
+redid = Redid {}
 
 [user_data]
 user_data = User Data:

--- a/data/widgets/about.xml
+++ b/data/widgets/about.xml
@@ -1,17 +1,17 @@
 <!-- Aseprite -->
 <!-- Copyright (C) 2018-present  Igara Studio S.A. -->
 <!-- Copyright (C) 2018  David Capello -->
-<gui i18nwarnings="false">
-<window id="about" text="About Aseprite">
+<gui>
+<window id="about" text="@.window_title">
   <vbox>
     <label text="" id="title" />
-    <label text="Animated sprite editor &amp;&amp; pixel art tool" />
-    <link text="Authors &amp;&amp; Credits" url="" id="credits" />
-    <link text="Translators" url="" id="i18n_credits" />
-    <link text="Open Source Projects" url="" id="licenses" />
+    <label text="@.subtitle" />
+    <link text="@.credits" url="" id="credits" />
+    <link text="@.translators" url="" id="i18n_credits" />
+    <link text="@.licenses" url="" id="licenses" />
     <separator horizontal="true" />
     <hbox>
-      <label text="Copyright (C) 2001-2026" />
+      <label text="@.copyright" />
       <link text="Igara Studio S.A." url="https://igara.com/" />
     </hbox>
     <link text="https://www.aseprite.org/" url="https://www.aseprite.org/" />

--- a/src/app/app_menus.cpp
+++ b/src/app/app_menus.cpp
@@ -890,7 +890,7 @@ void AppMenus::createNativeMenus()
 
 #if LAF_MACOS // Create default macOS app menus (App ... Window)
   {
-    os::MenuItemInfo about(fmt::format("About {}", get_app_name()));
+    os::MenuItemInfo about(Strings::Translate("mac_menu.about"));
     auto native = get_native_shortcut_for_command(CommandId::About());
     about.shortcut = native.shortcut;
     about.execute = [native] {
@@ -903,7 +903,7 @@ void AppMenus::createNativeMenus()
       item->setEnabled(can_call_global_shortcut(&native));
     };
 
-    os::MenuItemInfo preferences("Preferences...");
+    os::MenuItemInfo preferences(Strings::Translate("mac_menu.preferences"));
     native = get_native_shortcut_for_command(CommandId::Options());
     preferences.shortcut = native.shortcut;
     preferences.execute = [native] {
@@ -916,10 +916,10 @@ void AppMenus::createNativeMenus()
       item->setEnabled(can_call_global_shortcut(&native));
     };
 
-    os::MenuItemInfo hide(fmt::format("Hide {}", get_app_name()), os::MenuItemInfo::Hide);
+    os::MenuItemInfo hide(Strings::Translate("mac_menu.hide"), os::MenuItemInfo::Hide);
     hide.shortcut = os::Shortcut('h', os::kKeyCmdModifier);
 
-    os::MenuItemInfo quit(fmt::format("Quit {}", get_app_name()), os::MenuItemInfo::Quit);
+    os::MenuItemInfo quit(Strings::Translate("mac_menu.quit"), os::MenuItemInfo::Quit);
     quit.shortcut = os::Shortcut('q', os::kKeyCmdModifier);
 
     os::MenuRef appMenu = menus->makeMenu();
@@ -928,9 +928,10 @@ void AppMenus::createNativeMenus()
     appMenu->addItem(menus->makeMenuItem(preferences));
     appMenu->addItem(menus->makeMenuItem(os::MenuItemInfo(os::MenuItemInfo::Separator)));
     appMenu->addItem(menus->makeMenuItem(hide));
-    appMenu->addItem(
-      menus->makeMenuItem(os::MenuItemInfo("Hide Others", os::MenuItemInfo::HideOthers)));
-    appMenu->addItem(menus->makeMenuItem(os::MenuItemInfo("Show All", os::MenuItemInfo::ShowAll)));
+    appMenu->addItem(menus->makeMenuItem(
+      os::MenuItemInfo(Strings::Translate("mac_menu.hide_others"), os::MenuItemInfo::HideOthers)));
+    appMenu->addItem(menus->makeMenuItem(
+      os::MenuItemInfo(Strings::Translate("mac_menu.show_all"), os::MenuItemInfo::ShowAll)));
     appMenu->addItem(menus->makeMenuItem(os::MenuItemInfo(os::MenuItemInfo::Separator)));
     appMenu->addItem(menus->makeMenuItem(quit));
 
@@ -955,14 +956,15 @@ void AppMenus::createNativeMenus()
       ++i;
     }
 
-    os::MenuItemInfo minimize("Minimize", os::MenuItemInfo::Minimize);
+    os::MenuItemInfo minimize(Strings::Translate("mac_menu.minimize"), os::MenuItemInfo::Minimize);
     minimize.shortcut = os::Shortcut('m', os::kKeyCmdModifier);
 
     os::MenuRef windowMenu = menus->makeMenu();
     windowMenu->addItem(menus->makeMenuItem(minimize));
-    windowMenu->addItem(menus->makeMenuItem(os::MenuItemInfo("Zoom", os::MenuItemInfo::Zoom)));
+    windowMenu->addItem(
+      menus->makeMenuItem(os::MenuItemInfo(Strings::Translate("mac_menu.zoom"), os::MenuItemInfo::Zoom)));
 
-    os::MenuItemRef windowItem = menus->makeMenuItem(os::MenuItemInfo("Window"));
+    os::MenuItemRef windowItem = menus->makeMenuItem(os::MenuItemInfo(Strings::Translate("mac_menu.window")));
     windowItem->setSubmenu(windowMenu);
 
     // We use helpIndex+1 because the first index in m_osMenu is the

--- a/src/app/color.cpp
+++ b/src/app/color.cpp
@@ -11,6 +11,9 @@
 
 #include "app/color.h"
 
+#include "app/i18n/strings.h"
+#include "fmt/format.h"
+
 #include "app/color_utils.h"
 #include "app/modules/palettes.h"
 #include "base/debug.h"
@@ -218,23 +221,23 @@ std::string Color::toHumanReadableString(PixelFormat pixelFormat,
 
   if (humanReadable == LongHumanReadableString) {
     switch (getType()) {
-      case Color::MaskType: result << "Mask"; break;
+      case Color::MaskType: result << Strings::color_long_mask(); break;
 
       case Color::RgbType:
         if (pixelFormat == IMAGE_GRAYSCALE) {
-          result << "Gray " << getGray();
+          result << Strings::color_long_gray(getGray());
         }
         else {
           result << "RGB " << m_value.rgb.r << " " << m_value.rgb.g << " " << m_value.rgb.b;
 
           if (pixelFormat == IMAGE_INDEXED)
-            result << " Index " << color_utils::color_for_image(*this, IMAGE_INDEXED);
+            result << " " << Strings::color_long_index(color_utils::color_for_image(*this, IMAGE_INDEXED));
         }
         break;
 
       case Color::HsvType:
         if (pixelFormat == IMAGE_GRAYSCALE) {
-          result << "Gray " << getGray();
+          result << Strings::color_long_gray(getGray());
         }
         else {
           result << "HSV " << int(m_value.hsv.h) << "\xc2\xb0 "
@@ -242,7 +245,7 @@ std::string Color::toHumanReadableString(PixelFormat pixelFormat,
                  << std::clamp(int(m_value.hsv.v * 100.0), 0, 100) << "%";
 
           if (pixelFormat == IMAGE_INDEXED)
-            result << " Index " << color_utils::color_for_image(*this, IMAGE_INDEXED);
+            result << " " << Strings::color_long_index(color_utils::color_for_image(*this, IMAGE_INDEXED));
 
           result << " (RGB " << getRed() << " " << getGreen() << " " << getBlue() << ")";
         }
@@ -250,7 +253,7 @@ std::string Color::toHumanReadableString(PixelFormat pixelFormat,
 
       case Color::HslType:
         if (pixelFormat == IMAGE_GRAYSCALE) {
-          result << "Gray " << getGray();
+          result << Strings::color_long_gray(getGray());
         }
         else {
           result << "HSL " << int(m_value.hsl.h) << "\xc2\xb0 "
@@ -258,23 +261,23 @@ std::string Color::toHumanReadableString(PixelFormat pixelFormat,
                  << std::clamp(int(m_value.hsl.l * 100.0), 0, 100) << "%";
 
           if (pixelFormat == IMAGE_INDEXED)
-            result << " Index " << color_utils::color_for_image(*this, IMAGE_INDEXED);
+            result << " " << Strings::color_long_index(color_utils::color_for_image(*this, IMAGE_INDEXED));
 
           result << " (RGB " << getRed() << " " << getGreen() << " " << getBlue() << ")";
         }
         break;
 
-      case Color::GrayType:  result << "Gray " << m_value.gray.g; break;
+      case Color::GrayType:  result << Strings::color_long_gray(m_value.gray.g); break;
 
       case Color::IndexType: {
         int i = m_value.index;
         if (i >= 0 && i < (int)get_current_palette()->size()) {
           uint32_t _c = get_current_palette()->getEntry(i);
-          result << "Index " << i << " (RGB " << (int)rgba_getr(_c) << " " << (int)rgba_getg(_c)
-                 << " " << (int)rgba_getb(_c) << ")";
+          result << Strings::color_long_index(i) << " (RGB " << (int)rgba_getr(_c) << " "
+                 << (int)rgba_getg(_c) << " " << (int)rgba_getb(_c) << ")";
         }
         else {
-          result << "Index " << i << " (out of range)";
+          result << Strings::color_long_index(i) << " " << Strings::color_long_out_of_range();
         }
         break;
       }
@@ -287,11 +290,11 @@ std::string Color::toHumanReadableString(PixelFormat pixelFormat,
   }
   else if (humanReadable == ShortHumanReadableString) {
     switch (getType()) {
-      case Color::MaskType: result << "Mask"; break;
+      case Color::MaskType: result << Strings::color_short_mask(); break;
 
       case Color::RgbType:
         if (pixelFormat == IMAGE_GRAYSCALE) {
-          result << "Gry-" << getGray();
+          result << Strings::color_short_gray(getGray());
         }
         else {
           result << "#" << std::hex << std::setfill('0') << std::setw(2) << m_value.rgb.r
@@ -301,7 +304,7 @@ std::string Color::toHumanReadableString(PixelFormat pixelFormat,
 
       case Color::HsvType:
         if (pixelFormat == IMAGE_GRAYSCALE) {
-          result << "Gry-" << getGray();
+          result << Strings::color_short_gray(getGray());
         }
         else {
           result << int(m_value.hsv.h) << "\xc2\xb0"
@@ -312,7 +315,7 @@ std::string Color::toHumanReadableString(PixelFormat pixelFormat,
 
       case Color::HslType:
         if (pixelFormat == IMAGE_GRAYSCALE) {
-          result << "Gry-" << getGray();
+          result << Strings::color_short_gray(getGray());
         }
         else {
           result << int(m_value.hsl.h) << "\xc2\xb0"
@@ -321,9 +324,9 @@ std::string Color::toHumanReadableString(PixelFormat pixelFormat,
         }
         break;
 
-      case Color::GrayType:  result << "Gry-" << m_value.gray.g; break;
+      case Color::GrayType:  result << Strings::color_short_gray(m_value.gray.g); break;
 
-      case Color::IndexType: result << "Idx-" << m_value.index; break;
+      case Color::IndexType: result << Strings::color_short_index(m_value.index); break;
 
       default:               ASSERT(false); break;
     }

--- a/src/app/commands/cmd_about.cpp
+++ b/src/app/commands/cmd_about.cpp
@@ -11,6 +11,7 @@
 
 #include "app/app.h"
 #include "app/commands/command.h"
+#include "app/i18n/strings.h"
 #include "app/ui/main_window.h"
 #include "fmt/format.h"
 #include "ver/info.h"
@@ -43,7 +44,8 @@ bool AboutCommand::onEnabled(Context* context)
 void AboutCommand::onExecute(Context* context)
 {
   gen::About window;
-  window.title()->setText(fmt::format("{} v{}", get_app_name(), get_app_version()));
+  window.title()->setText(
+    fmt::format("{} v{}", Strings::about_app_name(), get_app_version()));
   window.licenses()->Click.connect([&window] {
     window.closeWindow(nullptr);
     App::instance()->mainWindow()->showBrowser("docs/LICENSES.md");

--- a/src/app/commands/cmd_mask_by_color.cpp
+++ b/src/app/commands/cmd_mask_by_color.cpp
@@ -318,7 +318,7 @@ void MaskByColorWindow::maskPreview()
 
 #ifdef SHOW_BOUNDARIES_GEN_PERFORMANCE
     double time = chrono.elapsed();
-    m_window->setText("Mask by Color (" + base::convert_to<std::string>(time) + ")");
+    m_window->setText(Strings::mask_by_color_title() + " (" + base::convert_to<std::string>(time) + ")");
 #endif
 
     update_screen_for_document(writer.document());

--- a/src/app/commands/cmd_modify_selection.cpp
+++ b/src/app/commands/cmd_modify_selection.cpp
@@ -101,7 +101,7 @@ void ModifySelectionCommand::onExecute(Context* context)
 
     window.setText(getActionName() + " Selection");
     if (m_modifier == Modifier::Border)
-      window.byLabel()->setText("Width:");
+      window.byLabel()->setText(Strings::modify_selection_width_label());
     else
       window.byLabel()->setText(getActionName() + " By:");
 

--- a/src/app/commands/cmd_undo.cpp
+++ b/src/app/commands/cmd_undo.cpp
@@ -11,6 +11,7 @@
 
 #include "app/app.h"
 #include "app/commands/command.h"
+#include "app/i18n/strings.h"
 #include "app/context_access.h"
 #include "app/doc_undo.h"
 #include "app/ini_file.h"
@@ -99,9 +100,9 @@ void UndoCommand::onExecute(Context* context)
   if (auto* statusBar = StatusBar::instance()) {
     std::string msg;
     if (m_type == Undo)
-      msg = "Undid " + undo->nextUndoLabel();
+      msg = Strings::undo_history_undid(undo->nextUndoLabel());
     else
-      msg = "Redid " + undo->nextRedoLabel();
+      msg = Strings::undo_history_redid(undo->nextRedoLabel());
     if (Preferences::instance().undo.showTooltip())
       statusBar->showTip(1000, msg);
     else

--- a/src/app/commands/filters/filter_target_buttons.cpp
+++ b/src/app/commands/filters/filter_target_buttons.cpp
@@ -56,7 +56,7 @@ FilterTargetButtons::FilterTargetButtons(int imgtype, bool withChannels)
         m_alpha = addItem("A");
 
         if (imgtype == IMAGE_INDEXED)
-          m_index = addItem("Index", 4, 1);
+          m_index = addItem(Strings::filters_target_index(), 4, 1);
         break;
 
       case IMAGE_GRAYSCALE:

--- a/src/app/ui/color_shades.cpp
+++ b/src/app/ui/color_shades.cpp
@@ -11,6 +11,8 @@
 
 #include "app/ui/color_shades.h"
 
+#include "app/i18n/strings.h"
+
 #include "app/app.h"
 #include "app/modules/gfx.h"
 #include "app/modules/palettes.h"
@@ -40,7 +42,7 @@ ColorShades::ColorShades(const Shade& colors, ClickType click)
   , m_dragIndex(-1)
   , m_boxSize(12)
 {
-  setText("No colors");
+  setText(Strings::color_shades_no_colors());
   initTheme();
 }
 

--- a/src/app/ui/layer_frame_comboboxes.cpp
+++ b/src/app/ui/layer_frame_comboboxes.cpp
@@ -75,10 +75,10 @@ FrameListItem::FrameListItem(doc::Tag* tag)
 
 void fill_area_combobox(const doc::Sprite* sprite, ui::ComboBox* area, const std::string& defArea)
 {
-  int i = area->addItem("Canvas");
+  int i = area->addItem(Strings::area_combo_canvas());
   dynamic_cast<ui::ListItem*>(area->getItem(i))->setValue(kWholeCanvas);
 
-  i = area->addItem("Selection");
+  i = area->addItem(Strings::area_combo_selection());
   dynamic_cast<ui::ListItem*>(area->getItem(i))->setValue(kSelectedCanvas);
   if (defArea == kSelectedCanvas)
     area->setSelectedItemIndex(i);

--- a/src/app/ui/palette_view.cpp
+++ b/src/app/ui/palette_view.cpp
@@ -22,6 +22,8 @@
 #include "app/site.h"
 #include "app/ui/editor/editor.h"
 #include "app/ui/palette_view.h"
+
+#include "app/i18n/strings.h"
 #include "app/ui/skin/skin_theme.h"
 #include "app/ui/status_bar.h"
 #include "app/ui_context.h"
@@ -214,7 +216,7 @@ public:
       picks[i] = false;
       if (!picks.picks()) {
         // Cannot remove empty tile
-        StatusBar::instance()->showTip(1000, "Cannot delete the empty tile");
+        StatusBar::instance()->showTip(1000, Strings::palette_view_cannot_delete_empty_tile());
         return;
       }
     }
@@ -261,7 +263,7 @@ public:
       newPicks[0] = false;
     if (!newPicks.picks()) {
       // Cannot move empty tile
-      StatusBar::instance()->showTip(1000, "Cannot move the empty tile");
+      StatusBar::instance()->showTip(1000, Strings::palette_view_cannot_move_empty_tile());
       return;
     }
 


### PR DESCRIPTION
## Summary

Moves user-visible English strings that were hardcoded in C++/XML into `data/strings/en.ini`, so translations (Weblate) can actually cover them. No behavior change — the English UI text is byte-identical to before.

- Export dialog area combobox: `"Canvas"` / `"Selection"` (`fill_area_combobox`)
- Status bar color descriptions: `"Index N"`, `"Gray N"`, `"Mask"`, `"(out of range)"`, and short forms `"Idx-"` / `"Gry-"` (`app::Color::toHumanReadableString`)
- Undo/redo status messages: `"Undid "` / `"Redid "` (`UndoCommand`)
- macOS native App/Window menu items (About/Preferences/Hide/Hide Others/Show All/Quit/Window/Minimize/Zoom) via a new `[mac_menu]` section
- About dialog labels (`about.xml` had `i18nwarnings="false"` with raw English text)
- Misc: `"No colors"` (`ColorShades`), `"Cannot delete/move the empty tile"` (`PaletteView`), `"Width:"` (`ModifySelection`), `"Index"` filter target button, `"Mask by Color"` window title

## Why

Found these while completing a full third-party translation — about a dozen strings across common dialogs (export, undo status, macOS menu bar, About) were impossible to localize because they were plain C++ literals instead of going through `Strings`/`@key` references.

## Test plan
- [x] Built locally (macOS arm64, Skia backend) and manually exercised each changed dialog/flow (Export As area dropdown, undo/redo status tip, About window, macOS app menu, empty-tile delete/move in palette, Modify Selection, filter target buttons, Mask by Color)
- [x] Confirmed English UI text is unchanged
- [x] `data/strings/en.ini` stays valid (loads correctly, no duplicate keys)