### PR TITLE
Avoid registering extensions for disabled formats (fix #6007)

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -151,6 +151,7 @@ target_sources(app-lib PRIVATE
   file/svg_format.cpp
   file/tga_format.cpp)
 if(ENABLE_WEBP AND WEBP_FOUND)
+  target_compile_definitions(dio-lib PUBLIC -DENABLE_WEBP)
   target_compile_definitions(app-lib PUBLIC -DENABLE_WEBP)
   target_sources(app-lib PRIVATE
     file/webp_format.cpp)

--- a/src/dio/detect_format.cpp
+++ b/src/dio/detect_format.cpp
@@ -178,11 +178,15 @@ FileFormat detect_format_by_file_extension(const std::string& filename)
   if (ext == "css")
     return FileFormat::CSS_STYLE;
 
+#ifdef ENABLE_WEBP
   if (ext == "webp")
     return FileFormat::WEBP_ANIMATION;
+#endif
 
+#ifdef ENABLE_PSD
   if (ext == "psd" || ext == "psb")
     return FileFormat::PSD_IMAGE;
+#endif
 
   if (ext == "qoi")
     return FileFormat::QOI_IMAGE;


### PR DESCRIPTION
Fixes #6007, added WebP as well since it had the same potential issue.

Had to add the ENABLE_WEBP definition to dio-lib, unsure as to why that one isn't getting defined but the PSD one is 🤔