### PR TITLE
Set the GIF version to 89a when exporting > 1 frame

### DIFF
--- a/src/app/file/gif_format.cpp
+++ b/src/app/file/gif_format.cpp
@@ -1073,7 +1073,9 @@ public:
 
   bool encode()
   {
-    writeHeader();
+    gifframe_t nframes = totalFrames();
+    // #4746: Use GIF 89a when there is more than one frame in the GIF.
+    writeHeader(nframes > 1);
     if (m_loop >= 0)
       writeLoopExtension();
 
@@ -1092,7 +1094,6 @@ public:
 
     // In this code "gifFrame" will be the GIF frame, and "frame" will
     // be the doc::Sprite frame.
-    gifframe_t nframes = totalFrames();
     for (gifframe_t gifFrame = 0; gifFrame < nframes; ++gifFrame) {
       ASSERT(frame_it != frame_end);
       if (m_fop->isStop())
@@ -1270,8 +1271,9 @@ private:
 
   doc::frame_t totalFrames() const { return m_fop->roi().frames(); }
 
-  void writeHeader()
+  void writeHeader(bool isGif89)
   {
+    EGifSetGifVersion(m_gifFile, isGif89);
     if (EGifPutScreenDesc(m_gifFile,
                           m_spriteBounds.w,
                           m_spriteBounds.h,


### PR DESCRIPTION
<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the Individual Contributor License Agreement V4.0. -->
<!-- If you're a first-time contributor, please sign the CLA
     as indicated in https://github.com/igarastudio/cla#signing
     and acknowledge it by leaving the statement below. -->

Hi! I ran into #4746. In one of my own projects, I implemented an animated GIF detection routine to suppress generating preview-sized images for animations. Based on the GIF specifications ([87a](https://www.w3.org/Graphics/GIF/spec-gif87.txt) and [89a](https://www.w3.org/Graphics/GIF/spec-gif89a.txt)), only GIF 89a supports the extensions which define animation support. In my original code, I therefore assumed that any GIF 87a file would not include animation and exited the routine early. This assumption turns out to be invalid, as proved by Aseprite :)

I have implemented a very small patch for Aseprite which tells giflib to write the GIF 89a header when the file has more than one animation frame. In my own testing, it works as expected: animated files export as GIF 89a and static files export as 87a.

I declare that my contributions are not co-authored using a generative AI technology.

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing
