### PR TITLE
Fix break position in some switch/case statements

### DIFF
--- a/src/app/commands/cmd_run_command.cpp
+++ b/src/app/commands/cmd_run_command.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2025  Igara Studio S.A.
+// Copyright (C) 2025-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -147,15 +147,18 @@ class RunnerWindow final : public gen::RunCommand {
         switch (msg->type()) {
           case kMouseDownMessage: {
             Click(m_item);
-          } break;
+            break;
+          }
           case kMouseEnterMessage:
           case kFocusEnterMessage: {
             setSelected(true);
-          } break;
+            break;
+          }
           case kMouseLeaveMessage:
           case kFocusLeaveMessage: {
             setSelected(false);
-          } break;
+            break;
+          }
           case kSetCursorMessage: {
             set_mouse_cursor(kHandCursor);
             return true;

--- a/src/app/doc.cpp
+++ b/src/app/doc.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2025  Igara Studio S.A.
+// Copyright (C) 2018-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -696,7 +696,8 @@ Doc* Doc::duplicate(DuplicateType type) const
       // sprite has a background layer.
       if (sourceSprite->backgroundLayer() != NULL)
         flatLayer->configureAsBackground();
-    } break;
+      break;
+    }
   }
 
   // Copy only some flags

--- a/src/app/script/events_class.cpp
+++ b/src/app/script/events_class.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2021-2024  Igara Studio S.A.
+// Copyright (C) 2021-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -201,7 +201,8 @@ private:
           ctx->add_observer(this);
 
         ++m_addedObserver;
-      } break;
+        break;
+      }
       case FgColorChange:
         m_fgConn = pref.colorBar.fgColor.AfterChange.connect([this] { onFgColorChange(); });
         break;

--- a/src/app/tools/inks.h
+++ b/src/app/tools/inks.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2024  Igara Studio S.A.
+// Copyright (C) 2018-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -117,7 +117,8 @@ public:
         int color = (m_type == WithFg ? loop->getFgColor() : loop->getBgColor());
         loop->setPrimaryColor(color);
         loop->setSecondaryColor(color);
-      } break;
+        break;
+      }
     }
 
     // TODO support different ink types for tilemaps (even custom brushes,

--- a/src/app/ui/tabs.cpp
+++ b/src/app/ui/tabs.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2025  Igara Studio S.A.
+// Copyright (C) 2018-present  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This program is distributed under the terms of
@@ -645,7 +645,8 @@ void Tabs::drawTab(Graphics* g, const gfx::Rect& _box, Tab* tab, int dy, bool ho
                                gfx::Rect(box.x, box.y + dy, box.x - dx, box.h),
                                info);
         dx += theme->dimensions.tabsIconWidth();
-      } break;
+        break;
+      }
     }
 
     // Tab with text + clipping the close button

--- a/src/doc/algorithm/floodfill.cpp
+++ b/src/doc/algorithm/floodfill.cpp
@@ -172,7 +172,8 @@ static int flooder(const Image* image,
         if (!color_equal_32((int)*(address + right), src_color, tolerance) || MASKED(right, y))
           break;
       }
-    } break;
+      break;
+    }
 
     case IMAGE_GRAYSCALE: {
       uint16_t* address = reinterpret_cast<uint16_t*>(image->getPixelAddress(0, y));
@@ -192,7 +193,8 @@ static int flooder(const Image* image,
         if (!color_equal_16((int)*(address + right), src_color, tolerance) || MASKED(right, y))
           break;
       }
-    } break;
+      break;
+    }
 
     case IMAGE_INDEXED: {
       uint8_t* address = image->getPixelAddress(0, y);
@@ -212,7 +214,8 @@ static int flooder(const Image* image,
         if (!color_equal_8((int)*(address + right), src_color, tolerance) || MASKED(right, y))
           break;
       }
-    } break;
+      break;
+    }
 
     case IMAGE_TILEMAP: {
       // TODO add support for mask
@@ -234,7 +237,8 @@ static int flooder(const Image* image,
         if (!color_equal_32_raw((int)*(address + right), src_color))
           break;
       }
-    } break;
+      break;
+    }
 
     default:
       // Check start pixel

--- a/src/render/quantization.cpp
+++ b/src/render/quantization.cpp
@@ -1,5 +1,5 @@
 // Aseprite Render Library
-// Copyright (c) 2019-2022  Igara Studio S.A.
+// Copyright (c) 2019-present  Igara Studio S.A.
 // Copyright (c) 2001-2018  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -411,7 +411,8 @@ void PaletteOptimizer::feedWithImage(const Image* image,
           m_histogram.addSamples(color, 1);
         }
       }
-    } break;
+      break;
+    }
 
     case IMAGE_GRAYSCALE: {
       const LockImageBits<GrayscaleTraits> bits(image, bounds);
@@ -429,7 +430,8 @@ void PaletteOptimizer::feedWithImage(const Image* image,
             1);
         }
       }
-    } break;
+      break;
+    }
 
     case IMAGE_INDEXED: ASSERT(false); break;
   }

--- a/src/ui/button.cpp
+++ b/src/ui/button.cpp
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2019-2023  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -219,14 +219,16 @@ bool ButtonBase::onProcessMessage(Message* msg)
                 onRightClick();
               else
                 generateButtonSelectSignal();
-            } break;
+              break;
+            }
 
             case kCheckWidget: {
               // Fire onClick() event
               onClick();
 
               invalidate();
-            } break;
+              break;
+            }
 
             case kRadioWidget: {
               setSelected(false);
@@ -234,7 +236,8 @@ bool ButtonBase::onProcessMessage(Message* msg)
 
               // Fire onClick() event
               onClick();
-            } break;
+              break;
+            }
           }
         }
         return true;

--- a/src/ui/slider.cpp
+++ b/src/ui/slider.cpp
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2019-2025  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2016  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -214,7 +214,8 @@ bool Slider::onProcessMessage(Message* msg)
               value = (value > 0 && min < 0) ? 0 : min;
             else
               value = std::stoi(valueString.substr(0, valueString.size() - 1));
-          } break;
+            break;
+          }
         }
 
         if (oldValue == value) {


### PR DESCRIPTION
We should always prefer:
```
case: {
  ...
  break;
}
case: ...
```
Instead of the compressed way:
```
case: {
  ...
} break;
case: ...
```
As it's easier to read/gives an extra separation between cases.