### PR TITLE
Fix Snap to Grid alignment for brushes larger than 1 pixel (fix #5998)

### DIFF
--- a/src/app/tools/tool_loop_manager.cpp
+++ b/src/app/tools/tool_loop_manager.cpp
@@ -305,6 +305,7 @@ void ToolLoopManager::snapToGrid(Stroke::Pt& pt)
     return;
 
   gfx::Point point(pt.x, pt.y);
+  point -= m_toolLoop->getBrush()->center();
   point = snap_to_grid(m_toolLoop->getGridBounds(), point, PreferSnapTo::ClosestGridVertex);
   point += m_toolLoop->getBrush()->center();
   pt.x = point.x;

--- a/src/app/ui/editor/brush_preview.cpp
+++ b/src/app/ui/editor/brush_preview.cpp
@@ -195,9 +195,11 @@ void BrushPreview::show(const gfx::Point& screenPos)
   // Get cursor position in the editor
   gfx::Point spritePos = m_editor->screenToEditor(screenPos);
   if (pref.cursor.snapToGrid() && m_editor->docPref().grid.snap()) {
-    spritePos =
-      snap_to_grid(m_editor->docPref().grid.bounds(), spritePos, PreferSnapTo::ClosestGridVertex) +
-      gfx::Point(brushBounds.w / 2, brushBounds.h / 2);
+    gfx::Point brushCenter(brushBounds.w / 2, brushBounds.h / 2);
+    spritePos = snap_to_grid(m_editor->docPref().grid.bounds(),
+                             spritePos - brushCenter,
+                             PreferSnapTo::ClosestGridVertex) +
+                brushCenter;
   }
 
   // Get the current tool


### PR DESCRIPTION
fix #5998