### PR TITLE
Fix multi-layer selection movement preview isn't working (fix #2865)

### DIFF
--- a/src/app/commands/cmd_move_mask.cpp
+++ b/src/app/commands/cmd_move_mask.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2024  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -10,7 +10,6 @@
 #endif
 
 #include "app/app.h"
-#include "app/cmd/shift_masked_cel.h"
 #include "app/commands/cmd_move_mask.h"
 #include "app/commands/command.h"
 #include "app/commands/params.h"
@@ -52,17 +51,12 @@ bool MoveMaskCommand::onEnabled(Context* context)
     case Boundaries:
       return context->checkFlags(ContextFlags::HasActiveDocument | ContextFlags::HasVisibleMask);
 
-    case Content:
-      if (m_wrap)
-        return context->checkFlags(ContextFlags::ActiveDocumentIsWritable |
-                                   ContextFlags::HasVisibleMask | ContextFlags::HasActiveImage |
-                                   ContextFlags::ActiveLayerIsEditable);
-      else {
-        auto editor = Editor::activeEditor();
-        return (editor != nullptr) &&
-               context->checkFlags(ContextFlags::HasActiveDocument | ContextFlags::HasVisibleMask |
-                                   ContextFlags::HasActiveImage);
-      }
+    case Content: {
+      auto* editor = Editor::activeEditor();
+      return (editor != nullptr) &&
+             context->checkFlags(ContextFlags::HasActiveDocument | ContextFlags::HasVisibleMask |
+                                 ContextFlags::HasActiveImage);
+    }
   }
 
   return false;
@@ -93,23 +87,14 @@ void MoveMaskCommand::onExecute(Context* context)
       break;
     }
 
-    case Content:
-      if (m_wrap) {
-        ContextWriter writer(context);
-        if (writer.cel()) {
-          // Rotate content
-          Tx tx(writer,
-                Strings::commands_MoveMask(Strings::commands_MoveMask_Content(), moveString));
-          tx(new cmd::ShiftMaskedCel(writer.cel(), delta.x, delta.y));
-          tx.commit();
-        }
-        update_screen_for_document(writer.document());
-      }
-      else {
-        auto editor = Editor::activeEditor();
+    case Content: {
+      auto* editor = Editor::activeEditor();
+      if (m_wrap)
+        editor->startShiftTransformation(delta.x, delta.y);
+      else
         editor->startSelectionTransformation(delta, 0.0);
-      }
       break;
+    }
   }
 }
 

--- a/src/app/extra_cel.h
+++ b/src/app/extra_cel.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2024  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -19,6 +19,7 @@
 #include "gfx/rect.h"
 #include "render/extra_type.h"
 
+#include <map>
 #include <memory>
 
 namespace doc {
@@ -26,6 +27,20 @@ class Sprite;
 }
 
 namespace app {
+
+// Data structure to hold original and transformed cel information
+// for multi-cel transformations. The key in the map is the original
+// cel pointer, and the value contains the clipped original image
+// and the transformed image with their respective bounds.
+struct ExtraCelData {
+  gfx::Rect originalBounds;
+  doc::ImageRef originalImage;
+  gfx::Rect transformedBounds;
+  doc::ImageRef transformedImage;
+};
+
+// Image Map used in PixelsMovement to correctly preview transformations
+using ExtraCelMap = std::map<const doc::Cel*, ExtraCelData>;
 
 class ExtraCel {
 public:
@@ -58,6 +73,12 @@ public:
   doc::BlendMode blendMode() const { return m_blendMode; }
   void setBlendMode(doc::BlendMode mode) { m_blendMode = mode; }
 
+  // Functions useful for PixelsMovement process and render::renderPlan
+  // function.
+  ExtraCelMap& celMap() { return m_celMap; }
+  const ExtraCelMap& celMap() const { return m_celMap; }
+  void clearCelMap() { m_celMap.clear(); }
+
 private:
   Purpose m_purpose;
   render::ExtraType m_type;
@@ -65,6 +86,9 @@ private:
   doc::ImageRef m_image;
   doc::ImageBufferPtr m_imageBuffer;
   doc::BlendMode m_blendMode;
+
+  // Map linking original cels to their original/transformed image data
+  ExtraCelMap m_celMap;
 
   DISABLE_COPYING(ExtraCel);
 };

--- a/src/app/render/renderer.h
+++ b/src/app/render/renderer.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2022-2023  Igara Studio S.A.
+// Copyright (C) 2022-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -83,6 +83,8 @@ public:
                              const doc::Layer* currentLayer,
                              const doc::frame_t currentFrame) = 0;
   virtual void removeExtraImage() = 0;
+  virtual void setExtraCelInfoMap(const render::ExtraCelInfoMap* map) = 0;
+  virtual void removeExtraCelInfoMap() = 0;
   virtual void setOnionskin(const render::OnionskinOptions& options) = 0;
   virtual void disableOnionskin() = 0;
 

--- a/src/app/render/shader_renderer.cpp
+++ b/src/app/render/shader_renderer.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2022-2024  Igara Studio S.A.
+// Copyright (C) 2022-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -165,6 +165,16 @@ void ShaderRenderer::setExtraImage(render::ExtraType type,
 void ShaderRenderer::removeExtraImage()
 {
   // TODO impl
+}
+
+void ShaderRenderer::setExtraCelInfoMap(const render::ExtraCelInfoMap* map)
+{
+  m_extraCelInfoMap = map;
+}
+
+void ShaderRenderer::removeExtraCelInfoMap()
+{
+  m_extraCelInfoMap = nullptr;
 }
 
 void ShaderRenderer::setOnionskin(const render::OnionskinOptions& options)

--- a/src/app/render/shader_renderer.h
+++ b/src/app/render/shader_renderer.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2022-2023  Igara Studio S.A.
+// Copyright (C) 2022-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -58,6 +58,8 @@ public:
                      const doc::Layer* currentLayer,
                      const doc::frame_t currentFrame) override;
   void removeExtraImage() override;
+  void setExtraCelInfoMap(const render::ExtraCelInfoMap* map) override;
+  void removeExtraCelInfoMap() override;
   void setOnionskin(const render::OnionskinOptions& options) override;
   void disableOnionskin() override;
 
@@ -112,6 +114,9 @@ private:
   // Palette of 256 colors (useful for the indexed shader to set all
   // colors outside the valid range as transparent RGBA=0 values)
   doc::Palette m_palette;
+
+  // Map for per-cel extra rendering (multi-cel transformations)
+  const render::ExtraCelInfoMap* m_extraCelInfoMap = nullptr;
 };
 
 } // namespace app

--- a/src/app/render/simple_renderer.cpp
+++ b/src/app/render/simple_renderer.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2022-2023  Igara Studio S.A.
+// Copyright (C) 2022-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -85,6 +85,16 @@ void SimpleRenderer::setExtraImage(render::ExtraType type,
 void SimpleRenderer::removeExtraImage()
 {
   m_render.removeExtraImage();
+}
+
+void SimpleRenderer::setExtraCelInfoMap(const render::ExtraCelInfoMap* map)
+{
+  m_render.setExtraCelInfoMap(map);
+}
+
+void SimpleRenderer::removeExtraCelInfoMap()
+{
+  m_render.removeExtraCelInfoMap();
 }
 
 void SimpleRenderer::setOnionskin(const render::OnionskinOptions& options)

--- a/src/app/render/simple_renderer.h
+++ b/src/app/render/simple_renderer.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2022-2023  Igara Studio S.A.
+// Copyright (C) 2022-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -43,6 +43,8 @@ public:
                      const doc::Layer* currentLayer,
                      const doc::frame_t currentFrame) override;
   void removeExtraImage() override;
+  void setExtraCelInfoMap(const render::ExtraCelInfoMap* map) override;
+  void removeExtraCelInfoMap() override;
   void setOnionskin(const render::OnionskinOptions& options) override;
   void disableOnionskin() override;
 

--- a/src/app/ui/editor/editor.cpp
+++ b/src/app/ui/editor/editor.cpp
@@ -3072,6 +3072,14 @@ void Editor::startFlipTransformation(doc::algorithm::FlipType flipType)
     standby->startFlipTransformation(this, flipType);
 }
 
+void Editor::startShiftTransformation(int dx, int dy)
+{
+  if (auto movingPixels = dynamic_cast<MovingPixelsState*>(m_state.get()))
+    movingPixels->shift(dx, dy);
+  else if (auto standby = dynamic_cast<StandbyState*>(m_state.get()))
+    standby->startShiftTransformation(this, dx, dy);
+}
+
 void Editor::updateTransformation(const Transformation& transform)
 {
   if (auto movingPixels = dynamic_cast<MovingPixelsState*>(m_state.get()))

--- a/src/app/ui/editor/editor.cpp
+++ b/src/app/ui/editor/editor.cpp
@@ -59,6 +59,7 @@
 #include "base/chrono.h"
 #include "base/convert_to.h"
 #include "base/scoped_value.h"
+#include "doc/blend_internals.h"
 #include "doc/doc.h"
 #include "doc/mask_boundaries.h"
 #include "doc/slice.h"
@@ -732,6 +733,23 @@ void Editor::drawOneSpriteUnclippedRect(ui::Graphics* g,
                                     m_frame);
     }
 
+    // Build map for per-cel extra rendering (multi-cel transformations)
+    // We use cel->data() as key to support linked cels.
+    render::ExtraCelInfoMap extraCelInfoMap;
+    if (extraCel && !extraCel->celMap().empty()) {
+      for (const auto& [cel, data] : extraCel->celMap()) {
+        if (data.transformedImage) {
+          int t;
+          extraCelInfoMap[cel->data()] = { data.transformedBounds,
+                                           data.transformedImage.get(),
+                                           MUL_UN8(cel->opacity(), cel->layer()->opacity(), t),
+                                           cel->layer()->blendMode() };
+        }
+      }
+      if (!extraCelInfoMap.empty())
+        m_renderEngine->setExtraCelInfoMap(&extraCelInfoMap);
+    }
+
     // Render background first (e.g. new ShaderRenderer will paint the
     // background on the screen first and then composite the rendered
     // sprite on it.)
@@ -756,6 +774,7 @@ void Editor::drawOneSpriteUnclippedRect(ui::Graphics* g,
     m_renderEngine->renderSprite(rendered.get(), m_sprite, m_frame, gfx::Clip(0, 0, rc2));
 
     m_renderEngine->removeExtraImage();
+    m_renderEngine->removeExtraCelInfoMap();
 
     // If the checkered background is visible in this sprite, we save
     // all settings of the background for this document.
@@ -3002,6 +3021,13 @@ void Editor::pasteImage(const Image* image, const Mask* mask, const gfx::Point* 
   }
 
   Site site = getSite();
+
+  // Do nothing when the image format to paste isn't compatible with
+  // the current layer + TilemapMode.
+  if ((image->pixelFormat() != IMAGE_TILEMAP && site.layer()->isTilemap() &&
+       site.tilemapMode() == TilemapMode::Tiles) ||
+      (image->pixelFormat() == IMAGE_TILEMAP && site.tilemapMode() == TilemapMode::Pixels))
+    return;
 
   // Snap to grid a pasted tilemap
   // TODO should we move this to PixelsMovement or MovingPixelsState?

--- a/src/app/ui/editor/editor.h
+++ b/src/app/ui/editor/editor.h
@@ -249,6 +249,7 @@ public:
 
   void startSelectionTransformation(const gfx::Point& move, double angle);
   void startFlipTransformation(doc::algorithm::FlipType flipType);
+  void startShiftTransformation(int dx, int dy);
   void updateTransformation(const Transformation& transform);
 
   // Used by EditorView to notify changes in the view's scroll

--- a/src/app/ui/editor/editor_render.cpp
+++ b/src/app/ui/editor/editor_render.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2023  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2018  David Capello
 //
 // This program is distributed under the terms of
@@ -163,6 +163,16 @@ void EditorRender::setExtraImage(render::ExtraType type,
 void EditorRender::removeExtraImage()
 {
   m_renderer->removeExtraImage();
+}
+
+void EditorRender::setExtraCelInfoMap(const render::ExtraCelInfoMap* map)
+{
+  m_renderer->setExtraCelInfoMap(map);
+}
+
+void EditorRender::removeExtraCelInfoMap()
+{
+  m_renderer->removeExtraCelInfoMap();
 }
 
 void EditorRender::setOnionskin(const render::OnionskinOptions& options)

--- a/src/app/ui/editor/editor_render.h
+++ b/src/app/ui/editor/editor_render.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2022  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2018  David Capello
 //
 // This program is distributed under the terms of
@@ -20,6 +20,7 @@
 #include "render/extra_type.h"
 #include "render/onionskin_options.h"
 #include "render/projection.h"
+#include "render/render.h"
 
 namespace doc {
 class Cel;
@@ -79,6 +80,8 @@ public:
                      const doc::Layer* currentLayer,
                      doc::frame_t currentFrame);
   void removeExtraImage();
+  void setExtraCelInfoMap(const render::ExtraCelInfoMap* map);
+  void removeExtraCelInfoMap();
 
   void setOnionskin(const render::OnionskinOptions& options);
   void disableOnionskin();

--- a/src/app/ui/editor/pixels_movement.cpp
+++ b/src/app/ui/editor/pixels_movement.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2026  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -41,8 +41,10 @@
 #include "doc/cel.h"
 #include "doc/image.h"
 #include "doc/layer.h"
+#include "doc/layer_tilemap.h"
 #include "doc/mask.h"
 #include "doc/sprite.h"
+#include "doc/tileset.h"
 #include "doc/util.h"
 #include "gfx/region.h"
 #include "render/render.h"
@@ -133,18 +135,35 @@ PixelsMovement::PixelsMovement(Context* context,
   // TODO: enable TilemapMode exchanges during PixelMovement.
   if (m_site.layer()->isTilemap() && ColorBar::instance())
     ColorBar::instance()->lockTilemapMode();
-  const float cornerThick = (m_site.tilemapMode() == TilemapMode::Tiles ?
-                               CORNER_THICK_FOR_TILEMAP_MODE :
-                               CORNER_THICK_FOR_PIXELS_MODE);
-  Transformation transform(mask->bounds(), cornerThick);
+
+  const bool isTilemapTilesMode = m_site.layer()->isTilemap() &&
+                                  m_site.tilemapMode() == TilemapMode::Tiles;
+  // If TilemapMode::Pixels it's need to force TilesetMode::Stack to generate
+  // new tiles during the transformation.
+  if (!isTilemapTilesMode)
+    m_site.tilesetMode(TilesetMode::Stack);
+  const float cornerThick = (isTilemapTilesMode ? CORNER_THICK_FOR_TILEMAP_MODE :
+                                                  CORNER_THICK_FOR_PIXELS_MODE);
+
+  // When in TilemapMode::Tiles, align the mask to the grid so we select
+  // complete tiles
+  std::unique_ptr<Mask> alignedMask;
+  const Mask* effectiveMask = mask;
+  if (isTilemapTilesMode) {
+    const doc::Grid grid = m_site.grid();
+    alignedMask.reset(new Mask(make_aligned_mask(&grid, mask)));
+    effectiveMask = alignedMask.get();
+  }
+
+  Transformation transform(effectiveMask->bounds(), cornerThick);
   set_pivot_from_preferences(transform);
 
   m_initialData = transform;
   m_currentData = transform;
 
-  m_initialMask.reset(new Mask(*mask));
-  m_initialMask0.reset(new Mask(*mask));
-  m_currentMask.reset(new Mask(*mask));
+  m_initialMask.reset(new Mask(*effectiveMask));
+  m_initialMask0.reset(new Mask(*effectiveMask));
+  m_currentMask.reset(new Mask(*effectiveMask));
 
   m_pivotVisConn = Preferences::instance().selection.pivotVisibility.AfterChange.connect(
     [this] { onPivotChange(); });
@@ -157,8 +176,48 @@ PixelsMovement::PixelsMovement(Context* context,
   // that someone else is using it (e.g. the editor brush preview),
   // and its owner could destroy our new "extra cel".
   ASSERT(!m_document->extraCel());
-  redrawExtraImage();
+
+  // Fill the selected cels vector and initialize the ExtraCelMap
+  // with the original clipped images for each cel.
+  // In TilemapMode::Tiles, filter out tilemap cels with different
+  // tileSizes and offset.
+  m_selectedCels = getEditableCels(isTilemapTilesMode);
+  if (!m_extraCel)
+    m_extraCel.reset(new ExtraCel);
+
+  // Create the celMap only in multi-cel cases only
+  if (m_selectedCels.size() > 1) {
+    for (Cel* cel : m_selectedCels) {
+      if (!cel ||
+          // Exclude only the current cel in the "cel Map".
+          // The current cel will be processed in drawImage
+          // the others cels will be processed in drawImages
+          cel == m_site.cel())
+        continue;
+
+      ExtraCelData data;
+      data.originalBounds = m_initialMask->bounds();
+
+      if (cel->layer()->isTilemap() && m_site.tilemapMode() == TilemapMode::Tiles) {
+        Site celSite = m_site;
+        celSite.layer(cel->layer());
+        celSite.frame(cel->frame());
+        data.originalImage.reset(new_tilemap_from_mask(celSite, m_initialMask.get()));
+      }
+      else {
+        data.originalImage.reset(
+          new_image_from_mask(*cel->layer(),
+                              cel->frame(),
+                              m_initialMask.get(),
+                              Preferences::instance().experimental.newBlend()));
+      }
+
+      m_extraCel->celMap()[cel] = std::move(data);
+    }
+  }
+
   redrawCurrentMask();
+  redrawExtraImages();
 
   // If the mask is different than the mask from the document
   // (e.g. it's from Paste command), we've to replace the document
@@ -194,7 +253,7 @@ void PixelsMovement::setFastMode(const bool fastMode)
   bool redraw = (m_fastMode && !fastMode);
   m_fastMode = fastMode;
   if (m_needsRotSpriteRedraw && redraw) {
-    redrawExtraImage();
+    redrawExtraImages();
     update_screen_for_document(m_document);
     m_needsRotSpriteRedraw = false;
   }
@@ -205,14 +264,15 @@ void PixelsMovement::flipImage(doc::algorithm::FlipType flipType)
   m_innerCmds.push_back(InnerCmd::MakeFlip(flipType));
 
   flipOriginalImage(flipType);
+  flipOriginalImages(flipType);
 
   {
     ContextWriter writer(m_reader, 1000);
 
     // Regenerate the transformed (rotated, scaled, etc.) image and
     // mask.
-    redrawExtraImage();
     redrawCurrentMask();
+    redrawExtraImages();
     updateDocumentMask();
 
     update_screen_for_document(m_document);
@@ -226,8 +286,8 @@ void PixelsMovement::rotate(double angle)
 
   m_document->setTransformation(m_currentData);
 
-  redrawExtraImage();
   redrawCurrentMask();
+  redrawExtraImages();
   updateDocumentMask();
 
   update_screen_for_document(m_document);
@@ -238,12 +298,13 @@ void PixelsMovement::shift(int dx, int dy)
   const double angle = m_currentData.angle();
   m_innerCmds.push_back(InnerCmd::MakeShift(dx, dy, angle));
   shiftOriginalImage(dx, dy, angle);
+  shiftOriginalImages(dx, dy, angle);
 
   {
     ContextWriter writer(m_reader, 1000);
 
-    redrawExtraImage();
     redrawCurrentMask();
+    redrawExtraImages();
     updateDocumentMask();
 
     update_screen_for_document(m_document);
@@ -256,7 +317,7 @@ void PixelsMovement::setTransformation(const Transformation& t)
 
   setTransformationBase(t);
 
-  redrawCurrentMask();
+  // redrawCurrentMask() is already called inside setTransformationBase()
   updateDocumentMask();
 
   update_screen_for_document(m_document);
@@ -271,7 +332,9 @@ void PixelsMovement::setTransformationBase(const Transformation& t)
   m_currentData = t;
   auto newCorners = m_currentData.transformedCorners();
 
-  redrawExtraImage();
+  // Update mask first so drawImages() can use the updated mask bounds
+  redrawCurrentMask();
+  redrawExtraImages();
 
   m_document->setTransformation(m_currentData);
 
@@ -311,7 +374,7 @@ void PixelsMovement::trim()
 
   // TODO this is similar to clear_mask_from_cels()
 
-  for (Cel* cel : getEditableCels()) {
+  for (Cel* cel : m_selectedCels) {
     if (cel != activeCel) {
       if (!restoreMask) {
         m_document->setMask(m_initialMask0.get());
@@ -336,11 +399,11 @@ void PixelsMovement::cutMask()
 
   {
     ContextWriter writer(m_reader, 1000);
-    if (writer.cel()) {
-      clear_mask_from_cel(m_tx, writer.cel(), m_site.tilemapMode(), m_site.tilesetMode());
 
-      // Do not trim here so we don't lost the information about all
-      // linked cels related to "writer.cel()"
+    // Cut from all selected cels, not just the current one
+    for (Cel* cel : m_selectedCels) {
+      if (cel)
+        clear_mask_from_cel(m_tx, cel, m_site.tilemapMode(), m_site.tilesetMode());
     }
   }
 
@@ -551,6 +614,18 @@ void PixelsMovement::moveImage(const gfx::PointF& pos, MoveModifier moveModifier
       bounds.y = a.y;
       bounds.w = b.x - a.x;
       bounds.h = b.y - a.y;
+
+      // In TilemapMode::Tiles, limit the scaling to a minimum of 1 tile
+      // and ensure width/height are always positive.
+      if (tilesModeOn) {
+        gfx::Rect gridBounds = m_site.gridBounds();
+        double minW = gridBounds.w;
+        double minH = gridBounds.h;
+        if (bounds.w < minW)
+          bounds.w = minW;
+        if (bounds.h < minH)
+          bounds.h = minH;
+      }
 
       newTransformation.bounds(bounds);
       m_adjustPivot = true;
@@ -808,38 +883,6 @@ void PixelsMovement::getDraggedImageCopy(std::unique_ptr<Image>& outputImage,
   outputMask.reset(mask.release());
 }
 
-void PixelsMovement::alignMasksAndTransformData(const Mask* initialMask0,
-                                                const Mask* initialMask,
-                                                const Mask* currentMask,
-                                                const Transformation* initialData,
-                                                const Transformation* currentData,
-                                                const doc::Grid& grid,
-                                                const gfx::Size& deltaA,
-                                                const gfx::Size& deltaB)
-{
-  m_initialMask0->replace(make_aligned_mask(&grid, initialMask0));
-  m_initialMask->replace(make_aligned_mask(&grid, initialMask));
-  m_currentMask->replace(make_aligned_mask(&grid, currentMask));
-  m_initialData = *initialData;
-  m_initialData.bounds(m_initialMask0->bounds());
-  m_currentData = *currentData;
-  // Raw grid alignment of currentData can result in unintentional scaling.
-  // That's why we need to know if the artist's intention was just to move
-  // the selection and/or scaling via 'initialDeltaA' and 'initialDeltaB'.
-  const gfx::Point currentDataAlignedOrigin =
-    grid
-      .alignBounds(
-        gfx::Rect(m_initialData.bounds().x + deltaA.w, m_initialData.bounds().y + deltaA.h, 1, 1))
-      .origin();
-  int deltaH = deltaB.w - deltaA.w;
-  int deltaV = deltaB.h - deltaA.h;
-  const gfx::RectF currentDataBounds(currentDataAlignedOrigin.x,
-                                     currentDataAlignedOrigin.y,
-                                     m_initialData.bounds().w + deltaH,
-                                     m_initialData.bounds().h + deltaV);
-  m_currentData.bounds(currentDataBounds);
-}
-
 void PixelsMovement::stampImage()
 {
   stampImage(false);
@@ -854,113 +897,20 @@ void PixelsMovement::stampImage(bool finalStamp)
   ContextWriter writer(m_reader, 1000);
   Cel* currentCel = m_site.cel();
 
-  CelList cels;
-  if (finalStamp) {
-    cels = getEditableCels();
-  }
   // Current cel (m_site.cel()) can be nullptr when we paste in an
   // empty cel (Ctrl+V) and cut (Ctrl+X) the floating pixels.
-  else {
-    cels.push_back(currentCel);
-  }
-
   if (currentCel && currentCel->layer() && currentCel->layer()->isImage() &&
       !currentCel->layer()->canEditPixels()) {
     Transformation initialCelPos(gfx::Rect(m_initialMask0->bounds()), m_currentData.cornerThick());
-    redrawExtraImage(&initialCelPos);
+    redrawExtraImages(&initialCelPos);
     stampExtraCelImage();
+    return;
   }
-
-  // Saving original values before the 'for' loop and the
-  // 'reproduceAllTransformationsWithInnerCmds' function for restoring later.
-  // All values of m_initialXX, m_currentXX will be recalculated
-  // to align their original selection bounds with each cel's grid.
-  const TilemapMode originalSiteTilemapMode = (m_site.tilemapMode() == TilemapMode::Tiles &&
-                                                   m_site.layer()->isTilemap() ?
-                                                 TilemapMode::Tiles :
-                                                 TilemapMode::Pixels);
-  const TilesetMode originalSiteTilesetMode = m_site.tilesetMode();
-  const Mask initialMask0(*m_initialMask0);
-  const Mask initialMask(*m_initialMask);
-  const Mask currentMask(*m_currentMask);
-  auto initialData = m_initialData;
-  auto currentData = m_currentData;
-
-  // We need a way to know if 'a' or 'b' corners has changed
-  // as result of a scaling or moving command to replicate the intention on
-  // the other layers according the original mask (which can be aligned or
-  // not to the tilemap grid)
-  //
-  //   a ----
-  //   |     |
-  //   |     |
-  //    ---- b
-  const gfx::Rect currentAlignedBounds(m_site.grid().alignBounds(currentData.bounds()));
-  const gfx::Rect initialAlignedBounds(m_site.grid().alignBounds(initialMask.bounds()));
-  const gfx::Size deltaA(currentAlignedBounds.origin().x - initialAlignedBounds.origin().x,
-                         currentAlignedBounds.origin().y - initialAlignedBounds.origin().y);
-  const gfx::Size deltaB(currentAlignedBounds.x2() - initialAlignedBounds.x2(),
-                         currentAlignedBounds.y2() - initialAlignedBounds.y2());
-
-  for (Cel* target : cels) {
-    // We'll re-create the transformation for the other cels
-    if (target != currentCel) {
-      ASSERT(target);
-      m_site.layer(target->layer());
-      m_site.frame(target->frame());
-      ASSERT(m_site.cel() == target);
-      Grid targetGrid(m_site.grid());
-      // Align masks and transformData before to 'reproduceAllTransformationsWithInnerCmds'
-      // Note: this alignement is needed only when the editor is on 'TilemapMode::Tiles',
-      // on the other hand 'TilemapMode::Pixels' do not require any additional
-      // mask/transformData adjustments.
-      if (originalSiteTilemapMode == TilemapMode::Tiles) {
-        if (target->layer()->isTilemap()) {
-          alignMasksAndTransformData(&initialMask0,
-                                     &initialMask,
-                                     &currentMask,
-                                     &initialData,
-                                     &currentData,
-                                     targetGrid,
-                                     deltaA,
-                                     deltaB);
-          m_site.tilemapMode(TilemapMode::Tiles);
-        }
-        else {
-          m_initialMask0->replace(initialMask0);
-          m_initialMask->replace(initialMask);
-          m_currentMask->replace(currentMask);
-          m_initialData.bounds(initialData.bounds());
-          m_currentData.bounds(currentData.bounds());
-          m_site.tilemapMode(TilemapMode::Pixels);
-        }
-      }
-      else {
-        m_site.tilemapMode(TilemapMode::Pixels);
-        m_site.tilesetMode(TilesetMode::Auto);
-      }
-      reproduceAllTransformationsWithInnerCmds();
-    }
-
-    redrawExtraImage();
-    stampExtraCelImage();
-  }
-
-  m_initialMask0->replace(initialMask0);
-  m_initialMask->replace(initialMask);
-  m_currentMask->replace(currentMask);
-  m_initialData.bounds(initialData.bounds());
-  m_currentData.bounds(currentData.bounds());
-  m_site.tilesetMode(originalSiteTilesetMode);
-  currentCel = m_site.cel();
-  if (currentCel &&
-      (m_site.layer() != currentCel->layer() || m_site.frame() != currentCel->frame())) {
-    m_site.layer(currentCel->layer());
-    m_site.frame(currentCel->frame());
-    m_site.tilemapMode(originalSiteTilemapMode);
-    m_site.tilesetMode(originalSiteTilesetMode);
-    redrawExtraImage();
-  }
+  // Stamp the current cel. Other cels in m_selectedCels will be
+  // stamped by stampExtraCelImages() using their pre-transformed
+  // images from the ExtraCelMap.
+  redrawExtraImages();
+  stampExtraCelImage();
 }
 
 void PixelsMovement::stampExtraCelImage()
@@ -992,6 +942,78 @@ void PixelsMovement::stampExtraCelImage()
   expand.getDestCanvas()->copy(image, gfx::Clip(dstPt, image->bounds()));
 
   expand.commit();
+}
+
+static void merge_tilemaps(Image* dst, const Image* src, gfx::Clip area)
+{
+  if (!area.clip(dst->width(), dst->height(), src->width(), src->height()))
+    return;
+
+  ImageConstIterator<TilemapTraits> src_it(src, area.srcBounds(), area.src.x, area.src.y);
+  ImageIterator<TilemapTraits> dst_it(dst, area.dstBounds(), area.dst.x, area.dst.y);
+  for (int y = 0; y < area.size.h; ++y) {
+    for (int x = 0; x < area.size.w; ++x) {
+      if (*src_it != doc::notile)
+        *dst_it = *src_it;
+      ++src_it;
+      ++dst_it;
+    }
+  }
+}
+
+void PixelsMovement::stampExtraCelImages()
+{
+  if (!m_extraCel)
+    return;
+
+  Layer* originalLayer = m_site.layer();
+  const frame_t originalFrame = m_site.frame();
+  const TilemapMode originalTilemapMode = m_site.tilemapMode();
+
+  // Stamp each transformed image from the map into its corresponding cel
+  for (auto& [cel, data] : m_extraCel->celMap()) {
+    if (!cel || !data.transformedImage)
+      continue;
+
+    m_site.layer(cel->layer());
+    m_site.frame(cel->frame());
+    const bool isTilemap = cel->layer()->isTilemap() && originalTilemapMode == TilemapMode::Tiles;
+    m_site.tilemapMode(isTilemap ? TilemapMode::Tiles : TilemapMode::Pixels);
+
+    ExpandCelCanvas expand(m_site, cel->layer(), TiledMode::NONE, m_tx, ExpandCelCanvas::None);
+
+    gfx::Point dstPt;
+    gfx::Size canvasImageSize = data.transformedImage->size();
+    gfx::Rect validateRegion = data.transformedBounds;
+    if (isTilemap) {
+      doc::Grid grid = m_site.grid();
+      dstPt = grid.canvasToTile(data.transformedBounds.origin());
+      canvasImageSize = grid.tileToCanvas(gfx::Rect(dstPt, canvasImageSize)).size();
+      validateRegion = gfx::Rect(data.transformedBounds.origin(), canvasImageSize);
+    }
+    else
+      dstPt = data.transformedBounds.origin() - expand.getCel()->position();
+
+    expand.validateDestCanvas(gfx::Region(validateRegion));
+
+    if (isTilemap)
+      merge_tilemaps(expand.getDestCanvas(),
+                     data.transformedImage.get(),
+                     gfx::Clip(dstPt, data.transformedImage->bounds()));
+    else
+      render::composite_image(expand.getDestCanvas(),
+                              data.transformedImage.get(),
+                              m_site.sprite()->palette(m_site.frame()),
+                              dstPt.x,
+                              dstPt.y,
+                              255,
+                              BlendMode::NORMAL);
+    expand.commit();
+  }
+
+  m_site.layer(originalLayer);
+  m_site.frame(originalFrame);
+  m_site.tilemapMode(originalTilemapMode);
 }
 
 void PixelsMovement::dropImageTemporarily()
@@ -1048,6 +1070,9 @@ void PixelsMovement::dropImage()
   // Stamp the image in the current layer.
   stampImage(true);
 
+  // Stamp the transformed images from the extra cel map into their cels
+  stampExtraCelImages();
+
   // Put the new mask
   m_document->setMask(m_initialMask0.get());
   m_tx(new cmd::SetMask(m_document, m_currentMask.get()));
@@ -1055,9 +1080,10 @@ void PixelsMovement::dropImage()
   // This is the end of the whole undo transaction.
   m_tx.commit();
 
-  // Destroy the extra cel (this cel will be used by the drawing
-  // cursor surely).
+  // Clear the extra cel map and destroy the extra cel
   ContextWriter writer(m_reader, 1000);
+  if (m_extraCel)
+    m_extraCel->clearCelMap();
   m_document->setExtraCel(ExtraCelRef(nullptr));
 }
 
@@ -1077,9 +1103,11 @@ void PixelsMovement::discardImage(const CommitChangesOption commit, const KeepMa
   if (commit == CommitChanges)
     m_tx.commit();
 
-  // Destroy the extra cel and regenerate the mask boundaries (we've
-  // just deselect the mask).
+  // Clear the extra cel map and destroy the extra cel, regenerate
+  // the mask boundaries (we've just deselect the mask).
   ContextWriter writer(m_reader, 1000);
+  if (m_extraCel)
+    m_extraCel->clearCelMap();
   m_document->setExtraCel(ExtraCelRef(nullptr));
   m_document->generateMaskBoundaries();
 }
@@ -1110,15 +1138,29 @@ void PixelsMovement::setMaskColor(bool opaque, color_t mask_color)
   ContextWriter writer(m_reader, 1000);
   m_opaque = opaque;
   m_maskColor = mask_color;
-  redrawExtraImage();
+  redrawExtraImages();
 
   update_screen_for_document(m_document);
 }
 
-void PixelsMovement::redrawExtraImage(Transformation* transformation)
+void PixelsMovement::redrawExtraImages(Transformation* transformation)
 {
   if (!transformation)
     transformation = &m_currentData;
+  if (!m_extraCel)
+    return;
+
+  if (m_tiledModeHelper && m_tiledModeHelper->tiledEnabled())
+    m_tiledModeHelper->wrapTransformation(transformation);
+
+  gfx::Rect bounds = transformation->transformedBounds();
+  if (bounds.isEmpty())
+    return;
+
+  if (m_tiledModeHelper && m_tiledModeHelper->hasModeFlag(TiledMode::X_AXIS))
+    bounds.enlargeXW(m_document->sprite()->width());
+  if (m_tiledModeHelper && m_tiledModeHelper->hasModeFlag(TiledMode::Y_AXIS))
+    bounds.enlargeYH(m_document->sprite()->height());
 
   int t, opacity =
            (m_site.layer()->isImage() ? static_cast<LayerImage*>(m_site.layer())->opacity() : 255);
@@ -1126,60 +1168,42 @@ void PixelsMovement::redrawExtraImage(Transformation* transformation)
   if (cel)
     opacity = MUL_UN8(opacity, cel->opacity(), t);
 
-  if (!m_extraCel)
-    m_extraCel.reset(new ExtraCel);
-
-  gfx::Rect bounds;
-  if (m_tiledModeHelper && m_tiledModeHelper->tiledEnabled()) {
-    m_tiledModeHelper->wrapTransformation(transformation);
-    // Enlarge the wrapped transformed bounds to make room for the copies
-    // of the chunk of pixels that will be drawn later on the extra cel.
-    bounds = transformation->transformedBounds();
-    if (m_tiledModeHelper->hasModeFlag(TiledMode::X_AXIS)) {
-      bounds.enlargeXW(m_document->sprite()->width());
-    }
-    if (m_tiledModeHelper->hasModeFlag(TiledMode::Y_AXIS)) {
-      bounds.enlargeYH(m_document->sprite()->height());
-    }
+  // Configure the main extra cel image (needed for paste in empty cel
+  // and single-cel transformations)
+  gfx::Size extraCelSize;
+  gfx::Rect extraCelBounds = bounds;
+  if (m_site.tilemapMode() == TilemapMode::Tiles) {
+    // Transforming tiles
+    extraCelSize = m_site.grid().canvasToTile(bounds).size();
+    extraCelBounds = m_site.grid().alignBounds(bounds);
   }
   else {
-    bounds = transformation->transformedBounds();
+    // Transforming pixels
+    extraCelSize = bounds.size();
   }
 
-  if (!bounds.isEmpty()) {
-    gfx::Size extraCelSize;
-    if (m_site.tilemapMode() == TilemapMode::Tiles) {
-      // Transforming tiles
-      extraCelSize = m_site.grid().canvasToTile(bounds).size();
-      bounds = m_site.grid().alignBounds(bounds);
-    }
-    else {
-      // Transforming pixels
-      extraCelSize = bounds.size();
-    }
-
-    m_extraCel->create(ExtraCel::Purpose::TransformationPreview,
-                       m_site.tilemapMode(),
-                       m_document->sprite(),
-                       bounds,
-                       extraCelSize,
-                       m_site.frame(),
-                       opacity);
-    m_extraCel->setType(render::ExtraType::PATCH);
-    m_extraCel->setBlendMode(m_site.layer()->isImage() ?
-                               static_cast<LayerImage*>(m_site.layer())->blendMode() :
-                               BlendMode::NORMAL);
-  }
-  else
-    m_extraCel->reset();
+  m_extraCel->create(ExtraCel::Purpose::TransformationPreview,
+                     m_site.tilemapMode(),
+                     m_document->sprite(),
+                     extraCelBounds,
+                     extraCelSize,
+                     m_site.frame(),
+                     opacity);
+  m_extraCel->setType(render::ExtraType::PATCH);
+  m_extraCel->setBlendMode(m_site.layer()->isImage() ?
+                             static_cast<LayerImage*>(m_site.layer())->blendMode() :
+                             BlendMode::NORMAL);
 
   m_document->setExtraCel(m_extraCel);
 
-  if (m_extraCel->image()) {
-    // Draw the transformed pixels in the extra-cel which is the chunk
-    // of pixels that the user is moving.
+  // Draw the main extra cel image (for current cel / paste)
+  if (m_extraCel->image() && m_originalImage) {
     drawImage(*transformation, m_extraCel->image(), gfx::PointF(bounds.origin()), true);
   }
+
+  // Draw images for all cels in the celMap (multi-cel cases)
+  if (m_selectedCels.size() > 1)
+    drawImages(*transformation);
 }
 
 void PixelsMovement::redrawCurrentMask()
@@ -1248,6 +1272,128 @@ void PixelsMovement::drawImage(const Transformation& transformation,
     if (m_tiledModeHelper && m_tiledModeHelper->tiledEnabled()) {
       m_tiledModeHelper->drawTiled(dst, cornerBounds);
     }
+  }
+}
+
+void PixelsMovement::drawImages(const Transformation& transformation)
+{
+  if (!m_extraCel)
+    return;
+
+  auto corners = transformation.transformedCorners();
+  gfx::Rect bounds = corners.bounds(transformation.cornerThick());
+  if (bounds.isEmpty())
+    return;
+
+  const gfx::Rect cornerBounds = bounds;
+  if (m_tiledModeHelper && m_tiledModeHelper->hasModeFlag(TiledMode::X_AXIS))
+    bounds.enlargeXW(m_document->sprite()->width());
+  if (m_tiledModeHelper && m_tiledModeHelper->hasModeFlag(TiledMode::Y_AXIS))
+    bounds.enlargeYH(m_document->sprite()->height());
+
+  for (auto& [cel, data] : m_extraCel->celMap()) {
+    if (!cel || !data.originalImage)
+      continue;
+
+    const bool isTilemap = cel->layer()->isTilemap() && m_site.tilemapMode() == TilemapMode::Tiles;
+    const doc::Grid grid = m_site.grid();
+    const gfx::Rect tileBounds = grid.canvasToTile(bounds);
+
+    gfx::Size transformedSize = isTilemap ? tileBounds.size() : bounds.size();
+
+    doc::PixelFormat pixelFormat = data.originalImage->pixelFormat();
+    if (!data.transformedImage || data.transformedImage->width() != transformedSize.w ||
+        data.transformedImage->height() != transformedSize.h ||
+        data.transformedImage->pixelFormat() != pixelFormat) {
+      data.transformedImage.reset(Image::create(pixelFormat, transformedSize.w, transformedSize.h));
+    }
+
+    data.transformedBounds = bounds;
+
+    if (isTilemap) {
+      data.transformedImage->setMaskColor(doc::notile);
+      data.transformedImage->clear(data.transformedImage->maskColor());
+      drawTransformedTilemap(transformation,
+                             data.transformedImage.get(),
+                             data.originalImage.get(),
+                             m_initialMask.get());
+
+      // Fill notiles with tiles from the cel (non-selected tiles within
+      // the transformed bounds area)
+      if (cel->image()) {
+        ImageRef tileMaskBitmap = make_tile_mask_bitmap(&grid, m_currentMask.get());
+
+        // Calculate tile bounds for the mask and cel (tile terms)
+        const gfx::Size tileSize = grid.tileSize();
+        const gfx::Rect maskTileBounds(data.transformedBounds.x / tileSize.w,
+                                       data.transformedBounds.y / tileSize.h,
+                                       data.transformedBounds.w / tileSize.w,
+                                       data.transformedBounds.h / tileSize.h);
+        const gfx::Rect celTileBounds(cel->position().x / tileSize.w,
+                                      cel->position().y / tileSize.h,
+                                      cel->image()->width(),
+                                      cel->image()->height());
+
+        // Work only on the intersection between mask and cel
+        const gfx::Rect intersection = maskTileBounds.createIntersection(celTileBounds);
+        // Intersection in cel-local coordinates
+        const gfx::Rect celLocalRect(intersection.x - celTileBounds.x,
+                                     intersection.y - celTileBounds.y,
+                                     intersection.w,
+                                     intersection.h);
+        // Offset to convert from cel to mask coordinates
+        const gfx::Point celToMaskOffset = celTileBounds.origin() - maskTileBounds.origin();
+
+        for (int v = celLocalRect.y; v < celLocalRect.y2(); ++v) {
+          for (int u = celLocalRect.x; u < celLocalRect.x2(); ++u) {
+            // Convert cel coordinates to mask coords
+            const gfx::Point maskPos(celToMaskOffset.x + u, celToMaskOffset.y + v);
+            const bool isSelected = tileMaskBitmap->getPixel(maskPos.x, maskPos.y) == 1;
+
+            if (isSelected && data.transformedImage->getPixel(maskPos.x, maskPos.y) != doc::notile)
+              continue;
+
+            const doc::tile_t tileValue = cel->image()->getPixel(u, v);
+
+            if (isSelected && tileValue == doc::notile)
+              continue;
+
+            if (tileValue != doc::notile)
+              data.transformedImage->putPixel(maskPos.x, maskPos.y, tileValue);
+          }
+        }
+      }
+    }
+    else {
+      data.transformedImage->setMaskColor(m_site.sprite()->transparentColor());
+      data.transformedImage->clear(data.transformedImage->maskColor());
+      // First render the original layer pixels within the bounds area
+      // (pixels outside the selection that are within the extra cel bounds).
+      // This ensures that when the extra cel area is excluded from the
+      // original cel render, we still see the original pixels outside the selection.
+      render::Render render;
+      render.renderLayer(data.transformedImage.get(),
+                         cel->layer(),
+                         cel->frame(),
+                         gfx::Clip(0, 0, bounds),
+                         BlendMode::SRC);
+      color_t maskColor = m_maskColor;
+      if (m_opaque) {
+        if (data.originalImage->pixelFormat() == IMAGE_INDEXED)
+          maskColor = -1;
+        else
+          maskColor = 0;
+      }
+      data.originalImage->setMaskColor(maskColor);
+      drawParallelogram(transformation,
+                        data.transformedImage.get(),
+                        data.originalImage.get(),
+                        m_initialMask.get(),
+                        corners,
+                        gfx::PointF(bounds.origin()));
+    }
+    if (m_tiledModeHelper && m_tiledModeHelper->tiledEnabled())
+      m_tiledModeHelper->drawTiled(data.transformedImage.get(), cornerBounds);
   }
 }
 
@@ -1343,24 +1489,6 @@ retry:; // In case that we don't have enough memory for RotSprite
   }
 }
 
-static void merge_tilemaps(Image* dst, const Image* src, gfx::Clip area)
-{
-  if (!area.clip(dst->width(), dst->height(), src->width(), src->height()))
-    return;
-
-  ImageConstIterator<TilemapTraits> src_it(src, area.srcBounds(), area.src.x, area.src.y);
-  ImageIterator<TilemapTraits> dst_it(dst, area.dstBounds(), area.dst.x, area.dst.y);
-
-  for (int y = 0; y < area.size.h; ++y) {
-    for (int x = 0; x < area.size.w; ++x) {
-      if (*src_it != doc::notile)
-        *dst_it = *src_it;
-      ++src_it;
-      ++dst_it;
-    }
-  }
-}
-
 void PixelsMovement::drawTransformedTilemap(const Transformation& transformation,
                                             doc::Image* dst,
                                             const doc::Image* src,
@@ -1404,8 +1532,8 @@ void PixelsMovement::onPivotChange()
 void PixelsMovement::onRotationAlgorithmChange()
 {
   try {
-    redrawExtraImage();
     redrawCurrentMask();
+    redrawExtraImages();
     updateDocumentMask();
 
     update_screen_for_document(m_document);
@@ -1446,10 +1574,30 @@ void PixelsMovement::shiftOriginalImage(const int dx, const int dy, const double
   doc::algorithm::shift_image(m_originalImage.get(), dx, dy, angle);
 }
 
+void PixelsMovement::flipOriginalImages(const doc::algorithm::FlipType flipType)
+{
+  if (!m_extraCel)
+    return;
+  for (auto& [cel, data] : m_extraCel->celMap())
+    if (data.originalImage)
+      doc::algorithm::flip_image(data.originalImage.get(),
+                                 gfx::Rect(gfx::Point(0, 0), data.originalImage->size()),
+                                 flipType);
+}
+
+void PixelsMovement::shiftOriginalImages(const int dx, const int dy, const double angle)
+{
+  if (!m_extraCel)
+    return;
+  for (auto& [cel, data] : m_extraCel->celMap())
+    if (data.originalImage)
+      doc::algorithm::shift_image(data.originalImage.get(), dx, dy, angle);
+}
+
 // Returns the list of cels that will be transformed (the first item
 // in the list must be the current cel that was transformed if the cel
 // wasn't nullptr).
-CelList PixelsMovement::getEditableCels()
+CelList PixelsMovement::getEditableCels(const bool filterTilemapsByTileSize)
 {
   CelList cels;
 
@@ -1485,6 +1633,28 @@ CelList PixelsMovement::getEditableCels()
     if (it != cels.end())
       cels.erase(it);
     cels.insert(cels.begin(), m_site.cel());
+  }
+
+  // Filter out tilemap cels with different tileSize and origin than the reference cel
+  if (filterTilemapsByTileSize) {
+    const auto refTilemapLayer = static_cast<const LayerTilemap*>(m_site.layer());
+    gfx::Size refTileSize = refTilemapLayer->tileset()->grid().tileSize();
+    gfx::Point refOffset(refTilemapLayer->tileset()->grid().origin());
+    if (m_site.cel())
+      refOffset = gfx::Point(m_site.cel()->position().x % refTileSize.w,
+                             m_site.cel()->position().y % refTileSize.h);
+    cels.erase(std::remove_if(cels.begin(),
+                              cels.end(),
+                              [&refTileSize, &refOffset](const Cel* cel) {
+                                if (!cel || !cel->layer()->isTilemap())
+                                  return false;
+                                auto tilemapLayer = static_cast<const LayerTilemap*>(cel->layer());
+                                gfx::Size celTileSize = tilemapLayer->tileset()->grid().tileSize();
+                                gfx::Point celOffset(cel->position().x % celTileSize.w,
+                                                     cel->position().y % refTileSize.h);
+                                return (refTileSize != celTileSize || refOffset != celOffset);
+                              }),
+               cels.end());
   }
 
   return cels;
@@ -1571,14 +1741,14 @@ void PixelsMovement::reproduceAllTransformationsWithInnerCmds()
         shiftOriginalImage(c.data.shift.dx, c.data.shift.dy, c.data.shift.angle);
         break;
       case InnerCmd::Stamp:
-        redrawExtraImage(c.data.stamp.transformation);
+        redrawExtraImages(c.data.stamp.transformation);
         stampExtraCelImage();
         break;
     }
   }
 
-  redrawExtraImage();
   redrawCurrentMask();
+  redrawExtraImages();
   updateDocumentMask();
 }
 

--- a/src/app/ui/editor/pixels_movement.cpp
+++ b/src/app/ui/editor/pixels_movement.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2026  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -41,8 +41,10 @@
 #include "doc/cel.h"
 #include "doc/image.h"
 #include "doc/layer.h"
+#include "doc/layer_tilemap.h"
 #include "doc/mask.h"
 #include "doc/sprite.h"
+#include "doc/tileset.h"
 #include "doc/util.h"
 #include "gfx/region.h"
 #include "render/render.h"
@@ -133,18 +135,35 @@ PixelsMovement::PixelsMovement(Context* context,
   // TODO: enable TilemapMode exchanges during PixelMovement.
   if (m_site.layer()->isTilemap() && ColorBar::instance())
     ColorBar::instance()->lockTilemapMode();
-  const float cornerThick = (m_site.tilemapMode() == TilemapMode::Tiles ?
-                               CORNER_THICK_FOR_TILEMAP_MODE :
-                               CORNER_THICK_FOR_PIXELS_MODE);
-  Transformation transform(mask->bounds(), cornerThick);
+
+  const bool isTilemapTilesMode = m_site.layer()->isTilemap() &&
+                                  m_site.tilemapMode() == TilemapMode::Tiles;
+  // If TilemapMode::Pixels it's need to force TilesetMode::Stack to generate
+  // new tiles during the transformation.
+  if (!isTilemapTilesMode)
+    m_site.tilesetMode(TilesetMode::Stack);
+  const float cornerThick = (isTilemapTilesMode ? CORNER_THICK_FOR_TILEMAP_MODE :
+                                                  CORNER_THICK_FOR_PIXELS_MODE);
+
+  // When in TilemapMode::Tiles, align the mask to the grid so we select
+  // complete tiles
+  std::unique_ptr<Mask> alignedMask;
+  const Mask* effectiveMask = mask;
+  if (isTilemapTilesMode) {
+    const doc::Grid grid = m_site.grid();
+    alignedMask.reset(new Mask(make_aligned_mask(&grid, mask)));
+    effectiveMask = alignedMask.get();
+  }
+
+  Transformation transform(effectiveMask->bounds(), cornerThick);
   set_pivot_from_preferences(transform);
 
   m_initialData = transform;
   m_currentData = transform;
 
-  m_initialMask.reset(new Mask(*mask));
-  m_initialMask0.reset(new Mask(*mask));
-  m_currentMask.reset(new Mask(*mask));
+  m_initialMask.reset(new Mask(*effectiveMask));
+  m_initialMask0.reset(new Mask(*effectiveMask));
+  m_currentMask.reset(new Mask(*effectiveMask));
 
   m_pivotVisConn = Preferences::instance().selection.pivotVisibility.AfterChange.connect(
     [this] { onPivotChange(); });
@@ -157,8 +176,48 @@ PixelsMovement::PixelsMovement(Context* context,
   // that someone else is using it (e.g. the editor brush preview),
   // and its owner could destroy our new "extra cel".
   ASSERT(!m_document->extraCel());
-  redrawExtraImage();
+
+  // Fill the selected cels vector and initialize the ExtraCelMap
+  // with the original clipped images for each cel.
+  // In TilemapMode::Tiles, filter out tilemap cels with different
+  // tileSizes and offset.
+  m_selectedCels = getEditableCels(isTilemapTilesMode);
+  if (!m_extraCel)
+    m_extraCel.reset(new ExtraCel);
+
+  // Create the celMap only in multi-cel cases only
+  if (m_selectedCels.size() > 1) {
+    for (Cel* cel : m_selectedCels) {
+      if (!cel ||
+          // Exclude only the current cel in the "cel Map".
+          // The current cel will be processed in drawImage
+          // the others cels will be processed in drawImages
+          cel == m_site.cel())
+        continue;
+
+      ExtraCelData data;
+      data.originalBounds = m_initialMask->bounds();
+
+      if (cel->layer()->isTilemap() && m_site.tilemapMode() == TilemapMode::Tiles) {
+        Site celSite = m_site;
+        celSite.layer(cel->layer());
+        celSite.frame(cel->frame());
+        data.originalImage.reset(new_tilemap_from_mask(celSite, m_initialMask.get()));
+      }
+      else {
+        data.originalImage.reset(
+          new_image_from_mask(*cel->layer(),
+                              cel->frame(),
+                              m_initialMask.get(),
+                              Preferences::instance().experimental.newBlend()));
+      }
+
+      m_extraCel->celMap()[cel] = std::move(data);
+    }
+  }
+
   redrawCurrentMask();
+  redrawExtraImages();
 
   // If the mask is different than the mask from the document
   // (e.g. it's from Paste command), we've to replace the document
@@ -194,7 +253,7 @@ void PixelsMovement::setFastMode(const bool fastMode)
   bool redraw = (m_fastMode && !fastMode);
   m_fastMode = fastMode;
   if (m_needsRotSpriteRedraw && redraw) {
-    redrawExtraImage();
+    redrawExtraImages();
     update_screen_for_document(m_document);
     m_needsRotSpriteRedraw = false;
   }
@@ -205,14 +264,15 @@ void PixelsMovement::flipImage(doc::algorithm::FlipType flipType)
   m_innerCmds.push_back(InnerCmd::MakeFlip(flipType));
 
   flipOriginalImage(flipType);
+  flipOriginalImages(flipType);
 
   {
     ContextWriter writer(m_reader, 1000);
 
     // Regenerate the transformed (rotated, scaled, etc.) image and
     // mask.
-    redrawExtraImage();
     redrawCurrentMask();
+    redrawExtraImages();
     updateDocumentMask();
 
     update_screen_for_document(m_document);
@@ -226,8 +286,8 @@ void PixelsMovement::rotate(double angle)
 
   m_document->setTransformation(m_currentData);
 
-  redrawExtraImage();
   redrawCurrentMask();
+  redrawExtraImages();
   updateDocumentMask();
 
   update_screen_for_document(m_document);
@@ -238,12 +298,13 @@ void PixelsMovement::shift(int dx, int dy)
   const double angle = m_currentData.angle();
   m_innerCmds.push_back(InnerCmd::MakeShift(dx, dy, angle));
   shiftOriginalImage(dx, dy, angle);
+  shiftOriginalImages(dx, dy, angle);
 
   {
     ContextWriter writer(m_reader, 1000);
 
-    redrawExtraImage();
     redrawCurrentMask();
+    redrawExtraImages();
     updateDocumentMask();
 
     update_screen_for_document(m_document);
@@ -256,7 +317,7 @@ void PixelsMovement::setTransformation(const Transformation& t)
 
   setTransformationBase(t);
 
-  redrawCurrentMask();
+  // redrawCurrentMask() is already called inside setTransformationBase()
   updateDocumentMask();
 
   update_screen_for_document(m_document);
@@ -271,7 +332,9 @@ void PixelsMovement::setTransformationBase(const Transformation& t)
   m_currentData = t;
   auto newCorners = m_currentData.transformedCorners();
 
-  redrawExtraImage();
+  // Update mask first so drawImages() can use the updated mask bounds
+  redrawCurrentMask();
+  redrawExtraImages();
 
   m_document->setTransformation(m_currentData);
 
@@ -311,7 +374,7 @@ void PixelsMovement::trim()
 
   // TODO this is similar to clear_mask_from_cels()
 
-  for (Cel* cel : getEditableCels()) {
+  for (Cel* cel : m_selectedCels) {
     if (cel != activeCel) {
       if (!restoreMask) {
         m_document->setMask(m_initialMask0.get());
@@ -336,11 +399,11 @@ void PixelsMovement::cutMask()
 
   {
     ContextWriter writer(m_reader, 1000);
-    if (writer.cel()) {
-      clear_mask_from_cel(m_tx, writer.cel(), m_site.tilemapMode(), m_site.tilesetMode());
 
-      // Do not trim here so we don't lost the information about all
-      // linked cels related to "writer.cel()"
+    // Cut from all selected cels, not just the current one
+    for (Cel* cel : m_selectedCels) {
+      if (cel)
+        clear_mask_from_cel(m_tx, cel, m_site.tilemapMode(), m_site.tilesetMode());
     }
   }
 
@@ -551,6 +614,18 @@ void PixelsMovement::moveImage(const gfx::PointF& pos, MoveModifier moveModifier
       bounds.y = a.y;
       bounds.w = b.x - a.x;
       bounds.h = b.y - a.y;
+
+      // In TilemapMode::Tiles, limit the scaling to a minimum of 1 tile
+      // and ensure width/height are always positive.
+      if (tilesModeOn) {
+        const gfx::Rect gridBounds = m_site.gridBounds();
+        const double minW = gridBounds.w;
+        const double minH = gridBounds.h;
+        if (bounds.w < minW)
+          bounds.w = minW;
+        if (bounds.h < minH)
+          bounds.h = minH;
+      }
 
       newTransformation.bounds(bounds);
       m_adjustPivot = true;
@@ -808,38 +883,6 @@ void PixelsMovement::getDraggedImageCopy(std::unique_ptr<Image>& outputImage,
   outputMask.reset(mask.release());
 }
 
-void PixelsMovement::alignMasksAndTransformData(const Mask* initialMask0,
-                                                const Mask* initialMask,
-                                                const Mask* currentMask,
-                                                const Transformation* initialData,
-                                                const Transformation* currentData,
-                                                const doc::Grid& grid,
-                                                const gfx::Size& deltaA,
-                                                const gfx::Size& deltaB)
-{
-  m_initialMask0->replace(make_aligned_mask(&grid, initialMask0));
-  m_initialMask->replace(make_aligned_mask(&grid, initialMask));
-  m_currentMask->replace(make_aligned_mask(&grid, currentMask));
-  m_initialData = *initialData;
-  m_initialData.bounds(m_initialMask0->bounds());
-  m_currentData = *currentData;
-  // Raw grid alignment of currentData can result in unintentional scaling.
-  // That's why we need to know if the artist's intention was just to move
-  // the selection and/or scaling via 'initialDeltaA' and 'initialDeltaB'.
-  const gfx::Point currentDataAlignedOrigin =
-    grid
-      .alignBounds(
-        gfx::Rect(m_initialData.bounds().x + deltaA.w, m_initialData.bounds().y + deltaA.h, 1, 1))
-      .origin();
-  int deltaH = deltaB.w - deltaA.w;
-  int deltaV = deltaB.h - deltaA.h;
-  const gfx::RectF currentDataBounds(currentDataAlignedOrigin.x,
-                                     currentDataAlignedOrigin.y,
-                                     m_initialData.bounds().w + deltaH,
-                                     m_initialData.bounds().h + deltaV);
-  m_currentData.bounds(currentDataBounds);
-}
-
 void PixelsMovement::stampImage()
 {
   stampImage(false);
@@ -854,113 +897,20 @@ void PixelsMovement::stampImage(bool finalStamp)
   ContextWriter writer(m_reader, 1000);
   Cel* currentCel = m_site.cel();
 
-  CelList cels;
-  if (finalStamp) {
-    cels = getEditableCels();
-  }
   // Current cel (m_site.cel()) can be nullptr when we paste in an
   // empty cel (Ctrl+V) and cut (Ctrl+X) the floating pixels.
-  else {
-    cels.push_back(currentCel);
-  }
-
   if (currentCel && currentCel->layer() && currentCel->layer()->isImage() &&
       !currentCel->layer()->canEditPixels()) {
     Transformation initialCelPos(gfx::Rect(m_initialMask0->bounds()), m_currentData.cornerThick());
-    redrawExtraImage(&initialCelPos);
+    redrawExtraImages(&initialCelPos);
     stampExtraCelImage();
+    return;
   }
-
-  // Saving original values before the 'for' loop and the
-  // 'reproduceAllTransformationsWithInnerCmds' function for restoring later.
-  // All values of m_initialXX, m_currentXX will be recalculated
-  // to align their original selection bounds with each cel's grid.
-  const TilemapMode originalSiteTilemapMode = (m_site.tilemapMode() == TilemapMode::Tiles &&
-                                                   m_site.layer()->isTilemap() ?
-                                                 TilemapMode::Tiles :
-                                                 TilemapMode::Pixels);
-  const TilesetMode originalSiteTilesetMode = m_site.tilesetMode();
-  const Mask initialMask0(*m_initialMask0);
-  const Mask initialMask(*m_initialMask);
-  const Mask currentMask(*m_currentMask);
-  auto initialData = m_initialData;
-  auto currentData = m_currentData;
-
-  // We need a way to know if 'a' or 'b' corners has changed
-  // as result of a scaling or moving command to replicate the intention on
-  // the other layers according the original mask (which can be aligned or
-  // not to the tilemap grid)
-  //
-  //   a ----
-  //   |     |
-  //   |     |
-  //    ---- b
-  const gfx::Rect currentAlignedBounds(m_site.grid().alignBounds(currentData.bounds()));
-  const gfx::Rect initialAlignedBounds(m_site.grid().alignBounds(initialMask.bounds()));
-  const gfx::Size deltaA(currentAlignedBounds.origin().x - initialAlignedBounds.origin().x,
-                         currentAlignedBounds.origin().y - initialAlignedBounds.origin().y);
-  const gfx::Size deltaB(currentAlignedBounds.x2() - initialAlignedBounds.x2(),
-                         currentAlignedBounds.y2() - initialAlignedBounds.y2());
-
-  for (Cel* target : cels) {
-    // We'll re-create the transformation for the other cels
-    if (target != currentCel) {
-      ASSERT(target);
-      m_site.layer(target->layer());
-      m_site.frame(target->frame());
-      ASSERT(m_site.cel() == target);
-      Grid targetGrid(m_site.grid());
-      // Align masks and transformData before to 'reproduceAllTransformationsWithInnerCmds'
-      // Note: this alignement is needed only when the editor is on 'TilemapMode::Tiles',
-      // on the other hand 'TilemapMode::Pixels' do not require any additional
-      // mask/transformData adjustments.
-      if (originalSiteTilemapMode == TilemapMode::Tiles) {
-        if (target->layer()->isTilemap()) {
-          alignMasksAndTransformData(&initialMask0,
-                                     &initialMask,
-                                     &currentMask,
-                                     &initialData,
-                                     &currentData,
-                                     targetGrid,
-                                     deltaA,
-                                     deltaB);
-          m_site.tilemapMode(TilemapMode::Tiles);
-        }
-        else {
-          m_initialMask0->replace(initialMask0);
-          m_initialMask->replace(initialMask);
-          m_currentMask->replace(currentMask);
-          m_initialData.bounds(initialData.bounds());
-          m_currentData.bounds(currentData.bounds());
-          m_site.tilemapMode(TilemapMode::Pixels);
-        }
-      }
-      else {
-        m_site.tilemapMode(TilemapMode::Pixels);
-        m_site.tilesetMode(TilesetMode::Auto);
-      }
-      reproduceAllTransformationsWithInnerCmds();
-    }
-
-    redrawExtraImage();
-    stampExtraCelImage();
-  }
-
-  m_initialMask0->replace(initialMask0);
-  m_initialMask->replace(initialMask);
-  m_currentMask->replace(currentMask);
-  m_initialData.bounds(initialData.bounds());
-  m_currentData.bounds(currentData.bounds());
-  m_site.tilesetMode(originalSiteTilesetMode);
-  currentCel = m_site.cel();
-  if (currentCel &&
-      (m_site.layer() != currentCel->layer() || m_site.frame() != currentCel->frame())) {
-    m_site.layer(currentCel->layer());
-    m_site.frame(currentCel->frame());
-    m_site.tilemapMode(originalSiteTilemapMode);
-    m_site.tilesetMode(originalSiteTilesetMode);
-    redrawExtraImage();
-  }
+  // Stamp the current cel. Other cels in m_selectedCels will be
+  // stamped by stampExtraCelImages() using their pre-transformed
+  // images from the ExtraCelMap.
+  redrawExtraImages();
+  stampExtraCelImage();
 }
 
 void PixelsMovement::stampExtraCelImage()
@@ -992,6 +942,78 @@ void PixelsMovement::stampExtraCelImage()
   expand.getDestCanvas()->copy(image, gfx::Clip(dstPt, image->bounds()));
 
   expand.commit();
+}
+
+static void merge_tilemaps(Image* dst, const Image* src, gfx::Clip area)
+{
+  if (!area.clip(dst->width(), dst->height(), src->width(), src->height()))
+    return;
+
+  ImageConstIterator<TilemapTraits> src_it(src, area.srcBounds(), area.src.x, area.src.y);
+  ImageIterator<TilemapTraits> dst_it(dst, area.dstBounds(), area.dst.x, area.dst.y);
+  for (int y = 0; y < area.size.h; ++y) {
+    for (int x = 0; x < area.size.w; ++x) {
+      if (*src_it != doc::notile)
+        *dst_it = *src_it;
+      ++src_it;
+      ++dst_it;
+    }
+  }
+}
+
+void PixelsMovement::stampExtraCelImages()
+{
+  if (!m_extraCel)
+    return;
+
+  Layer* originalLayer = m_site.layer();
+  const frame_t originalFrame = m_site.frame();
+  const TilemapMode originalTilemapMode = m_site.tilemapMode();
+
+  // Stamp each transformed image from the map into its corresponding cel
+  for (auto& [cel, data] : m_extraCel->celMap()) {
+    if (!cel || !data.transformedImage)
+      continue;
+
+    m_site.layer(cel->layer());
+    m_site.frame(cel->frame());
+    const bool isTilemap = cel->layer()->isTilemap() && originalTilemapMode == TilemapMode::Tiles;
+    m_site.tilemapMode(isTilemap ? TilemapMode::Tiles : TilemapMode::Pixels);
+
+    ExpandCelCanvas expand(m_site, cel->layer(), TiledMode::NONE, m_tx, ExpandCelCanvas::None);
+
+    gfx::Point dstPt;
+    gfx::Size canvasImageSize = data.transformedImage->size();
+    gfx::Rect validateRegion = data.transformedBounds;
+    if (isTilemap) {
+      doc::Grid grid = m_site.grid();
+      dstPt = grid.canvasToTile(data.transformedBounds.origin());
+      canvasImageSize = grid.tileToCanvas(gfx::Rect(dstPt, canvasImageSize)).size();
+      validateRegion = gfx::Rect(data.transformedBounds.origin(), canvasImageSize);
+    }
+    else
+      dstPt = data.transformedBounds.origin() - expand.getCel()->position();
+
+    expand.validateDestCanvas(gfx::Region(validateRegion));
+
+    if (isTilemap)
+      merge_tilemaps(expand.getDestCanvas(),
+                     data.transformedImage.get(),
+                     gfx::Clip(dstPt, data.transformedImage->bounds()));
+    else
+      render::composite_image(expand.getDestCanvas(),
+                              data.transformedImage.get(),
+                              m_site.sprite()->palette(m_site.frame()),
+                              dstPt.x,
+                              dstPt.y,
+                              255,
+                              BlendMode::NORMAL);
+    expand.commit();
+  }
+
+  m_site.layer(originalLayer);
+  m_site.frame(originalFrame);
+  m_site.tilemapMode(originalTilemapMode);
 }
 
 void PixelsMovement::dropImageTemporarily()
@@ -1048,6 +1070,9 @@ void PixelsMovement::dropImage()
   // Stamp the image in the current layer.
   stampImage(true);
 
+  // Stamp the transformed images from the extra cel map into their cels
+  stampExtraCelImages();
+
   // Put the new mask
   m_document->setMask(m_initialMask0.get());
   m_tx(new cmd::SetMask(m_document, m_currentMask.get()));
@@ -1055,9 +1080,10 @@ void PixelsMovement::dropImage()
   // This is the end of the whole undo transaction.
   m_tx.commit();
 
-  // Destroy the extra cel (this cel will be used by the drawing
-  // cursor surely).
+  // Clear the extra cel map and destroy the extra cel
   ContextWriter writer(m_reader, 1000);
+  if (m_extraCel)
+    m_extraCel->clearCelMap();
   m_document->setExtraCel(ExtraCelRef(nullptr));
 }
 
@@ -1077,9 +1103,11 @@ void PixelsMovement::discardImage(const CommitChangesOption commit, const KeepMa
   if (commit == CommitChanges)
     m_tx.commit();
 
-  // Destroy the extra cel and regenerate the mask boundaries (we've
-  // just deselect the mask).
+  // Clear the extra cel map and destroy the extra cel, regenerate
+  // the mask boundaries (we've just deselect the mask).
   ContextWriter writer(m_reader, 1000);
+  if (m_extraCel)
+    m_extraCel->clearCelMap();
   m_document->setExtraCel(ExtraCelRef(nullptr));
   m_document->generateMaskBoundaries();
 }
@@ -1110,15 +1138,29 @@ void PixelsMovement::setMaskColor(bool opaque, color_t mask_color)
   ContextWriter writer(m_reader, 1000);
   m_opaque = opaque;
   m_maskColor = mask_color;
-  redrawExtraImage();
+  redrawExtraImages();
 
   update_screen_for_document(m_document);
 }
 
-void PixelsMovement::redrawExtraImage(Transformation* transformation)
+void PixelsMovement::redrawExtraImages(Transformation* transformation)
 {
   if (!transformation)
     transformation = &m_currentData;
+  if (!m_extraCel)
+    return;
+
+  if (m_tiledModeHelper && m_tiledModeHelper->tiledEnabled())
+    m_tiledModeHelper->wrapTransformation(transformation);
+
+  gfx::Rect bounds = transformation->transformedBounds();
+  if (bounds.isEmpty())
+    return;
+
+  if (m_tiledModeHelper && m_tiledModeHelper->hasModeFlag(TiledMode::X_AXIS))
+    bounds.enlargeXW(m_document->sprite()->width());
+  if (m_tiledModeHelper && m_tiledModeHelper->hasModeFlag(TiledMode::Y_AXIS))
+    bounds.enlargeYH(m_document->sprite()->height());
 
   int t, opacity =
            (m_site.layer()->isImage() ? static_cast<LayerImage*>(m_site.layer())->opacity() : 255);
@@ -1126,60 +1168,42 @@ void PixelsMovement::redrawExtraImage(Transformation* transformation)
   if (cel)
     opacity = MUL_UN8(opacity, cel->opacity(), t);
 
-  if (!m_extraCel)
-    m_extraCel.reset(new ExtraCel);
-
-  gfx::Rect bounds;
-  if (m_tiledModeHelper && m_tiledModeHelper->tiledEnabled()) {
-    m_tiledModeHelper->wrapTransformation(transformation);
-    // Enlarge the wrapped transformed bounds to make room for the copies
-    // of the chunk of pixels that will be drawn later on the extra cel.
-    bounds = transformation->transformedBounds();
-    if (m_tiledModeHelper->hasModeFlag(TiledMode::X_AXIS)) {
-      bounds.enlargeXW(m_document->sprite()->width());
-    }
-    if (m_tiledModeHelper->hasModeFlag(TiledMode::Y_AXIS)) {
-      bounds.enlargeYH(m_document->sprite()->height());
-    }
+  // Configure the main extra cel image (needed for paste in empty cel
+  // and single-cel transformations)
+  gfx::Size extraCelSize;
+  gfx::Rect extraCelBounds = bounds;
+  if (m_site.tilemapMode() == TilemapMode::Tiles) {
+    // Transforming tiles
+    extraCelSize = m_site.grid().canvasToTile(bounds).size();
+    extraCelBounds = m_site.grid().alignBounds(bounds);
   }
   else {
-    bounds = transformation->transformedBounds();
+    // Transforming pixels
+    extraCelSize = bounds.size();
   }
 
-  if (!bounds.isEmpty()) {
-    gfx::Size extraCelSize;
-    if (m_site.tilemapMode() == TilemapMode::Tiles) {
-      // Transforming tiles
-      extraCelSize = m_site.grid().canvasToTile(bounds).size();
-      bounds = m_site.grid().alignBounds(bounds);
-    }
-    else {
-      // Transforming pixels
-      extraCelSize = bounds.size();
-    }
-
-    m_extraCel->create(ExtraCel::Purpose::TransformationPreview,
-                       m_site.tilemapMode(),
-                       m_document->sprite(),
-                       bounds,
-                       extraCelSize,
-                       m_site.frame(),
-                       opacity);
-    m_extraCel->setType(render::ExtraType::PATCH);
-    m_extraCel->setBlendMode(m_site.layer()->isImage() ?
-                               static_cast<LayerImage*>(m_site.layer())->blendMode() :
-                               BlendMode::NORMAL);
-  }
-  else
-    m_extraCel->reset();
+  m_extraCel->create(ExtraCel::Purpose::TransformationPreview,
+                     m_site.tilemapMode(),
+                     m_document->sprite(),
+                     extraCelBounds,
+                     extraCelSize,
+                     m_site.frame(),
+                     opacity);
+  m_extraCel->setType(render::ExtraType::PATCH);
+  m_extraCel->setBlendMode(m_site.layer()->isImage() ?
+                             static_cast<LayerImage*>(m_site.layer())->blendMode() :
+                             BlendMode::NORMAL);
 
   m_document->setExtraCel(m_extraCel);
 
-  if (m_extraCel->image()) {
-    // Draw the transformed pixels in the extra-cel which is the chunk
-    // of pixels that the user is moving.
+  // Draw the main extra cel image (for current cel / paste)
+  if (m_extraCel->image() && m_originalImage) {
     drawImage(*transformation, m_extraCel->image(), gfx::PointF(bounds.origin()), true);
   }
+
+  // Draw images for all cels in the celMap (multi-cel cases)
+  if (m_selectedCels.size() > 1)
+    drawImages(*transformation);
 }
 
 void PixelsMovement::redrawCurrentMask()
@@ -1248,6 +1272,128 @@ void PixelsMovement::drawImage(const Transformation& transformation,
     if (m_tiledModeHelper && m_tiledModeHelper->tiledEnabled()) {
       m_tiledModeHelper->drawTiled(dst, cornerBounds);
     }
+  }
+}
+
+void PixelsMovement::drawImages(const Transformation& transformation)
+{
+  if (!m_extraCel)
+    return;
+
+  auto corners = transformation.transformedCorners();
+  gfx::Rect bounds = corners.bounds(transformation.cornerThick());
+  if (bounds.isEmpty())
+    return;
+
+  const gfx::Rect cornerBounds = bounds;
+  if (m_tiledModeHelper && m_tiledModeHelper->hasModeFlag(TiledMode::X_AXIS))
+    bounds.enlargeXW(m_document->sprite()->width());
+  if (m_tiledModeHelper && m_tiledModeHelper->hasModeFlag(TiledMode::Y_AXIS))
+    bounds.enlargeYH(m_document->sprite()->height());
+
+  for (auto& [cel, data] : m_extraCel->celMap()) {
+    if (!cel || !data.originalImage)
+      continue;
+
+    const bool isTilemap = cel->layer()->isTilemap() && m_site.tilemapMode() == TilemapMode::Tiles;
+    const doc::Grid grid = m_site.grid();
+    const gfx::Rect tileBounds = grid.canvasToTile(bounds);
+
+    gfx::Size transformedSize = isTilemap ? tileBounds.size() : bounds.size();
+
+    doc::PixelFormat pixelFormat = data.originalImage->pixelFormat();
+    if (!data.transformedImage || data.transformedImage->width() != transformedSize.w ||
+        data.transformedImage->height() != transformedSize.h ||
+        data.transformedImage->pixelFormat() != pixelFormat) {
+      data.transformedImage.reset(Image::create(pixelFormat, transformedSize.w, transformedSize.h));
+    }
+
+    data.transformedBounds = bounds;
+
+    if (isTilemap) {
+      data.transformedImage->setMaskColor(doc::notile);
+      data.transformedImage->clear(data.transformedImage->maskColor());
+      drawTransformedTilemap(transformation,
+                             data.transformedImage.get(),
+                             data.originalImage.get(),
+                             m_initialMask.get());
+
+      // Fill notiles with tiles from the cel (non-selected tiles within
+      // the transformed bounds area)
+      if (cel->image()) {
+        ImageRef tileMaskBitmap = make_tile_mask_bitmap(&grid, m_currentMask.get());
+
+        // Calculate tile bounds for the mask and cel (tile terms)
+        const gfx::Size tileSize = grid.tileSize();
+        const gfx::Rect maskTileBounds(data.transformedBounds.x / tileSize.w,
+                                       data.transformedBounds.y / tileSize.h,
+                                       data.transformedBounds.w / tileSize.w,
+                                       data.transformedBounds.h / tileSize.h);
+        const gfx::Rect celTileBounds(cel->position().x / tileSize.w,
+                                      cel->position().y / tileSize.h,
+                                      cel->image()->width(),
+                                      cel->image()->height());
+
+        // Work only on the intersection between mask and cel
+        const gfx::Rect intersection = maskTileBounds.createIntersection(celTileBounds);
+        // Intersection in cel-local coordinates
+        const gfx::Rect celLocalRect(intersection.x - celTileBounds.x,
+                                     intersection.y - celTileBounds.y,
+                                     intersection.w,
+                                     intersection.h);
+        // Offset to convert from cel to mask coordinates
+        const gfx::Point celToMaskOffset = celTileBounds.origin() - maskTileBounds.origin();
+
+        for (int v = celLocalRect.y; v < celLocalRect.y2(); ++v) {
+          for (int u = celLocalRect.x; u < celLocalRect.x2(); ++u) {
+            // Convert cel coordinates to mask coords
+            const gfx::Point maskPos(celToMaskOffset.x + u, celToMaskOffset.y + v);
+            const bool isSelected = tileMaskBitmap->getPixel(maskPos.x, maskPos.y) == 1;
+
+            if (isSelected && data.transformedImage->getPixel(maskPos.x, maskPos.y) != doc::notile)
+              continue;
+
+            const doc::tile_t tileValue = cel->image()->getPixel(u, v);
+
+            if (isSelected && tileValue == doc::notile)
+              continue;
+
+            if (tileValue != doc::notile)
+              data.transformedImage->putPixel(maskPos.x, maskPos.y, tileValue);
+          }
+        }
+      }
+    }
+    else {
+      data.transformedImage->setMaskColor(m_site.sprite()->transparentColor());
+      data.transformedImage->clear(data.transformedImage->maskColor());
+      // First render the original layer pixels within the bounds area
+      // (pixels outside the selection that are within the extra cel bounds).
+      // This ensures that when the extra cel area is excluded from the
+      // original cel render, we still see the original pixels outside the selection.
+      render::Render render;
+      render.renderLayer(data.transformedImage.get(),
+                         cel->layer(),
+                         cel->frame(),
+                         gfx::Clip(0, 0, bounds),
+                         BlendMode::SRC);
+      color_t maskColor = m_maskColor;
+      if (m_opaque) {
+        if (data.originalImage->pixelFormat() == IMAGE_INDEXED)
+          maskColor = -1;
+        else
+          maskColor = 0;
+      }
+      data.originalImage->setMaskColor(maskColor);
+      drawParallelogram(transformation,
+                        data.transformedImage.get(),
+                        data.originalImage.get(),
+                        m_initialMask.get(),
+                        corners,
+                        gfx::PointF(bounds.origin()));
+    }
+    if (m_tiledModeHelper && m_tiledModeHelper->tiledEnabled())
+      m_tiledModeHelper->drawTiled(data.transformedImage.get(), cornerBounds);
   }
 }
 
@@ -1343,24 +1489,6 @@ retry:; // In case that we don't have enough memory for RotSprite
   }
 }
 
-static void merge_tilemaps(Image* dst, const Image* src, gfx::Clip area)
-{
-  if (!area.clip(dst->width(), dst->height(), src->width(), src->height()))
-    return;
-
-  ImageConstIterator<TilemapTraits> src_it(src, area.srcBounds(), area.src.x, area.src.y);
-  ImageIterator<TilemapTraits> dst_it(dst, area.dstBounds(), area.dst.x, area.dst.y);
-
-  for (int y = 0; y < area.size.h; ++y) {
-    for (int x = 0; x < area.size.w; ++x) {
-      if (*src_it != doc::notile)
-        *dst_it = *src_it;
-      ++src_it;
-      ++dst_it;
-    }
-  }
-}
-
 void PixelsMovement::drawTransformedTilemap(const Transformation& transformation,
                                             doc::Image* dst,
                                             const doc::Image* src,
@@ -1404,8 +1532,8 @@ void PixelsMovement::onPivotChange()
 void PixelsMovement::onRotationAlgorithmChange()
 {
   try {
-    redrawExtraImage();
     redrawCurrentMask();
+    redrawExtraImages();
     updateDocumentMask();
 
     update_screen_for_document(m_document);
@@ -1446,10 +1574,30 @@ void PixelsMovement::shiftOriginalImage(const int dx, const int dy, const double
   doc::algorithm::shift_image(m_originalImage.get(), dx, dy, angle);
 }
 
+void PixelsMovement::flipOriginalImages(const doc::algorithm::FlipType flipType)
+{
+  if (!m_extraCel)
+    return;
+  for (auto& [cel, data] : m_extraCel->celMap())
+    if (data.originalImage)
+      doc::algorithm::flip_image(data.originalImage.get(),
+                                 gfx::Rect(gfx::Point(0, 0), data.originalImage->size()),
+                                 flipType);
+}
+
+void PixelsMovement::shiftOriginalImages(const int dx, const int dy, const double angle)
+{
+  if (!m_extraCel)
+    return;
+  for (auto& [cel, data] : m_extraCel->celMap())
+    if (data.originalImage)
+      doc::algorithm::shift_image(data.originalImage.get(), dx, dy, angle);
+}
+
 // Returns the list of cels that will be transformed (the first item
 // in the list must be the current cel that was transformed if the cel
 // wasn't nullptr).
-CelList PixelsMovement::getEditableCels()
+CelList PixelsMovement::getEditableCels(const bool filterTilemapsByTileSize)
 {
   CelList cels;
 
@@ -1485,6 +1633,29 @@ CelList PixelsMovement::getEditableCels()
     if (it != cels.end())
       cels.erase(it);
     cels.insert(cels.begin(), m_site.cel());
+  }
+
+  // Filter out tilemap cels with different tileSize and origin than the reference cel
+  if (filterTilemapsByTileSize) {
+    const auto refTilemapLayer = static_cast<const LayerTilemap*>(m_site.layer());
+    gfx::Size refTileSize = refTilemapLayer->tileset()->grid().tileSize();
+    gfx::Point refOffset(refTilemapLayer->tileset()->grid().origin());
+    if (m_site.cel())
+      refOffset = gfx::Point(m_site.cel()->position().x % refTileSize.w,
+                             m_site.cel()->position().y % refTileSize.h);
+    cels.erase(
+      std::remove_if(cels.begin(),
+                     cels.end(),
+                     [&refTileSize, &refOffset](const Cel* cel) {
+                       if (!cel || !cel->layer()->isTilemap())
+                         return false;
+                       const auto* tilemapLayer = static_cast<const LayerTilemap*>(cel->layer());
+                       const gfx::Size celTileSize = tilemapLayer->tileset()->grid().tileSize();
+                       const gfx::Point celOffset(cel->position().x % celTileSize.w,
+                                                  cel->position().y % refTileSize.h);
+                       return (refTileSize != celTileSize || refOffset != celOffset);
+                     }),
+      cels.end());
   }
 
   return cels;
@@ -1571,14 +1742,14 @@ void PixelsMovement::reproduceAllTransformationsWithInnerCmds()
         shiftOriginalImage(c.data.shift.dx, c.data.shift.dy, c.data.shift.angle);
         break;
       case InnerCmd::Stamp:
-        redrawExtraImage(c.data.stamp.transformation);
+        redrawExtraImages(c.data.stamp.transformation);
         stampExtraCelImage();
         break;
     }
   }
 
-  redrawExtraImage();
   redrawCurrentMask();
+  redrawExtraImages();
   updateDocumentMask();
 }
 

--- a/src/app/ui/editor/pixels_movement.h
+++ b/src/app/ui/editor/pixels_movement.h
@@ -16,12 +16,14 @@
 #include "app/tx.h"
 #include "app/ui/editor/handle_type.h"
 #include "doc/algorithm/flip_type.h"
+#include "doc/cel_list.h"
 #include "doc/frame.h"
 #include "doc/image_ref.h"
 #include "gfx/size.h"
 #include "obs/connection.h"
 
 #include <memory>
+#include <vector>
 
 namespace doc {
 class Image;
@@ -139,14 +141,17 @@ private:
   bool editMultipleCels() const;
   void stampImage(bool finalStamp);
   void stampExtraCelImage();
+  void stampExtraCelImages();
   void onPivotChange();
   void onRotationAlgorithmChange();
   void redrawExtraImage(Transformation* transformation = nullptr);
+  void redrawExtraImages(Transformation* transformation = nullptr);
   void redrawCurrentMask();
   void drawImage(const Transformation& transformation,
                  doc::Image* dst,
                  const gfx::PointF& pt,
                  const bool renderOriginalLayer);
+  void drawImages(const Transformation& transformation);
   void drawMask(doc::Mask* dst, bool shrink);
   void drawParallelogram(const Transformation& transformation,
                          doc::Image* dst,
@@ -162,18 +167,11 @@ private:
   void hideDocumentMask();
 
   void flipOriginalImage(const doc::algorithm::FlipType flipType);
+  void flipOriginalImages(const doc::algorithm::FlipType flipType);
   void shiftOriginalImage(const int dx, const int dy, const double angle);
-  CelList getEditableCels();
+  void shiftOriginalImages(const int dx, const int dy, const double angle);
+  CelList getEditableCels(const bool filterTilemapsByTileSize = false);
   void reproduceAllTransformationsWithInnerCmds();
-
-  void alignMasksAndTransformData(const Mask* initialMask0,
-                                  const Mask* initialMask,
-                                  const Mask* currentMask,
-                                  const Transformation* initialData,
-                                  const Transformation* currentData,
-                                  const doc::Grid& grid,
-                                  const gfx::Size& deltaA,
-                                  const gfx::Size& deltaB);
 
 #if _DEBUG
   void dumpInnerCmds();
@@ -201,6 +199,9 @@ private:
   obs::scoped_connection m_rotAlgoConn;
   ExtraCelRef m_extraCel;
   bool m_canHandleFrameChange;
+
+  // Vector of selected cels for multi-cel transformation
+  doc::CelList m_selectedCels;
 
   // Fast mode is used to give a faster feedback to the user
   // avoiding RotSprite on each mouse movement.

--- a/src/app/ui/editor/standby_state.cpp
+++ b/src/app/ui/editor/standby_state.cpp
@@ -690,6 +690,14 @@ void StandbyState::startFlipTransformation(Editor* editor, doc::algorithm::FlipT
     movingPixels->flip(flipType);
 }
 
+void StandbyState::startShiftTransformation(Editor* editor, int dx, int dy)
+{
+  transformSelection(editor, NULL, NoHandle);
+
+  if (auto movingPixels = dynamic_cast<MovingPixelsState*>(editor->getState().get()))
+    movingPixels->shift(dx, dy);
+}
+
 void StandbyState::transformSelection(Editor* editor, MouseMessage* msg, HandleType handle)
 {
   Doc* document = editor->document();

--- a/src/app/ui/editor/standby_state.cpp
+++ b/src/app/ui/editor/standby_state.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2025  Igara Studio S.A.
+// Copyright (C) 2018-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -62,6 +62,7 @@
 #include "doc/mask.h"
 #include "doc/slice.h"
 #include "doc/sprite.h"
+#include "doc/util.h"
 #include "fmt/format.h"
 #include "gfx/rect.h"
 #include "os/surface.h"
@@ -719,10 +720,32 @@ void StandbyState::transformSelection(Editor* editor, MouseMessage* msg, HandleT
 
   try {
     Site site = editor->getSite();
+
+    // Tiled Mode + TilemapMode::Tiles + transformSelection not supported yet.
+    // Instead, aseprite switchs to TilemapMode::Pixels.
+    // This limitation on TilemapMode::Tiles is to avoid involuntary tile break when
+    // the canvas size is not a multiple of the tile size.
+    if (&editor->getTiledModeHelper() && editor->getTiledModeHelper().tiledEnabled() &&
+        site.layer()->isTilemap() && site.tilemapMode() == TilemapMode::Tiles &&
+        ColorBar::instance()) {
+      ColorBar::instance()->setTilemapMode(TilemapMode::Pixels);
+      site.tilemapMode(TilemapMode::Pixels);
+    }
+
     ImageRef tmpImage;
 
-    if (site.layer() && site.layer()->isTilemap() && site.tilemapMode() == TilemapMode::Tiles) {
-      tmpImage.reset(new_tilemap_from_mask(site, site.document()->mask()));
+    // When in TilemapMode::Tiles, align the mask to the grid so we select
+    // complete tiles
+    const bool isTilemapTilesMode = site.layer() && site.layer()->isTilemap() &&
+                                    site.tilemapMode() == TilemapMode::Tiles;
+    std::unique_ptr<doc::Mask> alignedMask;
+    const doc::Mask* effectiveMask = document->mask();
+
+    if (isTilemapTilesMode) {
+      doc::Grid grid = site.grid();
+      alignedMask.reset(new doc::Mask(doc::make_aligned_mask(&grid, document->mask())));
+      effectiveMask = alignedMask.get();
+      tmpImage.reset(new_tilemap_from_mask(site, effectiveMask));
     }
     else {
       tmpImage.reset(new_image_from_mask(site, Preferences::instance().experimental.newBlend()));
@@ -743,7 +766,7 @@ void StandbyState::transformSelection(Editor* editor, MouseMessage* msg, HandleT
     PixelsMovementPtr pixelsMovement(new PixelsMovement(UIContext::instance(),
                                                         site,
                                                         tmpImage.get(),
-                                                        document->mask(),
+                                                        effectiveMask,
                                                         "Transformation",
                                                         &editor->getTiledModeHelper()));
 

--- a/src/app/ui/editor/standby_state.cpp
+++ b/src/app/ui/editor/standby_state.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2025  Igara Studio S.A.
+// Copyright (C) 2018-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -62,6 +62,7 @@
 #include "doc/mask.h"
 #include "doc/slice.h"
 #include "doc/sprite.h"
+#include "doc/util.h"
 #include "fmt/format.h"
 #include "gfx/rect.h"
 #include "os/surface.h"
@@ -719,10 +720,32 @@ void StandbyState::transformSelection(Editor* editor, MouseMessage* msg, HandleT
 
   try {
     Site site = editor->getSite();
+
+    // Tiled Mode + TilemapMode::Tiles + transformSelection not supported yet.
+    // Instead, aseprite switchs to TilemapMode::Pixels.
+    // This limitation on TilemapMode::Tiles is to avoid involuntary tile break when
+    // the canvas size is not a multiple of the tile size.
+    if (&editor->getTiledModeHelper() && editor->getTiledModeHelper().tiledEnabled() &&
+        site.layer()->isTilemap() && site.tilemapMode() == TilemapMode::Tiles &&
+        ColorBar::instance()) {
+      ColorBar::instance()->setTilemapMode(TilemapMode::Pixels);
+      site.tilemapMode(TilemapMode::Pixels);
+    }
+
     ImageRef tmpImage;
 
-    if (site.layer() && site.layer()->isTilemap() && site.tilemapMode() == TilemapMode::Tiles) {
-      tmpImage.reset(new_tilemap_from_mask(site, site.document()->mask()));
+    // When in TilemapMode::Tiles, align the mask to the grid so we select
+    // complete tiles
+    const bool isTilemapTilesMode = site.layer() && site.layer()->isTilemap() &&
+                                    site.tilemapMode() == TilemapMode::Tiles;
+    std::unique_ptr<doc::Mask> alignedMask;
+    const doc::Mask* effectiveMask = document->mask();
+
+    if (isTilemapTilesMode) {
+      const doc::Grid grid = site.grid();
+      alignedMask.reset(new doc::Mask(doc::make_aligned_mask(&grid, document->mask())));
+      effectiveMask = alignedMask.get();
+      tmpImage.reset(new_tilemap_from_mask(site, effectiveMask));
     }
     else {
       tmpImage.reset(new_image_from_mask(site, Preferences::instance().experimental.newBlend()));
@@ -743,7 +766,7 @@ void StandbyState::transformSelection(Editor* editor, MouseMessage* msg, HandleT
     PixelsMovementPtr pixelsMovement(new PixelsMovement(UIContext::instance(),
                                                         site,
                                                         tmpImage.get(),
-                                                        document->mask(),
+                                                        effectiveMask,
                                                         "Transformation",
                                                         &editor->getTiledModeHelper()));
 

--- a/src/app/ui/editor/standby_state.h
+++ b/src/app/ui/editor/standby_state.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2025  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -54,6 +54,7 @@ public:
   void startSelectionTransformation(Editor* editor, const gfx::Point& move, double angle);
 
   void startFlipTransformation(Editor* editor, doc::algorithm::FlipType flipType);
+  void startShiftTransformation(Editor* editor, int dx, int dy);
 
 protected:
   EditorStatePtr handleDragActionsFromMessage(Editor* editor, const ui::Message* msg);

--- a/src/app/util/new_image_from_mask.cpp
+++ b/src/app/util/new_image_from_mask.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2024 Igara Studio S.A.
+// Copyright (C) 2019-present Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -201,9 +201,6 @@ doc::Image* new_tilemap_from_mask(const Site& site, const doc::Mask* srcMask)
   ASSERT(srcMask);
 
   const Cel* srcCel = site.cel();
-  if (!srcCel)
-    return nullptr;
-
   const doc::Grid grid = site.grid();
   const Image* srcMaskBitmap = srcMask->bitmap();
   const gfx::Rect& srcBounds = srcMask->bounds();
@@ -219,6 +216,9 @@ doc::Image* new_tilemap_from_mask(const Site& site, const doc::Mask* srcMask)
 
   // Clear the new tilemap
   clear_image(dst.get(), dst->maskColor());
+
+  if (!srcCel)
+    return dst.release();
 
   // Copy the masked zones
   if (srcMaskBitmap) {

--- a/src/doc/util.cpp
+++ b/src/doc/util.cpp
@@ -1,5 +1,5 @@
 // Aseprite Document Library
-// Copyright (c) 2020-2024 Igara Studio S.A.
+// Copyright (c) 2020-present Igara Studio S.A.
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -93,6 +93,43 @@ Mask make_aligned_mask(const Grid* grid, const Mask* mask)
   }
   maskOutput.unfreeze();
   return maskOutput;
+}
+
+ImageRef make_tile_mask_bitmap(const Grid* grid, const Mask* mask)
+{
+  if (!mask || !mask->bitmap())
+    return nullptr;
+
+  const gfx::Rect& pixelBounds = mask->bounds();
+  const gfx::Rect tileBounds = grid->canvasToTile(pixelBounds);
+
+  if (tileBounds.isEmpty())
+    return nullptr;
+
+  ImageRef tileMask(Image::create(IMAGE_BITMAP, tileBounds.w, tileBounds.h));
+  clear_image(tileMask.get(), 0);
+
+  const LockImageBits<BitmapTraits> maskBits(mask->bitmap());
+  auto mask_it = maskBits.begin();
+  const gfx::Point originTile = grid->canvasToTile(pixelBounds.origin());
+
+  // Iterate over each pixel in the mask and mark the corresponding
+  // tile if any pixel within that tile is selected.
+  for (int y = 0; y < pixelBounds.h; ++y) {
+    for (int x = 0; x < pixelBounds.w; ++x, ++mask_it) {
+      ASSERT(mask_it != maskBits.end());
+      if (*mask_it) {
+        gfx::Point tilePt = grid->canvasToTile(gfx::Point(pixelBounds.x + x, pixelBounds.y + y));
+        gfx::Point dstPt = tilePt - originTile;
+
+        if (tileMask->bounds().contains(dstPt)) {
+          tileMask->putPixel(dstPt.x, dstPt.y, 1);
+        }
+      }
+    }
+  }
+
+  return tileMask;
 }
 
 } // namespace doc

--- a/src/doc/util.cpp
+++ b/src/doc/util.cpp
@@ -1,5 +1,5 @@
 // Aseprite Document Library
-// Copyright (c) 2020-2024 Igara Studio S.A.
+// Copyright (c) 2020-present Igara Studio S.A.
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -93,6 +93,44 @@ Mask make_aligned_mask(const Grid* grid, const Mask* mask)
   }
   maskOutput.unfreeze();
   return maskOutput;
+}
+
+ImageRef make_tile_mask_bitmap(const Grid* grid, const Mask* mask)
+{
+  if (!mask || !mask->bitmap())
+    return nullptr;
+
+  const gfx::Rect& pixelBounds = mask->bounds();
+  const gfx::Rect tileBounds = grid->canvasToTile(pixelBounds);
+
+  if (tileBounds.isEmpty())
+    return nullptr;
+
+  ImageRef tileMask(Image::create(IMAGE_BITMAP, tileBounds.w, tileBounds.h));
+  clear_image(tileMask.get(), 0);
+
+  const LockImageBits<BitmapTraits> maskBits(mask->bitmap());
+  auto mask_it = maskBits.begin();
+  const gfx::Point originTile = grid->canvasToTile(pixelBounds.origin());
+
+  // Iterate over each pixel in the mask and mark the corresponding
+  // tile if any pixel within that tile is selected.
+  for (int y = 0; y < pixelBounds.h; ++y) {
+    for (int x = 0; x < pixelBounds.w; ++x, ++mask_it) {
+      ASSERT(mask_it != maskBits.end());
+      if (*mask_it) {
+        const gfx::Point tilePt = grid->canvasToTile(
+          gfx::Point(pixelBounds.x + x, pixelBounds.y + y));
+        const gfx::Point dstPt = tilePt - originTile;
+
+        if (tileMask->bounds().contains(dstPt)) {
+          tileMask->putPixel(dstPt.x, dstPt.y, 1);
+        }
+      }
+    }
+  }
+
+  return tileMask;
 }
 
 } // namespace doc

--- a/src/doc/util.h
+++ b/src/doc/util.h
@@ -1,5 +1,5 @@
 // Aseprite Document Library
-// Copyright (c) 2020-2024 Igara Studio S.A.
+// Copyright (c) 2020-present Igara Studio S.A.
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -8,6 +8,7 @@
 #define DOC_UTIL_H_INCLUDED
 #pragma once
 
+#include "doc/image_ref.h"
 #include "doc/tile.h"
 
 namespace doc {
@@ -32,6 +33,11 @@ void fix_old_tilemap(Image* image,
 // Returns a mask aligned with a given grid, starting from another
 // mask not aligned with the grid.
 Mask make_aligned_mask(const Grid* grid, const Mask* mask);
+
+// Creates a tile-level mask from a pixel-level mask.
+// Returns a bitmap image where each pixel represents a tile:
+// 1 = tile is inside the selection.
+ImageRef make_tile_mask_bitmap(const Grid* grid, const Mask* mask);
 
 } // namespace doc
 

--- a/src/render/render.cpp
+++ b/src/render/render.cpp
@@ -631,6 +631,16 @@ void Render::removeExtraImage()
   m_extraCel = nullptr;
 }
 
+void Render::setExtraCelInfoMap(const ExtraCelInfoMap* map)
+{
+  m_extraCelInfoMap = map;
+}
+
+void Render::removeExtraCelInfoMap()
+{
+  m_extraCelInfoMap = nullptr;
+}
+
 void Render::setOnionskin(const OnionskinOptions& options)
 {
   m_onionskin = options;
@@ -1020,6 +1030,9 @@ void Render::renderPlan(RenderPlan& plan,
         extraArea.h = 1;
     }
 
+    // Extra cel info from map (for multi-cel transformations)
+    const ExtraCelInfo* extraCelInfo = nullptr;
+
     switch (layer->type()) {
       case ObjectType::LayerImage:
       case ObjectType::LayerTilemap: {
@@ -1073,13 +1086,32 @@ void Render::renderPlan(RenderPlan& plan,
             if (!isSelected && m_nonactiveLayersOpacity != 255)
               opacity = MUL_UN8(opacity, m_nonactiveLayersOpacity, t);
 
+            // Check if there's extra cel info for this cel (multi-cel transformations)
+            // We use cel->data() as key to support linked cels
+            if (m_extraCelInfoMap) {
+              auto it = m_extraCelInfoMap->find(cel->data());
+              if (it != m_extraCelInfoMap->end())
+                extraCelInfo = &it->second;
+            }
+
             // Generally this is just one pass, but if we are using
             // OVER_COMPOSITE extra cel, this will be two passes.
             for (int pass = 0; pass < 2; ++pass) {
-              // Draw parts outside the "m_extraCel" area
-              if (drawExtra && m_extraType == ExtraType::PATCH) {
+              // Draw parts outside the "m_extraCel" area and/or extra cel info area
+              const bool hasExtraCelPatch = (drawExtra && m_extraType == ExtraType::PATCH);
+              const bool hasExtraCelInfo = (extraCelInfo && extraCelInfo->image);
+
+              if (hasExtraCelPatch || hasExtraCelInfo) {
                 gfx::Region originalAreas(area.srcBounds());
-                originalAreas.createSubtraction(originalAreas, gfx::Region(extraArea));
+
+                // Exclude the main extra cel area
+                if (hasExtraCelPatch)
+                  originalAreas.createSubtraction(originalAreas, gfx::Region(extraArea));
+
+                // Exclude the extra cel info area
+                if (hasExtraCelInfo)
+                  originalAreas.createSubtraction(originalAreas,
+                                                  gfx::Region(m_proj.apply(extraCelInfo->bounds)));
 
                 for (auto rc : originalAreas) {
                   renderCel(
@@ -1178,6 +1210,23 @@ void Render::renderPlan(RenderPlan& plan,
                   m_extraCel->opacity(),
                   m_extraBlendMode);
       }
+    }
+
+    // Draw per-cel extra images (for multi-cel transformations)
+    if (extraCelInfo && extraCelInfo->image && extraCelInfo->opacity > 0) {
+      const gfx::Rect extraBounds = m_proj.apply(extraCelInfo->bounds);
+      renderCel(image,
+                cel,
+                m_sprite,
+                extraCelInfo->image,
+                layer,
+                m_sprite->palette(frame),
+                extraCelInfo->bounds,
+                gfx::Clip(area.dst.x + extraBounds.x - area.src.x,
+                          area.dst.y + extraBounds.y - area.src.y,
+                          extraBounds),
+                extraCelInfo->opacity,
+                extraCelInfo->blendMode);
     }
   }
 }

--- a/src/render/render.h
+++ b/src/render/render.h
@@ -1,5 +1,5 @@
 // Aseprite Render Library
-// Copyright (c) 2019-2023 Igara Studio S.A.
+// Copyright (c) 2019-present Igara Studio S.A.
 // Copyright (c) 2001-2018 David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -18,14 +18,18 @@
 #include "doc/tile.h"
 #include "gfx/clip.h"
 #include "gfx/point.h"
+#include "gfx/rect.h"
 #include "gfx/size.h"
 #include "render/bg_options.h"
 #include "render/extra_type.h"
 #include "render/onionskin_options.h"
 #include "render/projection.h"
 
+#include <map>
+
 namespace doc {
 class Cel;
+class CelData;
 class Image;
 class Layer;
 class Palette;
@@ -36,6 +40,18 @@ class Tileset;
 
 namespace render {
 using namespace doc;
+
+// Extra cel info for per-cel rendering (used in multi-cel transformations)
+struct ExtraCelInfo {
+  gfx::Rect bounds;
+  const Image* image = nullptr;
+  int opacity = 255;
+  BlendMode blendMode = BlendMode::NORMAL;
+};
+
+// Map from CelData* to ExtraCelInfo for multi-cel transformations
+// Using CelData* as key allows linked cels to find their entry
+using ExtraCelInfoMap = std::map<const CelData*, ExtraCelInfo>;
 
 typedef void (*CompositeImageFunc)(Image* dst,
                                    const Image* src,
@@ -86,6 +102,11 @@ public:
 
   void setOnionskin(const OnionskinOptions& options);
   void disableOnionskin();
+
+  // Sets a map of extra cel info for per-cel rendering
+  // Used for multi-cel transformations
+  void setExtraCelInfoMap(const ExtraCelInfoMap* map);
+  void removeExtraCelInfoMap();
 
   void renderSprite(Image* dstImage, const Sprite* sprite, frame_t frame);
 
@@ -202,6 +223,7 @@ private:
   OnionskinOptions m_onionskin;
   ImageBufferPtr m_tmpBuf;
   bool m_composeGroups = false;
+  const ExtraCelInfoMap* m_extraCelInfoMap = nullptr;
 };
 
 void composite_image(Image* dst,


### PR DESCRIPTION
This fix solves the multi-layer/multi-cel transformation preview.

- It can manage a mix of image and tilemap layers in TilemapMode::Pixels or TilemapMode::Tiles.
- Considers opacities of each cel.
- Considers the blend modes of each layer.
- Considers the Z-order of each cel.
- Consider the overlaps between selected and unselected layers.
- Correct behavior of Skew/Rotate/Resize/Move/Flip/Shift transformations.
- In Tilemap Mode::Tiles, the tilemap layers that are transformed (Resize/Move) are restricted to those whose tile grid matches that of the active layer.
- When generating new tiles in a tilemap layer by breaking tiles because transformation in TilemapMode::Pixels, it was decided to do so in TilesetMode::Stack mode to avoid accidental destruction of tiles in the tileset.
- Fixed the Shift Pixels in a multi-layer transformation when it is the first transformation command.
- Consider non-rectangular selections.
- Consider linked cels.

fix #2865