### PR TITLE
Add checks to message recipient in Preferences focus message (fix #5946)

### DIFF
--- a/src/app/commands/cmd_options.cpp
+++ b/src/app/commands/cmd_options.cpp
@@ -1172,13 +1172,14 @@ private:
       case kFocusEnterMessage:
         // Resets the search when we focus any widget that has mouse interaction, unless it's in the
         // section list
-        if (msg->recipient() == sectionListbox() ||
-            (msg->recipient()->type() == kListItemWidget &&
-             msg->recipient()->parent() == sectionListbox()) ||
-            msg->recipient() == search() || msg->recipient()->hasFlags(IGNORE_MOUSE))
-          return false;
-
         if (!search()->text().empty()) {
+          if (auto* recipient = msg->recipient();
+              recipient &&
+              (recipient == sectionListbox() ||
+               (recipient->type() == kListItemWidget && recipient->parent() == sectionListbox()) ||
+               recipient == search() || recipient->hasFlags(IGNORE_MOUSE)))
+            return false;
+
           search()->clear();
           onSearch();
         }


### PR DESCRIPTION
I could not reproduce the error on my machine, it _seems_ to be the result of `msg->recipient()` being null, which is a thing I assumed could not happen on focus messages and indeed looking their creation it can't, so this is kind of a speculative fix. 
We also move the check to happen only when we want to do the search clear which should reduce the likelyhood it happens by a lot.