### PR TITLE
Throw an exception when DocDestroyer can't unlock the document (fix #5988)

### DIFF
--- a/src/app/doc_access.h
+++ b/src/app/doc_access.h
@@ -194,6 +194,10 @@ public:
   {
     ASSERT(m_doc != nullptr);
 
+    m_doc->unlock(m_lockResult);
+    if (m_lockResult != LockResult::OK)
+      throw CannotWriteDocException();
+
     // Don't create a backup for destroyed documents (e.g. documents
     // are destroyed when they are used internally by Aseprite or by
     // a script and then closed with Sprite:close())
@@ -202,8 +206,6 @@ public:
 
     m_doc->close();
     Doc* doc = m_doc;
-    unlock();
-
     delete doc;
     m_doc = nullptr;
   }
@@ -212,11 +214,13 @@ public:
   {
     ASSERT(m_doc != nullptr);
 
+    m_doc->unlock(m_lockResult);
+    if (m_lockResult != LockResult::OK)
+      throw CannotWriteDocException();
+
     Context* ctx = (Context*)m_doc->context();
     m_doc->close();
     Doc* doc = m_doc;
-    unlock();
-
     ctx->closeDocument(doc);
     m_doc = nullptr;
   }


### PR DESCRIPTION
Fixes #5988 avoiding a crash by just throwing if we can't unlock the document, should also help in other places that use DocDestroyer since some of them are explicitly catching the lock exceptions but these would've never been throw with the current code., which I'm not sure if it's an oversight or maybe something that got refactored away at some point.