### PR TITLE
[lua] Add `Dialog:samerow`

### DIFF
--- a/src/app/script/dialog_class.cpp
+++ b/src/app/script/dialog_class.cpp
@@ -719,7 +719,7 @@ int Dialog_newrow(lua_State* L)
     // Dialog:newrow{ always }
     if (lua_is_key_true(L, 2, "always")) {
       dlg->autoNewRow = true;
-      // sameRow has higher prioity, uncheck it
+      // autoSameRow has priority when adding widget, uncheck it
       dlg->autoSameRow = false;
     }
     lua_pop(L, 1);

--- a/src/app/script/dialog_class.cpp
+++ b/src/app/script/dialog_class.cpp
@@ -128,6 +128,8 @@ struct Dialog {
   // Pointer to current grid (might be the main grid or a tab's grid).
   ui::Grid* currentGrid;
   ui::HBox* hbox = nullptr;
+  bool sameRow = false;
+  bool autoSameRow = false;
   bool autoNewRow = false;
   WidgetsList mainWidgets;
   std::map<std::string, ui::Widget*, std::less<>> dataWidgets;
@@ -603,11 +605,16 @@ int Dialog_add_widget(lua_State* L, Widget* widget)
 
   // This is to separate different kind of widgets without label in
   // different rows. Separator widgets will always create a new row.
-  if (dlg->lastWidgetType != widget->type() || dlg->autoNewRow ||
+  if (dlg->sameRow && widget->type() != ui::kSeparatorWidget && 
+      dlg->lastWidgetType != ui::kSeparatorWidget) {
+    dlg->lastWidgetType = widget->type();
+  }
+  else if (dlg->lastWidgetType != widget->type() || dlg->autoNewRow ||
       widget->type() == ui::kSeparatorWidget) {
     dlg->lastWidgetType = widget->type();
     dlg->hbox = nullptr;
   }
+  dlg->sameRow = dlg->autoSameRow;
 
   if (lua_istable(L, 2)) {
     // Widget ID (used to fill the Dialog_get_data table then)
@@ -710,8 +717,28 @@ int Dialog_newrow(lua_State* L)
   dlg->autoNewRow = false;
   if (lua_istable(L, 2)) {
     // Dialog:newrow{ always }
-    if (lua_is_key_true(L, 2, "always"))
+    if (lua_is_key_true(L, 2, "always")) {
       dlg->autoNewRow = true;
+      // sameRow has higher prioity, uncheck it
+      dlg->autoSameRow= false; 
+    }
+    lua_pop(L, 1);
+  }
+
+  lua_pushvalue(L, 1);
+  return 1;
+}
+
+int Dialog_samerow(lua_State* L)
+{
+  auto dlg = get_obj<Dialog>(L, 1);
+
+  dlg->sameRow = true;
+  dlg->autoSameRow = false;
+  if (lua_istable(L, 2)) {
+    // Dialog:samerow{ always }
+    if (lua_is_key_true(L, 2, "always"))
+      dlg->autoSameRow = true;
     lua_pop(L, 1);
   }
 
@@ -2029,6 +2056,7 @@ const luaL_Reg Dialog_methods[] = {
   { "showMenu",  Dialog_showMenu  },
   { "close",     Dialog_close     },
   { "newrow",    Dialog_newrow    },
+  { "samerow",   Dialog_samerow    },
   { "separator", Dialog_separator },
   { "label",     Dialog_label     },
   { "button",    Dialog_button    },

--- a/src/app/script/dialog_class.cpp
+++ b/src/app/script/dialog_class.cpp
@@ -605,12 +605,12 @@ int Dialog_add_widget(lua_State* L, Widget* widget)
 
   // This is to separate different kind of widgets without label in
   // different rows. Separator widgets will always create a new row.
-  if (dlg->sameRow && widget->type() != ui::kSeparatorWidget && 
+  if (dlg->sameRow && widget->type() != ui::kSeparatorWidget &&
       dlg->lastWidgetType != ui::kSeparatorWidget) {
     dlg->lastWidgetType = widget->type();
   }
   else if (dlg->lastWidgetType != widget->type() || dlg->autoNewRow ||
-      widget->type() == ui::kSeparatorWidget) {
+           widget->type() == ui::kSeparatorWidget) {
     dlg->lastWidgetType = widget->type();
     dlg->hbox = nullptr;
   }
@@ -720,7 +720,7 @@ int Dialog_newrow(lua_State* L)
     if (lua_is_key_true(L, 2, "always")) {
       dlg->autoNewRow = true;
       // sameRow has higher prioity, uncheck it
-      dlg->autoSameRow= false; 
+      dlg->autoSameRow = false;
     }
     lua_pop(L, 1);
   }
@@ -2056,7 +2056,7 @@ const luaL_Reg Dialog_methods[] = {
   { "showMenu",  Dialog_showMenu  },
   { "close",     Dialog_close     },
   { "newrow",    Dialog_newrow    },
-  { "samerow",   Dialog_samerow    },
+  { "samerow",   Dialog_samerow   },
   { "separator", Dialog_separator },
   { "label",     Dialog_label     },
   { "button",    Dialog_button    },


### PR DESCRIPTION
Hello!

This is a suggestion to allow placing different widgets on the same line by calling `dialog:samerow` similar to how `dialog:newrow` creates a new line, including "always" option. 

I can not say this is a severe issue, but occasionally I regret not being able to add an extra thingy with a text/color widget. Usually, it's preset values, but can be units in a dropdown, or a button to update something on demand. Same can be achieved with separators, at the cost of the dialog being long.

The implementation is sorta dumb, it just sets a flag checked before adding the element, skipping adding an hbox. It is still possible to use `newrow()` correctly on following widgets. I think the only case where the check behavior needs a correction is switching from always the same row to always a new row. Separators are handled separately and always go in a new row.

-----

Test scripts:

```lua
Dialog{ title = "same row no label" }
    :entry{ text = "entry" }
    :samerow()
    :button{ text = "Check" }
    :entry{ text = "entry1" }
    :entry{ text = "entry2" }
    :samerow()
    :button{ text = "Check" }
    :samerow()
    :check{ text = "Option" }
    :newrow()
    :button{ text = "OK" }
    :show()
```
<img width="584" height="238" alt="image" src="https://github.com/user-attachments/assets/48a0611d-f252-4382-8cdf-c5886c43fbc7" />

```lua
Dialog{ title = "same row with labels" }
    :entry{ text = "entry", label = "label1" }
    :samerow()
    :button{ text = "Check" }
    :entry{ text = "entry1" }
    :entry{ label ="label2", text = "entry2" }
    :samerow()
    :button{ text = "Check" }
    :newrow()
    :button{ text = "OK" }
    :show()
```
<img width="386" height="303" alt="image" src="https://github.com/user-attachments/assets/06367fd7-be6b-4e33-bb62-39af814b357a" />

```lua
Dialog{ title = "same row after newrow always" }
    :newrow { always = true }
    :entry{ text = "entry" }
    :samerow()
    :button{ text = "Check" }
    :entry{ text = "entry1" }
    :entry{ text = "entry2" }
    :samerow()
    :button{ text = "Check" }
    :newrow()
    :button{ text = "OK" }
    :show()
```
<img width="376" height="310" alt="image" src="https://github.com/user-attachments/assets/90bbcd64-b866-4e2f-bb3b-56fd19b4b4e5" />

```lua
Dialog{ title = "same row always" }
    :samerow { always = true }
    :entry{ text = "entry" }
    :button{ text = "Check" }
    :entry{ text = "entry1" }
    :entry{ text = "entry2" }
    :button{ text = "Check" }
    :check{ text = "Option" }
    :button{ text = "OK", label= "label1" }
    :show()
```
<img width="910" height="186" alt="image" src="https://github.com/user-attachments/assets/6cfdb2d8-95d2-46b2-9432-6dcce0b87617" />

```lua
Dialog{ title = "same row always with newrow" }
    :samerow { always = true }
    :entry{ text = "entry" }
    :button{ text = "Check" }
    :newrow()
    :entry{ text = "entry1" }
    :entry{ text = "entry2" }
    :button{ text = "Check" }
    :check{ text = "Option" }
    :newrow()
    :button{ text = "OK", label= "label1" }
    :show()
```
<img width="654" height="243" alt="image" src="https://github.com/user-attachments/assets/5c35a184-81bd-4997-a0b9-ad5112f13c37" />

```lua
Dialog{ title = "same row always alternate with newrow always" }
    :samerow { always = true }
    :entry{ text = "entry" }
    :button{ text = "Check1" }
    :newrow { always = true }
    :entry{ text = "entry1" }
    :entry{ text = "entry2" }
    :button{ text = "Check2" }
    :samerow{ always = true }
    :color()
    :check{ text = "Option" }
    :button{ text = "OK", label= "label1" }
    :show()
```
<img width="560" height="352" alt="image" src="https://github.com/user-attachments/assets/b5fd46a8-4beb-4d8e-95a1-d6874e6d0810" />

```lua
Dialog{ title = "same row always with separators" }
    :samerow{always = true}
    :entry{ text = "entry1" }
    :separator{ text = "separator1" }
    :separator{ text = "separator2" }
    :entry{ text = "entry2" }
    :button{ text = "OK" }
    :show()
```
<img width="386" height="281" alt="image" src="https://github.com/user-attachments/assets/50a2ae51-18a5-4986-8e82-2e52a8516b7a" />


------

I declare that my contributions are not co-authored using a generative AI technology.

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing
