### PR TITLE
aseprite-thumbnailer: fix, and prevent argument injection

### DIFF
--- a/src/desktop/linux/aseprite-thumbnailer
+++ b/src/desktop/linux/aseprite-thumbnailer
@@ -6,14 +6,11 @@
 # Licensed under the the MIT License (https://opensource.org/licenses/MIT).
 
 if [ $# -ge 2 -a $# -lt 4 ]; then
-  mkdir -p /tmp/Aseprite
-  filename=${1//\//.}$RANDOM
   if [ $# -eq 2 ]; then
-    aseprite -b --frame-range "0,0" $1 --sheet /tmp/Aseprite/$filename.png
+    aseprite -b --frame-range "0,0" "$1" --sheet "$2"
   elif [ $# -eq 3 ]; then
-    aseprite -b --frame-range "0,0" $1 --shrink-to "$3,$3" --sheet /tmp/Aseprite/$filename.png
+    aseprite -b --frame-range "0,0" "$1" --shrink-to "$3,$3" --sheet "$2"
   fi
-  mkdir -p $(dirname "$2"); mv /tmp/Aseprite/$filename.png $2;
 else
   echo "Parameters for aseprite thumbnailer are: inputfile outputfile [size]"
 fi


### PR DESCRIPTION
Hello! I was using aseprite(source build) on Linux in sway WM with terminal file managers. So, I never actually touched aseprite-thumbnailer until recently. I tried it in both thunar, dolphin, and thumbnailer is not working. Plus, It is also leading to possible code execution in Thunar. Dolphin simply doesn't generate thumbnail and doesn't cause code execution. Nautilus works fine.

### How to make that code execution work
- systems with default sh is symlink to bash
- file manager is Thunar with tumbler thumbnailer installed
- create injection lua script
- save a valid aseprite file with spaces in name. e.g. `abc --script inject.lua .aseprite`
- open thunar and navigate to that aseprite file. the lua script will be executed.

demostration in a ubuntu vm with sh symlinked to bash. (mouse pointer lost in recorded video)

https://github.com/user-attachments/assets/f7124930-0259-4186-a16d-10fe479ed8cb



Before, 
Thunar: no thumbnail, code exec
dolphin: no thumbnail
nautilus: works fine
<img width="1920" height="1080" alt="before-withspace" src="https://github.com/user-attachments/assets/1bdb7032-d244-4d80-9d79-5aa61fbf57f1" />

After fix, it shows thumbnails correctly both in thunar and dolphin
<img width="1920" height="1080" alt="after" src="https://github.com/user-attachments/assets/6a454b2c-f438-4092-8ec7-a762070b3577" />

