### PR TITLE
Add adjustable mouse wheel speed (fix #5103)

### DIFF
--- a/data/pref.xml
+++ b/data/pref.xml
@@ -190,6 +190,7 @@
       <option id="show_scrollbars" type="bool" default="true" />
       <option id="auto_scroll" type="bool" default="true" />
       <option id="auto_scroll_speed" type="int" default="100" />
+      <option id="wheel_scroll_speed" type="int" default="100" />
       <option id="right_click_mode" type="RightClickMode" default="RightClickMode::PAINT_BGCOLOR" />
       <option id="auto_select_layer" type="bool" default="false" />
       <option id="auto_select_layer_quick" type="bool" default="true" />

--- a/data/strings/en.ini
+++ b/data/strings/en.ini
@@ -1505,6 +1505,7 @@ show_scrollbars = Show scroll-bars in sprite editor
 show_scrollbars_tooltip = Show scroll-bars in all sprite editors
 auto_scroll = Auto-scroll on editor edges
 auto_scroll_speed = Speed [Slower / Faster]:
+wheel_scroll_speed = Wheel Speed [Slower / Faster]:
 auto_fit = Auto-fit on screen when a sprite is opened
 straight_line_preview = Preview straight line immediately with the Pencil tool
 straight_line_preview_tooltip = The Pencil tool can draw straight lines\nusing Shift + Click, with this option checked\nyou will see the preview immediately when\nthe Shift key is pressed

--- a/data/widgets/keyboard_shortcuts.xml
+++ b/data/widgets/keyboard_shortcuts.xml
@@ -1,5 +1,5 @@
 <!-- Aseprite -->
-<!-- Copyright (C) 2018-2024  Igara Studio S.A. -->
+<!-- Copyright (C) 2018-present  Igara Studio S.A. -->
 <!-- Copyright (C) 2001-2016  David Capello -->
 <gui>
   <window id="keyboard_shortcuts" text="@keyboard_shortcuts.title" help="keyboard-shortcuts">
@@ -52,6 +52,10 @@
                    pref="editor.zoom_with_slide" />
             <check text="@.invert_brush_size_wheel" id="invert_brush_size_scroll"
                    pref="editor.invert_brush_size_wheel" />
+            <hbox>
+              <label text="@options.wheel_scroll_speed" />
+              <slider id="wheel_scroll_speed" min="5" max="500" value="100" width="128" />
+            </hbox>
             <view expansive="true">
               <listbox id="wheel_actions" />
             </view>

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -278,8 +278,11 @@ int App::initialize(const AppOptions& options)
   system->setAppName(get_app_name());
   system->setAppMode(m_isGui ? os::AppMode::GUI : os::AppMode::CLI);
 
-  if (m_isGui)
+  if (m_isGui) {
     m_uiSystem.reset(new ui::UISystem);
+
+    ui::set_wheel_speed_factor(pref.editor.wheelScrollSpeed() / 100.0);
+  }
 
   bool createLogInDesktop = false;
   switch (options.verboseLevel()) {

--- a/src/app/commands/cmd_keyboard_shortcuts.cpp
+++ b/src/app/commands/cmd_keyboard_shortcuts.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2025  Igara Studio S.A.
+// Copyright (C) 2018-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -17,6 +17,7 @@
 #include "app/i18n/strings.h"
 #include "app/match_words.h"
 #include "app/modules/gui.h"
+#include "app/pref/preferences.h"
 #include "app/resource_finder.h"
 #include "app/tools/tool.h"
 #include "app/tools/tool_box.h"
@@ -37,6 +38,7 @@
 #include "ui/separator.h"
 #include "ui/size_hint_event.h"
 #include "ui/splitter.h"
+#include "ui/system.h"
 
 #include "keyboard_shortcuts.xml.h"
 
@@ -508,6 +510,7 @@ public:
     slideZoom()->setVisible(false);
 #endif
 
+    wheelScrollSpeed()->setValue(ui::get_wheel_speed_factor() * 100);
     wheelBehavior()->setSelectedItem(m_keys.hasMouseWheelCustomization() ? 1 : 0);
     if (isDefaultWheelBehavior()) {
       m_keys.setDefaultMouseWheelKeys(wheelZoom()->isSelected());
@@ -1056,6 +1059,9 @@ void KeyboardShortcutsCommand::onExecute(Context* context)
       msg.setPropagateToChildren(true);
       window.sendMessage(&msg);
     }
+
+    Preferences::instance().editor.wheelScrollSpeed(window.wheelScrollSpeed()->getValue());
+    ui::set_wheel_speed_factor(window.wheelScrollSpeed()->getValue() / 100.0);
 
     // Save keyboard shortcuts in configuration file
     {

--- a/src/app/ui/colsel/color_selector.cpp
+++ b/src/app/ui/colsel/color_selector.cpp
@@ -256,21 +256,25 @@ bool ColorSelector::onProcessMessage(ui::Message* msg)
           scale = 15.0;
         }
 
-        double newHue = m_color.getHsvHue() +
-                        scale * (+static_cast<MouseMessage*>(msg)->wheelDelta().x -
-                                 static_cast<MouseMessage*>(msg)->wheelDelta().y);
+        const double dz = scale * (static_cast<MouseMessage*>(msg)->wheelDelta().x -
+                                   static_cast<MouseMessage*>(msg)->wheelDelta().y);
 
-        while (newHue < 0.0)
-          newHue += 360.0;
-        newHue = std::fmod(newHue, 360.0);
+        const int step =
+          ui::adjustWheelStep(dz, static_cast<MouseMessage*>(msg)->preciseWheel(), 16);
+        if (step != 0) {
+          double newHue = m_color.getHsvHue() + step;
+          while (newHue < 0.0)
+            newHue += 360.0;
+          newHue = std::fmod(newHue, 360.0);
 
-        if (newHue != m_color.getHsvHue()) {
-          app::Color newColor = app::Color::fromHsv(newHue,
-                                                    m_color.getHsvSaturation(),
-                                                    m_color.getHsvValue(),
-                                                    currentAlphaForNewColor());
+          if (newHue != m_color.getHsvHue()) {
+            const app::Color newColor = app::Color::fromHsv(newHue,
+                                                            m_color.getHsvSaturation(),
+                                                            m_color.getHsvValue(),
+                                                            currentAlphaForNewColor());
 
-          ColorChange(newColor, kButtonNone);
+            ColorChange(newColor, kButtonNone);
+          }
         }
       }
       break;

--- a/src/app/ui/editor/state_with_wheel_behavior.cpp
+++ b/src/app/ui/editor/state_with_wheel_behavior.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2020-2023  Igara Studio S.A.
+// Copyright (C) 2020-present  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This program is distributed under the terms of
@@ -173,28 +173,34 @@ void StateWithWheelBehavior::processWheelAction(Editor* editor,
       break;
 
     case WheelAction::FgColor: {
-      int lastIndex = get_current_palette()->size() - 1;
-      int newIndex = initialFgColor().getIndex() + int(dz);
-      newIndex = std::clamp(newIndex, 0, lastIndex);
-      changeFgColor(app::Color::fromIndex(newIndex));
+      const int step = ui::adjustWheelStep(dz, preciseWheel == PreciseWheel::On, 16);
+      if (step != 0) {
+        int lastIndex = get_current_palette()->size() - 1;
+        int newIndex = std::clamp(initialFgColor().getIndex() + step, 0, lastIndex);
+        changeFgColor(app::Color::fromIndex(newIndex));
+      }
       break;
     }
 
     case WheelAction::BgColor: {
-      int lastIndex = get_current_palette()->size() - 1;
-      int newIndex = initialBgColor().getIndex() + int(dz);
-      newIndex = std::clamp(newIndex, 0, lastIndex);
-      ColorBar::instance()->setBgColor(app::Color::fromIndex(newIndex));
+      const int step = ui::adjustWheelStep(dz, preciseWheel == PreciseWheel::On, 16);
+      if (step != 0) {
+        int lastIndex = get_current_palette()->size() - 1;
+        int newIndex = std::clamp(initialBgColor().getIndex() + step, 0, lastIndex);
+        ColorBar::instance()->setBgColor(app::Color::fromIndex(newIndex));
+      }
       break;
     }
 
     case WheelAction::FgTile: {
       auto tilesView = ColorBar::instance()->getTilesView();
       if (tilesView->tileset()) {
-        int lastIndex = tilesView->tileset()->size() - 1;
-        int newIndex = initialFgTileIndex() + int(dz);
-        newIndex = std::clamp(newIndex, 0, lastIndex);
-        ColorBar::instance()->setFgTile(newIndex);
+        const int step = ui::adjustWheelStep(dz, preciseWheel == PreciseWheel::On, 16);
+        if (step != 0) {
+          const int lastIndex = tilesView->tileset()->size() - 1;
+          int newIndex = std::clamp(initialFgTileIndex() + step, 0, lastIndex);
+          ColorBar::instance()->setFgTile(newIndex);
+        }
       }
       break;
     }
@@ -202,10 +208,12 @@ void StateWithWheelBehavior::processWheelAction(Editor* editor,
     case WheelAction::BgTile: {
       auto tilesView = ColorBar::instance()->getTilesView();
       if (tilesView->tileset()) {
-        int lastIndex = tilesView->tileset()->size() - 1;
-        int newIndex = initialBgTileIndex() + int(dz);
-        newIndex = std::clamp(newIndex, 0, lastIndex);
-        ColorBar::instance()->setBgTile(newIndex);
+        const int step = ui::adjustWheelStep(dz, preciseWheel == PreciseWheel::On, 16);
+        if (step != 0) {
+          const int lastIndex = tilesView->tileset()->size() - 1;
+          int newIndex = std::clamp(initialBgTileIndex() + step, 0, lastIndex);
+          ColorBar::instance()->setBgTile(newIndex);
+        }
       }
       break;
     }
@@ -236,17 +244,13 @@ void StateWithWheelBehavior::processWheelAction(Editor* editor,
     case WheelAction::Zoom: {
       render::Zoom zoom = initialZoom(editor);
 
-      if (preciseWheel == PreciseWheel::On) {
-        dz /= 1.5;
-        if (dz < -1.0)
-          dz = -1.0;
-        else if (dz > 1.0)
-          dz = 1.0;
+      if (preciseWheel == PreciseWheel::On)
+        dz = std::clamp(dz, -1.0, 1.0);
+      const int step = ui::adjustWheelStep(dz, preciseWheel == PreciseWheel::On, 4);
+      if (step != 0) {
+        zoom = render::Zoom::fromLinearScale(zoom.linearScale() - step);
+        setZoom(editor, zoom, position);
       }
-
-      zoom = render::Zoom::fromLinearScale(zoom.linearScale() - int(dz));
-
-      setZoom(editor, zoom, position);
       break;
     }
 
@@ -254,23 +258,23 @@ void StateWithWheelBehavior::processWheelAction(Editor* editor,
     case WheelAction::VScroll: {
       View* view = View::getView(editor);
       gfx::Point scroll = initialScroll(editor);
+      const double speed = ui::get_wheel_speed_factor();
 
       if (preciseWheel == PreciseWheel::Off) {
         gfx::Rect vp = view->viewportBounds();
 
-        if (wheelAction == WheelAction::HScroll) {
-          delta.x = int(dz * vp.w);
-        }
-        else {
-          delta.y = int(dz * vp.h);
-        }
+        if (wheelAction == WheelAction::HScroll)
+          // 10 is an experimental value
+          delta.x = dz * vp.w * speed / 10;
+        else
+          delta.y = dz * vp.h * speed / 10;
 
-        if (scrollBigSteps == ScrollBigSteps::On) {
-          delta /= 2;
-        }
-        else {
-          delta /= 10;
-        }
+        if (scrollBigSteps == ScrollBigSteps::On)
+          delta *= 5;
+      }
+      else {
+        delta.x = delta.x * speed;
+        delta.y = delta.y * speed;
       }
 
       editor->setEditorScroll(scroll + delta);

--- a/src/app/ui/file_list.cpp
+++ b/src/app/ui/file_list.cpp
@@ -371,16 +371,11 @@ bool FileList::onProcessMessage(Message* msg)
           gfx::Point delta = static_cast<MouseMessage*>(msg)->wheelDelta();
           const bool precise = static_cast<MouseMessage*>(msg)->preciseWheel();
           double dz = delta.x + delta.y;
-
-          if (precise) {
-            dz /= 1.5;
-            if (dz < -1.0)
-              dz = -1.0;
-            else if (dz > 1.0)
-              dz = 1.0;
-          }
-
-          setZoom(zoom() - dz);
+          if (precise)
+            dz = std::clamp(dz, -1.0, 1.0);
+          const int step = ui::adjustWheelStep(dz, precise, 16);
+          if (step != 0)
+            setZoom(zoom() - step);
           break;
         }
         else {

--- a/src/app/ui/palette_view.cpp
+++ b/src/app/ui/palette_view.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2025  Igara Studio S.A.
+// Copyright (C) 2018-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -730,19 +730,30 @@ bool PaletteView::onProcessMessage(Message* msg)
 
       gfx::Point delta = static_cast<MouseMessage*>(msg)->wheelDelta();
 
+      const double speed = ui::get_wheel_speed_factor();
+
       if (msg->onlyCtrlPressed() || msg->onlyCmdPressed()) {
-        int z = delta.x - delta.y;
-        setBoxSize(m_boxsize + z);
+        const bool precise = static_cast<MouseMessage*>(msg)->preciseWheel();
+        const int step = ui::adjustWheelStep(delta.x - delta.y, precise, 4);
+        if (step != 0)
+          setBoxSize(m_boxsize + step);
       }
       else {
         gfx::Point scroll = view->viewScroll();
+        gfx::Point scrollDelta;
 
-        if (static_cast<MouseMessage*>(msg)->preciseWheel())
-          scroll += delta;
-        else
-          scroll += delta * 3 * boxSizePx();
+        if (static_cast<MouseMessage*>(msg)->preciseWheel()) {
+          scrollDelta = delta;
+          scrollDelta.x = scrollDelta.x * speed;
+          scrollDelta.y = scrollDelta.y * speed;
+        }
+        else {
+          const gfx::Size visible = view->visibleSize();
+          scrollDelta.x = delta.x * visible.w * speed / 10;
+          scrollDelta.y = delta.y * visible.h * speed / 10;
+        }
 
-        view->setViewScroll(scroll);
+        view->setViewScroll(scroll + scrollDelta);
       }
       break;
     }

--- a/src/app/ui/timeline/timeline.cpp
+++ b/src/app/ui/timeline/timeline.cpp
@@ -1494,32 +1494,28 @@ bool Timeline::onProcessMessage(Message* msg)
         if (msg->ctrlPressed() || // TODO configurable
             msg->cmdPressed()) {
           double dz = delta.x + delta.y;
-
-          if (precise) {
-            dz /= 1.5;
-            if (dz < -1.0)
-              dz = -1.0;
-            else if (dz > 1.0)
-              dz = 1.0;
-          }
-
-          setZoomAndUpdate(m_zoom - dz, true);
+          if (precise)
+            dz = std::clamp(dz, -1.0, 1.0);
+          const int step = ui::adjustWheelStep(dz, precise, 8);
+          if (step != 0)
+            setZoomAndUpdate(m_zoom - step, true);
         }
         else {
-          if (!precise) {
-            delta.x *= frameBoxWidth();
-            delta.y *= layerBoxHeight();
+          const double speed = ui::get_wheel_speed_factor();
 
+          if (!precise) {
             if (delta.x == 0 && // On macOS shift already changes the wheel axis
                 msg->shiftPressed()) {
               if (std::fabs(delta.y) > delta.x)
                 std::swap(delta.x, delta.y);
             }
 
-            if (msg->altPressed()) {
-              delta.x *= 3;
-              delta.y *= 3;
-            }
+            delta.x = delta.x * frameBoxWidth();
+            delta.y = delta.y * layerBoxHeight();
+          }
+          else {
+            delta.x = delta.x * speed;
+            delta.y = delta.y * speed;
           }
           setViewScroll(viewScroll() + delta);
         }

--- a/src/ui/slider.cpp
+++ b/src/ui/slider.cpp
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2019-2025  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2016  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -28,6 +28,8 @@ namespace ui {
 int Slider::slider_press_x;
 int Slider::slider_press_value;
 bool Slider::slider_press_left;
+// Accumulator to smoothly process wheel steps on a mouse with preciseWheel.
+static double step_accum = 0.0;
 
 Slider::Slider(int min, int max, int value, SliderDelegate* delegate)
   : Widget(kSliderWidget)
@@ -247,14 +249,23 @@ bool Slider::onProcessMessage(Message* msg)
 
     case kMouseWheelMessage:
       if (isEnabled() && !isReadOnly()) {
-        int value = m_value + static_cast<MouseMessage*>(msg)->wheelDelta().x -
-                    static_cast<MouseMessage*>(msg)->wheelDelta().y;
-
-        value = std::clamp(value, m_min, m_max);
-
-        if (m_value != value) {
-          setValue(value);
-          onChange();
+        const double dz = static_cast<MouseMessage*>(msg)->wheelDelta().x -
+                          static_cast<MouseMessage*>(msg)->wheelDelta().y;
+        int step;
+        if (static_cast<MouseMessage*>(msg)->preciseWheel()) {
+          step_accum += dz * (m_max - m_min) * get_wheel_speed_factor() / 256;
+          step = step_accum;
+          step_accum -= step;
+        }
+        else {
+          step = dz;
+        }
+        if (step != 0) {
+          const int value = std::clamp(m_value + step, m_min, m_max);
+          if (m_value != value) {
+            setValue(value);
+            onChange();
+          }
         }
         return true;
       }

--- a/src/ui/system.cpp
+++ b/src/ui/system.cpp
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2018-2025  Igara Studio S.A.
+// Copyright (C) 2018-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -42,6 +42,9 @@ static CursorType mouse_cursor_type = kOutsideDisplay;
 static const Cursor* mouse_cursor_custom = nullptr;
 static Display* mouse_display = nullptr;
 static bool use_native_mouse_cursor = true;
+
+// Mouse wheel speed
+static double wheel_speed_factor = 1.0;
 
 // Mouse information
 static int mouse_cursor_scale = 1;
@@ -215,6 +218,30 @@ bool get_clipboard_text(std::string& text)
     return delegate->getClipboardText(text);
   else
     return false;
+}
+
+void set_wheel_speed_factor(double factor)
+{
+  wheel_speed_factor = factor;
+}
+
+double get_wheel_speed_factor()
+{
+  return wheel_speed_factor;
+}
+
+// Accumulator to smoothly process wheel steps on a mouse with preciseWheel.
+static double step_accum = 0.0;
+
+int adjustWheelStep(double dz, bool precise, double divisor)
+{
+  if (precise) {
+    step_accum += dz * wheel_speed_factor / divisor;
+    const int step = step_accum;
+    step_accum -= step;
+    return step;
+  }
+  return int(dz);
 }
 
 void set_use_native_cursors(bool state)

--- a/src/ui/system.h
+++ b/src/ui/system.h
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2019-2025  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -65,6 +65,10 @@ gfx::Point get_mouse_position();
 // Sets the mouse position relative to a specific display (or
 // relative to the desktop if it's nullptr)
 void set_mouse_position(const gfx::Point& newPos, Display* display);
+
+void set_wheel_speed_factor(double factor);
+double get_wheel_speed_factor();
+int adjustWheelStep(double dz, bool precise, double divisor);
 
 void execute_from_ui_thread(std::function<void()>&& func);
 // If it is called from the UI thread just executes the function, if it is

--- a/src/ui/view.cpp
+++ b/src/ui/view.cpp
@@ -1,5 +1,5 @@
 // Aseprite UI Library
-// Copyright (C) 2018-2025  Igara Studio S.A.
+// Copyright (C) 2018-present  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -41,6 +41,9 @@
 namespace ui {
 
 using namespace gfx;
+
+static double wheelScrollAccumX = 0.0;
+static double wheelScrollAccumY = 0.0;
 
 View::View() : Widget(kViewWidget), m_scrollbar_h(HORIZONTAL, this), m_scrollbar_v(VERTICAL, this)
 {
@@ -216,24 +219,35 @@ void View::scrollByMessage(const Widget* widget, Message* message, std::optional
     return;
 
   auto mouseMsg = static_cast<MouseMessage*>(message);
-
-  if (!multiplier.has_value())
-    multiplier = widget->textHeight() * 3;
-
+  const double speed = get_wheel_speed_factor();
   gfx::Point scroll = view->viewScroll();
+  gfx::Point delta;
 
-  if (mouseMsg->preciseWheel())
-    scroll += mouseMsg->wheelDelta();
-  else
-    scroll += mouseMsg->wheelDelta() * (*multiplier);
+  if (mouseMsg->preciseWheel()) {
+    const gfx::Point wd = mouseMsg->wheelDelta();
+    wheelScrollAccumX += wd.x * speed;
+    wheelScrollAccumY += wd.y * speed;
+    delta.x = wheelScrollAccumX;
+    delta.y = wheelScrollAccumY;
+    wheelScrollAccumX -= delta.x;
+    wheelScrollAccumY -= delta.y;
+  }
+  else {
+    const gfx::Point wd = mouseMsg->wheelDelta();
+    delta.x = wd.x * view->visibleSize().w * speed / 10;
+    delta.y = wd.y * view->visibleSize().h * speed / 10;
+  }
 
-  view->setViewScroll(scroll);
+  view->setViewScroll(scroll + delta);
 }
 
 bool View::onProcessMessage(Message* msg)
 {
   switch (msg->type()) {
     case kFocusEnterMessage:
+      wheelScrollAccumX = 0.0;
+      wheelScrollAccumY = 0.0;
+      [[fallthrough]];
     case kFocusLeaveMessage:
       // TODO This is theme specific stuff
       // Redraw the borders each time the focus enters or leaves the view.


### PR DESCRIPTION
These changes make it possible to fine-tune the sensitivity/response speed of both the mouse wheel and trackpad wheel emulation.

During the implementation, I realized that each context using trackpad wheel emulation required its own baseline adjustment. As a result, I had to experimentally tune some values, which is why you may notice a few hardcoded constants.

There is a complementary PR to improve the behavior on Windows: https://github.com/aseprite/laf/pull/192

fix #5103