### PR TITLE
Use new laf-base/file size API to avoid platform-specific code handling big files

### DIFF
--- a/docs/ase-file-specs.md
+++ b/docs/ase-file-specs.md
@@ -67,6 +67,7 @@ To read the sprite:
 A 128-byte header (same as FLC/FLI header, but with other magic number):
 
     DWORD       File size
+                It is 0xFFFFFFFF if the size is bigger than 4GB
     WORD        Magic number (0xA5E0)
     WORD        Frames
     WORD        Width in pixels

--- a/src/app/file/gif_format.cpp
+++ b/src/app/file/gif_format.cpp
@@ -38,14 +38,6 @@
 
 #include <gif_lib.h>
 
-#ifdef _WIN32
-  #include <io.h>
-  #define posix_lseek _lseek
-#else
-  #include <unistd.h>
-  #define posix_lseek lseek
-#endif
-
 #if GIFLIB_MAJOR < 5
   #define GifMakeMapObject MakeMapObject
   #define GifFreeMapObject FreeMapObject
@@ -187,7 +179,7 @@ static inline doc::color_t colormap2rgba(ColorMapObject* colormap, int i)
 // merged with new colormaps.
 class GifDecoder {
 public:
-  GifDecoder(FileOp* fop, GifFileType* gifFile, int fd, size_t filesize)
+  GifDecoder(FileOp* fop, GifFileType* gifFile, int fd, const base::filesize_t filesize)
     : m_fop(fop)
     , m_gifFile(gifFile)
     , m_fd(fd)
@@ -234,7 +226,7 @@ public:
         break;
 
       if (m_filesize > 0) {
-        int pos = posix_lseek(m_fd, 0, SEEK_CUR);
+        const auto pos = base::base_lseek(m_fd, 0, SEEK_CUR);
         m_fop->setProgress(double(pos) / double(m_filesize));
       }
     }
@@ -843,7 +835,7 @@ private:
   FileOp* m_fop;
   GifFileType* m_gifFile;
   int m_fd;
-  size_t m_filesize;
+  base::filesize_t m_filesize;
   std::unique_ptr<Sprite> m_sprite;
   gfx::Rect m_spriteBounds;
   LayerImage* m_layer;
@@ -868,7 +860,7 @@ bool GifFormat::onLoad(FileOp* fop)
 {
   // The filesize is used only to report some progress when we decode
   // the GIF file.
-  size_t filesize = base::file_size(fop->filename());
+  const auto filesize = base::file_size(fop->filename());
 
 #if GIFLIB_MAJOR >= 5
   int errCode = 0;

--- a/src/app/file/qoi_format.cpp
+++ b/src/app/file/qoi_format.cpp
@@ -11,6 +11,7 @@
 #include "app/file/file.h"
 #include "app/file/file_format.h"
 #include "base/file_handle.h"
+#include "base/file_size.h"
 
 #define QOI_NO_STDIO
 #define QOI_IMPLEMENTATION
@@ -49,19 +50,9 @@ bool QoiFormat::onLoad(FileOp* fop)
   FileHandle handle(open_file_with_exception(fop->filename(), "rb"));
   FILE* f = handle.get();
 
-#if LAF_WINDOWS
-  _fseeki64(f, 0, SEEK_END);
-  auto size = _ftelli64(f);
+  const auto size = base::file_size(f);
   if (size <= 0)
     return false;
-  _fseeki64(f, 0, SEEK_SET);
-#else
-  fseeko(f, 0, SEEK_END);
-  auto size = ftello(f);
-  if (size <= 0)
-    return false;
-  fseeko(f, 0, SEEK_SET);
-#endif
 
   auto data = QOI_MALLOC(size);
   if (!data)

--- a/src/app/file/webp_format.cpp
+++ b/src/app/file/webp_format.cpp
@@ -22,6 +22,7 @@
 #include "app/pref/preferences.h"
 #include "base/convert_to.h"
 #include "base/file_handle.h"
+#include "base/file_size.h"
 #include "doc/doc.h"
 #include "ui/manager.h"
 
@@ -84,19 +85,7 @@ bool WebPFormat::onLoad(FileOp* fop)
   FileHandle handle(open_file_with_exception(fop->filename(), "rb"));
   FILE* fp = handle.get();
 
-  size_t len = 0;
-#if LAF_WINDOWS
-  if (_fseeki64(fp, 0, SEEK_END) == 0) {
-    len = _ftelli64(fp);
-    _fseeki64(fp, 0, SEEK_SET);
-  }
-#else
-  if (fseeko(fp, 0, SEEK_END) == 0) {
-    len = ftello(fp);
-    fseeko(fp, 0, SEEK_SET);
-  }
-#endif
-
+  const auto len = base::file_size(fp);
   if (len < 4) {
     fop->setError("The specified file is not a WebP file\n");
     return false;

--- a/src/app/script/app_fs_object.cpp
+++ b/src/app/script/app_fs_object.cpp
@@ -15,6 +15,8 @@
 #include "base/file_size.h"
 #include "base/fs.h"
 
+#include <limits>
+
 namespace app { namespace script {
 
 namespace {
@@ -97,8 +99,13 @@ int AppFS_isDirectory(lua_State* L)
 int AppFS_fileSize(lua_State* L)
 {
   const char* fn = lua_tostring(L, 1);
-  if (fn)
-    lua_pushinteger(L, base::file_size(fn));
+  if (fn) {
+    const auto size = base::file_size(fn);
+    if (size <= std::numeric_limits<lua_Integer>::max())
+      lua_pushinteger(L, size);
+    else
+      lua_pushnumber(L, size);
+  }
   else
     lua_pushnil(L);
   return 1;

--- a/src/app/util/msk_file.cpp
+++ b/src/app/util/msk_file.cpp
@@ -25,7 +25,7 @@ using namespace doc;
 // Loads a MSK file (Animator and Animator Pro format)
 Mask* load_msk_file(const char* filename)
 {
-  int orig_size = base::file_size(filename);
+  const auto orig_size = base::file_size(filename);
   int i, c, u, v, byte, magic, size;
   Mask* mask = NULL;
 

--- a/src/desktop/win/thumbnail_handler.cpp
+++ b/src/desktop/win/thumbnail_handler.cpp
@@ -6,6 +6,7 @@
 // Read LICENSE.txt for more information.
 
 #include "base/base.h"
+#include "base/file_size.h"
 #include "dio/decode_delegate.h"
 #include "dio/decode_file.h"
 #include "dio/file_interface.h"
@@ -50,7 +51,7 @@ public:
 
   bool ok() const override { return m_ok; }
 
-  uint64_t tell() override
+  base::fileoff_t tell() override
   {
     LARGE_INTEGER delta;
     delta.QuadPart = 0;
@@ -64,7 +65,7 @@ public:
     return newPos.QuadPart;
   }
 
-  void seek(uint64_t absPos) override
+  void seek(const base::fileoff_t absPos) override
   {
     LARGE_INTEGER pos;
     pos.QuadPart = absPos;

--- a/src/dio/aseprite_common.h
+++ b/src/dio/aseprite_common.h
@@ -9,6 +9,7 @@
 #define DIO_ASEPRITE_COMMON_H_INCLUDED
 #pragma once
 
+#include "base/file_size.h"
 #include "base/ints.h"
 
 #include <map>
@@ -33,8 +34,9 @@
 #define ASE_FILE_CHUNK_TAGS              0x2018
 #define ASE_FILE_CHUNK_PALETTE           0x2019
 #define ASE_FILE_CHUNK_USER_DATA         0x2020
-#define ASE_FILE_CHUNK_SLICES                                                                      \
-  0x2021 // Deprecated chunk (used on dev versions only between v1.2-beta7 and v1.2-beta8)
+// ASE_FILE_CHUNK_SLICES is a deprecated chunk (used on dev versions
+// only between v1.2-beta7 and v1.2-beta8)
+#define ASE_FILE_CHUNK_SLICES             0x2021
 #define ASE_FILE_CHUNK_SLICE              0x2022
 #define ASE_FILE_CHUNK_TILESET            0x2023
 
@@ -80,9 +82,9 @@
 namespace dio {
 
 struct AsepriteHeader {
-  uint64_t pos; // TODO used by the encoder in app project
+  base::fileoff_t pos; // TODO used by the encoder in app project
 
-  uint32_t size; // TODO should be uint64_t to support file sizes >4.30GB (requires format revision)
+  uint32_t size; // For file sizes bigger than 4GB it's set to 0xFFFFFFFF
   uint16_t magic;
   uint16_t frames;
   uint16_t width;
@@ -104,7 +106,7 @@ struct AsepriteHeader {
 };
 
 struct AsepriteFrameHeader {
-  uint64_t pos;
+  base::fileoff_t pos;
   uint32_t size;
   uint16_t magic;
   uint32_t chunks;
@@ -113,7 +115,7 @@ struct AsepriteFrameHeader {
 
 struct AsepriteChunk {
   int type;
-  uint64_t start;
+  base::fileoff_t start;
 };
 
 class AsepriteExternalFiles {

--- a/src/dio/aseprite_decoder.cpp
+++ b/src/dio/aseprite_decoder.cpp
@@ -101,7 +101,7 @@ bool AsepriteDecoder::decode()
   // Read frame by frame to end-of-file
   for (frame_t frame = 0; frame < nframes; ++frame) {
     // Start frame position
-    const uint64_t frame_pos = tell();
+    const auto frame_pos = tell();
     delegate()->progress((float)frame_pos / (float)header.size);
 
     // Read frame header
@@ -117,7 +117,7 @@ bool AsepriteDecoder::decode()
       // Read chunks
       for (uint32_t c = 0; c < frame_header.chunks; c++) {
         // Start chunk position
-        const uint64_t chunk_pos = tell();
+        const auto chunk_pos = tell();
         delegate()->progress((float)chunk_pos / (float)header.size);
 
         // Read chunk information
@@ -307,7 +307,7 @@ bool AsepriteDecoder::decode()
 
 bool AsepriteDecoder::readHeader(AsepriteHeader* header)
 {
-  const uint64_t headerPos = tell();
+  const auto headerPos = tell();
 
   header->size = read32();
   header->magic = read16();
@@ -676,7 +676,7 @@ void read_compressed_image_templ(FileInterface* f,
                                  DecodeDelegate* delegate,
                                  Image* image,
                                  const AsepriteHeader* header,
-                                 const size_t chunk_end)
+                                 const base::fileoff_t chunk_end)
 {
   PixelIO<ImageTraits> pixel_io;
   z_stream zstream;
@@ -697,7 +697,7 @@ void read_compressed_image_templ(FileInterface* f,
   int y = 0;
 
   while (true) {
-    size_t input_bytes;
+    base::fileoff_t input_bytes;
 
     if (f->tell() + compressed.size() > chunk_end) {
       input_bytes = chunk_end - f->tell(); // Remaining bytes
@@ -774,7 +774,7 @@ void read_compressed_image(FileInterface* f,
                            DecodeDelegate* delegate,
                            Image* image,
                            const AsepriteHeader* header,
-                           const size_t chunk_end)
+                           const base::fileoff_t chunk_end)
 {
   // Try to read pixel data
   try {
@@ -812,7 +812,7 @@ void read_compressed_image(FileInterface* f,
 Cel* AsepriteDecoder::readCelChunk(frame_t frame,
                                    PixelFormat pixelFormat,
                                    const AsepriteHeader* header,
-                                   const size_t chunk_end)
+                                   const base::fileoff_t chunk_end)
 {
   // Read chunk data
   const layer_t layer_index = read16();
@@ -1264,8 +1264,8 @@ Tileset* AsepriteDecoder::readTilesetChunk(Sprite* sprite,
   if (flags & ASE_TILESET_FLAG_EMBEDDED) {
     if (ntiles > 0) {
       const uint32_t dataSize = read32(); // Size of compressed data
-      const uint64_t dataBeg = tell();
-      const uint64_t dataEnd = dataBeg + dataSize;
+      const auto dataBeg = tell();
+      const auto dataEnd = dataBeg + dataSize;
 
       base::buffer compressed;
       if (delegate()->cacheCompressedTilesets() && dataSize > 0) {
@@ -1309,9 +1309,9 @@ Tileset* AsepriteDecoder::readTilesetChunk(Sprite* sprite,
 void AsepriteDecoder::readPropertiesMaps(UserData::PropertiesMaps& propertiesMaps,
                                          const AsepriteExternalFiles& extFiles)
 {
-  auto startPos = tell();
-  auto size = read32();
-  auto numMaps = read32();
+  const auto startPos = tell();
+  const auto size = read32();
+  const auto numMaps = read32();
   try {
     for (int i = 0; i < numMaps; ++i) {
       auto id = read32();
@@ -1457,7 +1457,7 @@ void AsepriteDecoder::readTilesData(Tileset* tileset, const AsepriteExternalFile
 {
   // Read as many user data chunks as tiles are in the tileset
   for (tile_index i = 0; i < tileset->size(); i++) {
-    const uint64_t chunk_pos = tell();
+    const auto chunk_pos = tell();
     // Read chunk information
     const int chunk_size = read32();
     const int chunk_type = read16();

--- a/src/dio/aseprite_decoder.h
+++ b/src/dio/aseprite_decoder.h
@@ -57,7 +57,7 @@ private:
   doc::Cel* readCelChunk(doc::frame_t frame,
                          doc::PixelFormat pixelFormat,
                          const AsepriteHeader* header,
-                         const size_t chunk_end);
+                         base::fileoff_t chunk_end);
   void readCelExtraChunk(doc::Cel* cel);
   void readColorProfile(doc::Sprite* sprite);
   void readExternalFiles(AsepriteExternalFiles& extFiles);

--- a/src/dio/aseprite_encoder.cpp
+++ b/src/dio/aseprite_encoder.cpp
@@ -217,13 +217,19 @@ void AsepriteEncoder::writeHeader(const AsepriteHeader* header)
 
 void AsepriteEncoder::writeHeaderFileSize(AsepriteHeader* header)
 {
-  header->size = tell() - header->pos; // TODO truncates to uint32_t for files >4.30GB
+  const auto end = tell();
+
+  // Truncate to the largest 32-bit value for files bigger than 4GB
+  auto size = end - header->pos;
+  if (size > 0xFFFFFFFF)
+    size = 0xFFFFFFFF;
+
+  header->size = size;
 
   seek(header->pos);
   write32(header->size);
 
-  seek(header->pos + header->size); // TODO wrong position for files >4.30GB, works only because
-                                    // nothing writes after this
+  seek(end);
 }
 
 void AsepriteEncoder::prepareFrameHeader(AsepriteFrameHeader* frame_header)
@@ -239,7 +245,7 @@ void AsepriteEncoder::prepareFrameHeader(AsepriteFrameHeader* frame_header)
 
 void AsepriteEncoder::writeFrameHeader(AsepriteFrameHeader* frame_header)
 {
-  const uint64_t end = tell();
+  const auto end = tell();
 
   frame_header->size = end - frame_header->pos;
 
@@ -363,8 +369,8 @@ void AsepriteEncoder::writeChunkStart(AsepriteFrameHeader* frame_header,
 
 void AsepriteEncoder::writeChunkEnd(AsepriteChunk* chunk)
 {
-  const uint64_t chunk_end = tell();
-  const uint64_t chunk_size = chunk_end - chunk->start;
+  const auto chunk_end = tell();
+  const auto chunk_size = chunk_end - chunk->start;
 
   seek(chunk->start);
   write32(chunk_size);
@@ -1137,7 +1143,7 @@ void AsepriteEncoder::writeTilesetChunk(AsepriteFrameHeader* frame_header,
 
   // Flag 2 = tileset
   if (flags & ASE_TILESET_FLAG_EMBEDDED) {
-    const uint64_t beg = tell();
+    const auto beg = tell();
 
     // Save the cached tileset compressed data
     if (!tileset->compressedData().empty() &&
@@ -1170,7 +1176,7 @@ void AsepriteEncoder::writeTilesetChunk(AsepriteFrameHeader* frame_header,
       if (compressedDataPtr)
         tileset->setCompressedData(compressedData);
 
-      const uint64_t end = tell();
+      const auto end = tell();
       seek(beg);
       write32(end - beg - 4); // Save the compressed data length
       seek(end);
@@ -1280,7 +1286,7 @@ void AsepriteEncoder::writePropertiesMaps(const AsepriteExternalFiles& ext_files
 {
   ASSERT(nmaps > 0);
 
-  const uint64_t startPos = tell();
+  const auto startPos = tell();
   // We zero the size in bytes of all properties maps stored in this
   // chunk for now. (actual value is calculated after serialization
   // of all properties maps, at which point this field is overwritten)
@@ -1315,7 +1321,7 @@ void AsepriteEncoder::writePropertiesMaps(const AsepriteExternalFiles& ext_files
     write32(extensionId);
     writePropertyValue(properties, depth);
   }
-  const uint64_t endPos = tell();
+  const auto endPos = tell();
   // We can overwrite the properties maps size now
   seek(startPos);
   write32(endPos - startPos);

--- a/src/dio/decoder.h
+++ b/src/dio/decoder.h
@@ -39,8 +39,8 @@ protected:
   DecodeDelegate* delegate() { return m_delegate; }
   FileInterface* f() { return m_f; }
 
-  uint64_t tell() { return m_f->tell(); }
-  void seek(uint64_t absPos) { m_f->seek(absPos); }
+  base::fileoff_t tell() { return m_f->tell(); }
+  void seek(const base::fileoff_t absPos) { m_f->seek(absPos); }
 
   uint8_t read8() { return m_f->read8(); }
 

--- a/src/dio/encoder.h
+++ b/src/dio/encoder.h
@@ -35,9 +35,8 @@ protected:
   EncodeDelegate* delegate() { return m_delegate; }
   FileInterface* f() { return m_f; }
 
-  uint64_t tell() { return m_f->tell(); }
-
-  void seek(uint64_t absPos) { m_f->seek(absPos); }
+  base::fileoff_t tell() { return m_f->tell(); }
+  void seek(const base::fileoff_t absPos) { m_f->seek(absPos); }
 
   void write8(const uint8_t value) { m_f->write8(value); }
   size_t writeBytes(uint8_t* buf, size_t n) { return m_f->writeBytes(buf, n); }

--- a/src/dio/file_interface.h
+++ b/src/dio/file_interface.h
@@ -9,6 +9,8 @@
 #define DIO_FILE_INTERFACE_H_INCLUDED
 #pragma once
 
+#include "base/file_size.h"
+
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
@@ -23,10 +25,10 @@ public:
   virtual bool ok() const = 0;
 
   // Current position in the file
-  virtual uint64_t tell() = 0;
+  virtual base::fileoff_t tell() = 0;
 
   // Jump to the given position in the file
-  virtual void seek(uint64_t absPos) = 0;
+  virtual void seek(base::fileoff_t absPos) = 0;
 
   // Returns the next byte in the file or 0 if ok() = false
   virtual uint8_t read8() = 0;
@@ -41,8 +43,8 @@ class StdioFileInterface : public FileInterface {
 public:
   StdioFileInterface(FILE* file);
   bool ok() const override;
-  uint64_t tell() override;
-  void seek(uint64_t absPos) override;
+  base::fileoff_t tell() override;
+  void seek(base::fileoff_t absPos) override;
   uint8_t read8() override;
   size_t readBytes(uint8_t* buf, size_t n) override;
   void write8(uint8_t value) override;

--- a/src/dio/stdio.cpp
+++ b/src/dio/stdio.cpp
@@ -18,22 +18,14 @@ bool StdioFileInterface::ok() const
   return m_ok;
 }
 
-uint64_t StdioFileInterface::tell()
+base::fileoff_t StdioFileInterface::tell()
 {
-#if LAF_WINDOWS
-  return _ftelli64(m_file);
-#else
-  return ftello(m_file);
-#endif
+  return base::base_ftell(m_file);
 }
 
-void StdioFileInterface::seek(uint64_t absPos)
+void StdioFileInterface::seek(const base::fileoff_t absPos)
 {
-#if LAF_WINDOWS
-  _fseeki64(m_file, absPos, SEEK_SET);
-#else
-  fseeko(m_file, absPos, SEEK_SET);
-#endif
+  base::base_fseek(m_file, absPos, SEEK_SET);
 }
 
 uint8_t StdioFileInterface::read8()

--- a/src/doc/file/col_file.cpp
+++ b/src/doc/file/col_file.cpp
@@ -11,6 +11,8 @@
 
 #include "base/base.h"
 #include "base/cfile.h"
+#include "base/file_handle.h"
+#include "base/file_size.h"
 #include "doc/color_scales.h"
 #include "doc/image.h"
 #include "doc/palette.h"
@@ -30,28 +32,21 @@ std::unique_ptr<Palette> load_col_file(const char* filename)
 {
   int c, r, g, b;
 
-  FILE* f = std::fopen(filename, "rb");
+  FileHandle fh(open_file(filename, "rb"));
+  FILE* f = fh.get();
   if (!f)
     return nullptr;
 
   // Get file size.
-#ifdef _WIN32
-  _fseeki64(f, 0, SEEK_END);
-  const std::size_t size = _ftelli64(f);
-  const std::div_t d = std::div(size - 8, 3);
-  _fseeki64(f, 0, SEEK_SET);
-#else
-  fseeko(f, 0, SEEK_END);
-  const std::size_t size = ftello(f);
-  const std::div_t d = std::div(size - 8, 3);
-  fseeko(f, 0, SEEK_SET);
-#endif
+  const auto size = file_size(f);
+  if (size > 0xFFFFFFFF) // Unexpected file size
+    return nullptr;
+
+  const std::div_t d = std::div((int)size - 8, 3);
 
   bool pro = (size == 768) ? false : true; // is Animator Pro format?
-  if (!(size) || (pro && d.rem)) {         // Invalid format
-    fclose(f);
-    return NULL;
-  }
+  if (!(size) || (pro && d.rem))           // Invalid format
+    return nullptr;
 
   // Animator format
   std::unique_ptr<Palette> pal = nullptr;
@@ -81,10 +76,8 @@ std::unique_ptr<Palette> load_col_file(const char* filename)
     version = fgetw(f); // Version file
 
     // Unknown format
-    if (magic != PROCOL_MAGIC_NUMBER || version != 0) {
-      fclose(f);
+    if (magic != PROCOL_MAGIC_NUMBER || version != 0)
       return nullptr;
-    }
 
     pal = std::make_unique<Palette>(frame_t(0), std::min(d.quot, 256));
 
@@ -100,14 +93,14 @@ std::unique_ptr<Palette> load_col_file(const char* filename)
     }
   }
 
-  fclose(f);
   return pal;
 }
 
 // Saves an Animator Pro COL file
 bool save_col_file(const Palette* pal, const char* filename)
 {
-  FILE* f = fopen(filename, "wb");
+  FileHandle fh(open_file(filename, "wb"));
+  FILE* f = fh.get();
   if (!f)
     return false;
 
@@ -126,7 +119,6 @@ bool save_col_file(const Palette* pal, const char* filename)
       break;
   }
 
-  fclose(f);
   return true;
 }
 


### PR DESCRIPTION
Refactors https://github.com/aseprite/aseprite/pull/5957

It moves all platform-specific code to handle file sizes/tell/seek to laf-base functions. There is a new `base::file_size(FILE*)` function to get the file size of an open `FILE` handle too.

This also fixes the `AsepriteDecoder::readCelChunk()` using the new `base::fileoff_t` type to limit the decompression of images to the expected chunk size.

It might be problems if one chunk is bigger than 4GB, but probably it's too much to ask to the file format. And finally the header file size will be `0xFFFFFFFF` when the whole file is bigger than 4GB (it is commented in the `.aseprite` spec).