### PR TITLE
[lua] Add save/beforesave sprite.events (close #5115)

### DIFF
--- a/src/app/commands/cmd_save_file.cpp
+++ b/src/app/commands/cmd_save_file.cpp
@@ -225,6 +225,10 @@ void SaveFileBaseCommand::saveDocumentInBackground(const Context* context,
     if (resizeOnTheFly == ResizeOnTheFly::On)
       fop->setOnTheFlyScale(scale);
 
+    if (markAsSaved == MarkAsSaved::On) {
+      document->notifyBeforeSave();
+    }
+
     if (fop->fileFormat() && fop->fileFormat()->dioFormat() >= dio::FileFormat::FIRST_CUSTOM) {
       // Custom formats must run on the main thread
       fop->operate();
@@ -257,6 +261,7 @@ void SaveFileBaseCommand::saveDocumentInBackground(const Context* context,
       document->markAsSaved();
       document->setFilename(filename);
       document->incrementVersion();
+      document->notifyAfterSave();
     }
 
     if (context->isUIAvailable() && params().ui()) {

--- a/src/app/doc.cpp
+++ b/src/app/doc.cpp
@@ -227,6 +227,18 @@ void Doc::notifyGeneralUpdate()
   notify_observers<DocEvent&>(&DocObserver::onGeneralUpdate, ev);
 }
 
+void Doc::notifyBeforeSave()
+{
+  DocEvent ev(this);
+  notify_observers<DocEvent&>(&DocObserver::onBeforeSave, ev);
+}
+
+void Doc::notifyAfterSave()
+{
+  DocEvent ev(this);
+  notify_observers<DocEvent&>(&DocObserver::onAfterSave, ev);
+}
+
 void Doc::notifyColorSpaceChanged()
 {
   updateOSColorSpace(true);

--- a/src/app/doc.h
+++ b/src/app/doc.h
@@ -128,6 +128,8 @@ public:
   // Notifications
 
   void notifyGeneralUpdate();
+  void notifyBeforeSave();
+  void notifyAfterSave();
   void notifyColorSpaceChanged();
   void notifyPaletteChanged();
   void notifySpritePixelsModified(Sprite* sprite, const gfx::Region& region, frame_t frame);

--- a/src/app/doc_observer.h
+++ b/src/app/doc_observer.h
@@ -28,6 +28,9 @@ public:
   // anything in the document could be changed.
   virtual void onGeneralUpdate(DocEvent& ev) {}
 
+  virtual void onBeforeSave(DocEvent& ev) {}
+  virtual void onAfterSave(DocEvent& ev) {}
+
   virtual void onColorSpaceChanged(DocEvent& ev) {}
   virtual void onPixelFormatChanged(DocEvent& ev) {}
   virtual void onPaletteChanged(DocEvent& ev) {}

--- a/src/app/script/events_class.cpp
+++ b/src/app/script/events_class.cpp
@@ -365,6 +365,8 @@ public:
   enum : EventType {
     Unknown = -1,
     Change,
+    BeforeSave,
+    AfterSave,
     FilenameChange,
     AfterAddTile,
 #if ENABLE_REMAP_TILESET_EVENT
@@ -397,6 +399,10 @@ public:
   {
     if (std::strcmp(eventName, "change") == 0)
       return Change;
+    else if (std::strcmp(eventName, "beforesave") == 0)
+      return BeforeSave;
+    else if (std::strcmp(eventName, "save") == 0)
+      return AfterSave;
     else if (std::strcmp(eventName, "filenamechange") == 0)
       return FilenameChange;
     else if (std::strcmp(eventName, "afteraddtile") == 0)
@@ -427,6 +433,10 @@ public:
       g_spriteEvents.erase(it);
     }
   }
+
+  void onBeforeSave(DocEvent& ev) override { call(BeforeSave); }
+
+  void onAfterSave(DocEvent& ev) override { call(AfterSave); }
 
   void onFileNameChanged(Doc* doc) override { call(FilenameChange); }
 


### PR DESCRIPTION
Adds `save` and `beforesave` sprite events
Close #5115

**Example code:**
``` Lua
function beforeSaveFunc()
	print("beforeSaveFunc! ----------")
	local spr = app.sprite
	print("spr.filename: "..tostring(spr.filename))
	print("spr.isModified: "..tostring(spr.isModified))
end

function afterSaveFunc()
	print("afterSaveFunc! ----------")
	local spr = app.sprite
	print("spr.filename: "..tostring(spr.filename))
	print("spr.isModified: "..tostring(spr.isModified))
end

local spr = app.sprite
spr.events:on("save", afterSaveFunc)
spr.events:on("beforesave", beforeSaveFunc)
print("Save events on!")
```

---

I declare that my contributions are not co-authored using a generative AI technology.

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing
