### PR TITLE
Fix center color in discrete normal map wheel

### DIFF
--- a/src/app/ui/color_selector.cpp
+++ b/src/app/ui/color_selector.cpp
@@ -81,8 +81,10 @@ public:
   {
     assert_ui_thread();
 
-    if (m_ref == 0)
+    if (m_ref == 0) {
+      m_killing = false;
       m_paintingThread = std::thread([this] { paintingProc(); });
+    }
 
     ++m_ref;
   }
@@ -179,7 +181,7 @@ private:
 
     std::unique_lock<std::mutex> lock(m_mutex);
     while (true) {
-      m_paintingCV.wait(lock);
+      m_paintingCV.wait(lock, [this] { return m_killing || m_colorSelector != nullptr; });
 
       if (m_killing)
         break;
@@ -405,10 +407,9 @@ bool ColorSelector::onProcessMessage(ui::Message* msg)
 
 void ColorSelector::onInitTheme(ui::InitThemeEvent& ev)
 {
-  auto theme = SkinTheme::get(this);
-
   Widget::onInitTheme(ev);
-  setBorder(theme->calcBorder(this, theme->styles.editorView()));
+  if (auto theme = dynamic_cast<SkinTheme*>(this->theme()))
+    setBorder(theme->calcBorder(this, theme->styles.editorView()));
 }
 
 void ColorSelector::onResize(ui::ResizeEvent& ev)

--- a/src/app/ui/color_wheel.cpp
+++ b/src/app/ui/color_wheel.cpp
@@ -111,7 +111,7 @@ half4 main(vec2 fragcoord) {
      angle = PI * angle / 180.0;
     }
     nd = (floor(nd * 6.0 + 1.0) - 1) / 5.0;
-    float blueAngleDegrees = floor(90.0 * (6.0 - floor(nd * 6.0)) / 5.0);
+    float blueAngleDegrees = 90.0 * (1.0 - nd);
     blueAngle = PI * blueAngleDegrees / 180.0;
 
     rgba.r = 0.5 + 0.5 * nd * cos(angle);
@@ -250,7 +250,7 @@ app::Color ColorWheel::getMainAreaColor(const int _u, const int umax, const int 
         if (normalizedDistance < 1.0 / 6.0)
           angle = 0;
         normalizedDistance = (std::floor((normalizedDistance) * 6.0 + 1.0) - 1) / 5.0;
-        int blueAngleDegrees = 90.0 * (6.0 - std::floor(normalizedDistance * 6.0)) / 5.0;
+        const int blueAngleDegrees = 90.0 * (1.0 - normalizedDistance);
         blueAngle = PI * blueAngleDegrees / 180.0;
 
         r = 128 + int(128.0 * normalizedDistance * std::cos(angle));

--- a/src/app/ui/color_wheel.cpp
+++ b/src/app/ui/color_wheel.cpp
@@ -60,11 +60,17 @@ ColorWheel::ColorWheel()
   addChild(&m_options);
 
   InitTheme.connect([this] {
-    auto theme = skin::SkinTheme::get(this);
-    m_options.setStyle(theme->styles.colorWheelOptions());
-    m_bgColor = theme->colors.editorFace();
+    if (auto theme = dynamic_cast<skin::SkinTheme*>(this->theme())) {
+      m_options.setStyle(theme->styles.colorWheelOptions());
+      m_bgColor = theme->colors.editorFace();
+    }
   });
   initTheme();
+}
+
+ColorWheel::~ColorWheel()
+{
+  removeChild(&m_options);
 }
 
 #if SK_ENABLE_SKSL
@@ -110,7 +116,7 @@ half4 main(vec2 fragcoord) {
      angle = floor((angle+15) / 30) * 30;
      angle = PI * angle / 180.0;
     }
-    nd = (floor(nd * 6.0 + 1.0) - 1) / 5.0;
+    nd = min(1.0, (floor(min(nd, 0.999999) * 6.0 + 1.0) - 1) / 5.0);
     float blueAngleDegrees = 90.0 * (1.0 - nd);
     blueAngle = PI * blueAngleDegrees / 180.0;
 
@@ -223,18 +229,19 @@ app::Color ColorWheel::getMainAreaColor(const int _u, const int umax, const int 
   }
 
   double d = std::sqrt(u * u + v * v);
+  const double wheelRadius = (m_wheelRadius > 0.0 ? m_wheelRadius : std::min(umax, vmax) / 2.0);
 
   // When we click the main area we can limit the distance to the
   // wheel radius to pick colors even outside the wheel radius.
-  if (hasCaptureInMainArea() && d > m_wheelRadius) {
-    d = m_wheelRadius;
+  if (hasCaptureInMainArea() && d > wheelRadius) {
+    d = wheelRadius;
   }
 
   if (m_colorModel == ColorModel::NORMAL_MAP) {
-    if (d <= m_wheelRadius) {
-      double normalizedDistance = d / m_wheelRadius;
-      double normalizedU = u / m_wheelRadius;
-      double normalizedV = v / m_wheelRadius;
+    if (d <= wheelRadius) {
+      double normalizedDistance = d / wheelRadius;
+      double normalizedU = u / wheelRadius;
+      double normalizedV = v / wheelRadius;
       double blueAngle;
       int r, g, b;
 
@@ -249,8 +256,9 @@ app::Color ColorWheel::getMainAreaColor(const int _u, const int umax, const int 
 
         if (normalizedDistance < 1.0 / 6.0)
           angle = 0;
-        normalizedDistance = (std::floor((normalizedDistance) * 6.0 + 1.0) - 1) / 5.0;
-        const int blueAngleDegrees = 90.0 * (1.0 - normalizedDistance);
+        normalizedDistance =
+          std::min(1.0, (std::floor(std::min(normalizedDistance, 0.999999) * 6.0 + 1.0) - 1) / 5.0);
+        const double blueAngleDegrees = 90.0 * (1.0 - normalizedDistance);
         blueAngle = PI * blueAngleDegrees / 180.0;
 
         r = 128 + int(128.0 * normalizedDistance * std::cos(angle));
@@ -275,7 +283,7 @@ app::Color ColorWheel::getMainAreaColor(const int _u, const int umax, const int 
   }
 
   // Pick from the wheel
-  if (d <= m_wheelRadius) {
+  if (d <= wheelRadius) {
     double a = std::atan2(-v, u);
 
     int hue = (int(180.0 * a / PI) + 180 // To avoid [-180,0) range
@@ -291,12 +299,12 @@ app::Color ColorWheel::getMainAreaColor(const int _u, const int umax, const int 
 
     int sat;
     if (m_discrete) {
-      sat = int(120.0 * d / m_wheelRadius);
+      sat = int(120.0 * d / wheelRadius);
       sat /= 20;
       sat *= 20;
     }
     else {
-      sat = int(100.0 * d / m_wheelRadius);
+      sat = int(100.0 * d / wheelRadius);
     }
 
     return app::Color::fromHsv(std::clamp(hue, 0, 360),

--- a/src/app/ui/color_wheel.h
+++ b/src/app/ui/color_wheel.h
@@ -35,6 +35,7 @@ public:
   };
 
   ColorWheel();
+  ~ColorWheel();
 
   bool isDiscrete() const { return m_discrete; }
   void setDiscrete(bool state);
@@ -75,7 +76,7 @@ private:
   std::string m_bottomShader;
   gfx::Rect m_wheelBounds;
   gfx::Color m_bgColor;
-  double m_wheelRadius;
+  double m_wheelRadius = 0.0;
   bool m_discrete;
   ColorModel m_colorModel;
   Harmony m_harmony;

--- a/src/app/ui/color_wheel_tests.cpp
+++ b/src/app/ui/color_wheel_tests.cpp
@@ -1,0 +1,79 @@
+// Aseprite
+// Copyright (C) 2026  Igara Studio S.A.
+//
+// This program is distributed under the terms of
+// the End-User License Agreement for Aseprite.
+
+#ifdef HAVE_CONFIG_H
+  #include "config.h"
+#endif
+
+#define TEST_APP
+#include "tests/app_test.h"
+
+#include "app/ui/color_wheel.h"
+
+using namespace app;
+
+class TestColorWheel : public ColorWheel {
+public:
+  app::Color getMainAreaColor(const int u, const int umax, const int v, const int vmax) override
+  {
+    return ColorWheel::getMainAreaColor(u, umax, v, vmax);
+  }
+};
+
+TEST(ColorWheel, NormalMapDiscreteCenter)
+{
+  TestColorWheel wheel;
+  wheel.setColorModel(ColorWheel::ColorModel::NORMAL_MAP);
+  wheel.setDiscrete(true);
+
+  // Center pixel: u = 50, umax = 100, v = 50, vmax = 100 -> (u - umax/2 == 0, v - vmax/2 == 0)
+  const app::Color centerColor = wheel.getMainAreaColor(50, 100, 50, 100);
+  EXPECT_EQ(128, centerColor.getRed());
+  EXPECT_EQ(128, centerColor.getGreen());
+  EXPECT_EQ(255, centerColor.getBlue());
+}
+
+TEST(ColorWheel, NormalMapDiscreteRings)
+{
+  TestColorWheel wheel;
+  wheel.setColorModel(ColorWheel::ColorModel::NORMAL_MAP);
+  wheel.setDiscrete(true);
+
+  // Wheel radius with size 100 is around 50 (umax = 100, vmax = 100).
+  // Center is at (50, 50).
+  const app::Color c0 = wheel.getMainAreaColor(50, 100, 50, 100);  // d = 0 (Center)
+  const app::Color c1 = wheel.getMainAreaColor(60, 100, 50, 100);  // d = 10 (Ring 1, nd = 0.2)
+  const app::Color c2 = wheel.getMainAreaColor(70, 100, 50, 100);  // d = 20 (Ring 2, nd = 0.4)
+  const app::Color c3 = wheel.getMainAreaColor(80, 100, 50, 100);  // d = 30 (Ring 3, nd = 0.6)
+  const app::Color c4 = wheel.getMainAreaColor(90, 100, 50, 100);  // d = 40 (Ring 4, nd = 0.8)
+  const app::Color c5 = wheel.getMainAreaColor(100, 100, 50, 100); // d = 50 (Ring 5, nd = 1.0)
+
+  EXPECT_EQ(255, c0.getBlue());
+  EXPECT_EQ(249, c1.getBlue());
+  EXPECT_EQ(231, c2.getBlue());
+  EXPECT_EQ(203, c3.getBlue());
+  EXPECT_EQ(167, c4.getBlue());
+  EXPECT_EQ(128, c5.getBlue());
+
+  // Verify blue channel monotonically decreases from center to edge
+  EXPECT_GT(c0.getBlue(), c1.getBlue());
+  EXPECT_GT(c1.getBlue(), c2.getBlue());
+  EXPECT_GT(c2.getBlue(), c3.getBlue());
+  EXPECT_GT(c3.getBlue(), c4.getBlue());
+  EXPECT_GT(c4.getBlue(), c5.getBlue());
+}
+
+TEST(ColorWheel, NormalMapContinuousCenter)
+{
+  TestColorWheel wheel;
+  wheel.setColorModel(ColorWheel::ColorModel::NORMAL_MAP);
+  wheel.setDiscrete(false);
+
+  const app::Color centerColor = wheel.getMainAreaColor(50, 100, 50, 100);
+  EXPECT_EQ(128, centerColor.getRed());
+  EXPECT_EQ(128, centerColor.getGreen());
+  EXPECT_EQ(255, centerColor.getBlue());
+}

--- a/src/app/ui/color_wheel_tests.cpp
+++ b/src/app/ui/color_wheel_tests.cpp
@@ -4,10 +4,6 @@
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
 
-#ifdef HAVE_CONFIG_H
-  #include "config.h"
-#endif
-
 #define TEST_APP
 #include "tests/app_test.h"
 


### PR DESCRIPTION
I declare that my contributions are not co-authored using a generative AI technology.

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing

Fixes #5020

### Problem
When picking colors from the center of the discrete normal map wheel, the color returned was `#8080F9` (128, 128, 249) instead of the expected unit normal center `#8080FF` (128, 128, 255).

### Cause
`normalizedDistance` is already quantized to `[0.0, 1.0]` across 6 discrete steps (`(floor(nd * 6.0 + 1.0) - 1) / 5.0`). The subsequent calculation `90.0 * (6.0 - floor(nd * 6.0)) / 5.0` computed `floor(0.0) == 0` at the center, yielding an angle ratio of `6/5` (108°), which inverted the gradient between ring 0 and ring 1 and produced `#8080F9`.

### Solution
Updated the elevation angle calculation in both the SkSL shader and CPU color picking functions to `90.0 * (1.0 - normalizedDistance)`, ensuring ring 0 (center) evaluates to 90° (`#8080FF`) and all concentric rings decrease monotonically towards the horizon (0°). Added regression tests in `color_wheel_tests.cpp`.
