### PR TITLE
Harden TLS, Lua sandbox, extensions, and file parsers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -29,7 +29,7 @@
 	url = https://github.com/aseprite/undo.git
 [submodule "laf"]
 	path = laf
-	url = https://github.com/aseprite/laf.git
+	url = https://github.com/giobuilds/laf.git
 [submodule "third_party/cmark"]
 	path = third_party/cmark
 	url = https://github.com/aseprite/cmark.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,16 +111,17 @@ endif()
 
 # SSL/TLS support
 if(REQUIRE_CURL AND NOT USE_SHARED_CURL)
-  # Disable OpenSSL (use native libraries only)
-  set(CMAKE_USE_OPENSSL OFF CACHE BOOL "Use OpenSSL code. Experimental")
   set(CMAKE_USE_LIBSSH2 OFF CACHE BOOL "Use libSSH2")
 
   if(WIN32)
+    set(CMAKE_USE_OPENSSL OFF CACHE BOOL "Use OpenSSL code. Experimental")
     set(CMAKE_USE_SCHANNEL ON CACHE BOOL "enable Windows native SSL/TLS")
   elseif(APPLE)
+    set(CMAKE_USE_OPENSSL OFF CACHE BOOL "Use OpenSSL code. Experimental")
     set(CMAKE_USE_SECTRANSP ON CACHE BOOL "enable Apple OS native SSL/TLS")
   else()
-    # TODO Linux?
+    # Linux has no native TLS API equivalent to SChannel/SecureTransport.
+    set(CMAKE_USE_OPENSSL ON CACHE BOOL "Use OpenSSL for TLS on Linux" FORCE)
   endif()
 endif()
 

--- a/src/app/extensions.cpp
+++ b/src/app/extensions.cpp
@@ -72,6 +72,48 @@ constexpr const char* kPackageJson = "package.json";
 constexpr const char* kInfoJson = "__info.json";
 constexpr const char* kPrefLua = "__pref.lua";
 
+bool is_safe_extension_name(const std::string& name)
+{
+  if (name.empty() || name == "." || name == "..")
+    return false;
+  for (char c : name) {
+    if (base::is_path_separator(c) || c == ':' || c == '\0')
+      return false;
+  }
+  return true;
+}
+
+bool is_safe_zip_entry(const std::string& fn)
+{
+  if (fn.empty() || base::is_absolute_path(fn))
+    return false;
+  std::string part;
+  for (std::size_t i = 0; i <= fn.size(); ++i) {
+    if (i == fn.size() || base::is_path_separator(fn[i])) {
+      if (part == "..")
+        return false;
+      part.clear();
+    }
+    else {
+      part.push_back(fn[i]);
+    }
+  }
+  return true;
+}
+
+bool path_stays_under(const std::string& path, const std::string& root)
+{
+  const std::string abs = base::normalize_path(base::get_absolute_path(path));
+  std::string absRoot = base::normalize_path(base::get_absolute_path(root));
+  if (abs.empty() || absRoot.empty())
+    return false;
+  absRoot = base::remove_path_separator(absRoot);
+  if (abs == absRoot)
+    return true;
+  const std::string prefix = absRoot + base::path_separator;
+  return abs.size() > prefix.size() && abs.compare(0, prefix.size(), prefix) == 0;
+}
+
 class ReadArchive {
 public:
   ReadArchive(const std::string& filename) : m_arch(nullptr), m_open(false)
@@ -160,6 +202,10 @@ public:
   WriteArchive() : m_arch(nullptr), m_open(false)
   {
     m_arch = archive_write_disk_new();
+    archive_write_disk_set_options(m_arch,
+                                   ARCHIVE_EXTRACT_SECURE_NODOTDOT |
+                                     ARCHIVE_EXTRACT_SECURE_SYMLINKS |
+                                     ARCHIVE_EXTRACT_SECURE_NOABSOLUTEPATHS);
     m_open = true;
   }
 
@@ -341,6 +387,15 @@ void Extension::removeCommand(const std::string& id)
       ++it;
     }
   }
+}
+
+bool Extension::hasCommand(const std::string& id) const
+{
+  for (const auto& item : m_plugin.items) {
+    if (item.type == PluginItem::Command && item.id == id)
+      return true;
+  }
+  return false;
 }
 
 void Extension::addMenuGroup(const std::string& id)
@@ -826,7 +881,27 @@ static void serialize_table(lua_State* L, int idx, std::string& result)
         else {
           result.push_back('[');
           result.push_back('"');
-          result += k;
+          for (const char* p = k; *p; ++p) {
+            switch (*p) {
+              case '\"':
+                result.push_back('\\');
+                result.push_back('\"');
+                break;
+              case '\\':
+                result.push_back('\\');
+                result.push_back('\\');
+                break;
+              case '\n':
+                result.push_back('\\');
+                result.push_back('n');
+                break;
+              case '\r':
+                result.push_back('\\');
+                result.push_back('r');
+                break;
+              default: result.push_back(*p); break;
+            }
+          }
           result.push_back('"');
           result.push_back(']');
         }
@@ -1219,7 +1294,9 @@ void Extensions::uninstallExtension(Extension* extension, const DeletePluginPref
 ExtensionInfo Extensions::getCompressedExtensionInfo(const std::string& zipFn) const
 {
   ExtensionInfo info;
-  info.dstPath = base::join_path(m_userExtensionsPath, base::get_file_title(zipFn));
+  const std::string zipTitle = base::get_file_title(zipFn);
+  info.dstPath = base::join_path(m_userExtensionsPath,
+                                 is_safe_extension_name(zipTitle) ? zipTitle : "unnamed-extension");
 
   // First of all we read the package.json file inside the .zip to
   // know 1) the extension name, 2) that the .json file can be parsed
@@ -1267,7 +1344,8 @@ ExtensionInfo Extensions::getCompressedExtensionInfo(const std::string& zipFn) c
       }
       info.name = json["name"].string_value();
       info.version = json["version"].string_value();
-      info.dstPath = base::join_path(m_userExtensionsPath, info.name);
+      if (is_safe_extension_name(info.name))
+        info.dstPath = base::join_path(m_userExtensionsPath, info.name);
     }
     break;
   }
@@ -1277,6 +1355,9 @@ ExtensionInfo Extensions::getCompressedExtensionInfo(const std::string& zipFn) c
 Extension* Extensions::installCompressedExtension(const std::string& zipFn,
                                                   const ExtensionInfo& info)
 {
+  if (!path_stays_under(info.dstPath, m_userExtensionsPath))
+    throw base::Exception("Invalid extension destination path");
+
   base::paths installedFiles;
 
   // Uncompress zipFn in info.dstPath
@@ -1313,9 +1394,18 @@ Extension* Extensions::installCompressedExtension(const std::string& zipFn,
           continue;
       }
 
+      if (!is_safe_zip_entry(fn)) {
+        LOG("EXT: Rejecting unsafe zip entry <%s>\n", fn.c_str());
+        continue;
+      }
+
       installedFiles.push_back(fn);
 
       const std::string fullFn = base::join_path(info.dstPath, fn);
+      if (!path_stays_under(fullFn, info.dstPath)) {
+        LOG("EXT: Rejecting zip entry that escapes <%s>\n", info.dstPath.c_str());
+        continue;
+      }
 #if _WIN32
       archive_entry_copy_pathname_w(entry, base::from_utf8(fullFn).c_str());
 #else
@@ -1488,6 +1578,10 @@ Extension* Extensions::loadExtension(const std::string& path,
 
         // The path must be always relative to the extension
         scriptPath = base::join_path(path, scriptPath);
+        if (!path_stays_under(scriptPath, path)) {
+          LOG("EXT: Ignoring script path outside the extension <%s>\n", scriptPath.c_str());
+          continue;
+        }
 
         LOG("EXT: New script path=%s\n", scriptPath.c_str());
 
@@ -1500,10 +1594,13 @@ Extension* Extensions::loadExtension(const std::string& path,
 
       // The path must be always relative to the extension
       scriptPath = base::join_path(path, scriptPath);
-
-      LOG("EXT: New script path=%s\n", scriptPath.c_str());
-
-      extension->addScript(scriptPath);
+      if (path_stays_under(scriptPath, path)) {
+        LOG("EXT: New script path=%s\n", scriptPath.c_str());
+        extension->addScript(scriptPath);
+      }
+      else {
+        LOG("EXT: Ignoring script path outside the extension <%s>\n", scriptPath.c_str());
+      }
     }
 
     extension->MenuItemRemoveWidget.connect([](Widget* item) {

--- a/src/app/extensions.h
+++ b/src/app/extensions.h
@@ -135,6 +135,7 @@ public:
 #ifdef ENABLE_SCRIPTING
   void addCommand(const std::string& id);
   void removeCommand(const std::string& id);
+  bool hasCommand(const std::string& id) const;
 
   void addMenuGroup(const std::string& id);
   void removeMenuGroup(const std::string& id);

--- a/src/app/extensions_tests.cpp
+++ b/src/app/extensions_tests.cpp
@@ -470,6 +470,57 @@ end)" },
   EXPECT_FALSE(base::is_directory(info.dstPath));
 }
 
+TEST(Extensions, ZipSlipRejected)
+{
+  INIT_EXTENSION_TEST();
+
+  const std::string zipPath = "zipslip-test.aseprite-extension";
+  if (base::is_file(zipPath))
+    base::delete_file(zipPath);
+
+  {
+    const auto a =
+      std::unique_ptr<archive, void (*)(archive*)>(archive_write_new(), [](struct archive* a) {
+        EXPECT_EQ(archive_write_close(a), ARCHIVE_OK);
+        EXPECT_EQ(archive_write_free(a), ARCHIVE_OK);
+      });
+    ASSERT_EQ(archive_write_set_format_zip(a.get()), ARCHIVE_OK);
+    ASSERT_EQ(archive_write_open_filename(a.get(), zipPath.c_str()), ARCHIVE_OK);
+
+    auto add = [&](const char* pathname, const std::string& data) {
+      const auto e = std::unique_ptr<struct archive_entry, void (*)(struct archive_entry*)>(
+        archive_entry_new(),
+        &archive_entry_free);
+      archive_entry_set_pathname(e.get(), pathname);
+      archive_entry_set_perm(e.get(), 0644);
+      archive_entry_set_filetype(e.get(), AE_IFREG);
+      archive_entry_set_size(e.get(), data.size());
+      ASSERT_EQ(archive_write_header(a.get(), e.get()), ARCHIVE_OK);
+      ASSERT_GE(archive_write_data(a.get(), data.data(), data.size()), 0);
+    };
+
+    add("evil/package.json",
+        R"({"name":"zipslip-test","displayName":"Zip Slip","contributes":{"scripts":"./script.lua"}})");
+    add("evil/script.lua", "function init(plugin) end");
+    add("evil/../../zipslip-pwned.txt", "pwned");
+  }
+
+  auto info = app.extensions().getCompressedExtensionInfo(zipPath);
+  app.extensions().installCompressedExtension(zipPath, info);
+
+  EXPECT_FALSE(base::is_file("zipslip-pwned.txt"));
+  EXPECT_FALSE(base::is_file(base::join_path(base::get_file_path(info.dstPath), "../zipslip-pwned.txt")));
+
+  Extension* testExt = nullptr;
+  for (auto* ext : app.extensions()) {
+    if (ext->name() == "zipslip-test")
+      testExt = ext;
+  }
+  ASSERT_TRUE(testExt != nullptr);
+  app.extensions().uninstallExtension(testExt, DeletePluginPref::Yes);
+  base::delete_file(zipPath);
+}
+
 TEST(Extensions, CustomFormatsLoad)
 {
   const ExtFiles extensionFiles = {

--- a/src/app/file/bmp_format.cpp
+++ b/src/app/file/bmp_format.cpp
@@ -24,6 +24,8 @@
 #include "doc/doc.h"
 #include "fmt/format.h"
 
+#include <cstdint>
+
 namespace app {
 
 // Max supported .bmp size (to filter out invalid image sizes)
@@ -1014,13 +1016,13 @@ bool BmpFormat::onLoad(FileOp* fop)
       return false;
     }
 
-    uint32_t size = infoheader.biWidth * uint32_t(ABS(int(infoheader.biHeight)));
+    uint64_t size = uint64_t(infoheader.biWidth) * uint64_t(ABS(int(infoheader.biHeight)));
     if (infoheader.biBitCount >= 8)
-      size *= (infoheader.biBitCount / 8);
+      size *= uint64_t(infoheader.biBitCount / 8);
     else if (8 / infoheader.biBitCount > 0)
-      size /= (8 / infoheader.biBitCount);
+      size /= uint64_t(8 / infoheader.biBitCount);
 
-    if (size > kMaxBmpSize) {
+    if (size > uint64_t(kMaxBmpSize)) {
       fop->setError(fmt::format("BMP size unsupported ({:.2f} MB > {:.2f} MB).\n",
                                 size / 1024.0 / 1024.0,
                                 kMaxBmpSize / 1024.0 / 1024.0)

--- a/src/app/file/gif_format.cpp
+++ b/src/app/file/gif_format.cpp
@@ -738,6 +738,8 @@ private:
     int ncolors = (colormap ? colormap->ColorCount : 1);
     int w = m_spriteBounds.w;
     int h = m_spriteBounds.h;
+    if (w < 1 || h < 1)
+      throw Exception("Invalid GIF canvas size.\n");
 
     m_sprite.reset(new Sprite(ImageSpec(ColorMode::INDEXED, w, h), ncolors));
     m_sprite->setTransparentColor(m_bgIndex);

--- a/src/app/script/app_fs_object.cpp
+++ b/src/app/script/app_fs_object.cpp
@@ -14,6 +14,8 @@
 #include "app/script/security.h"
 #include "base/fs.h"
 
+#include <string>
+
 namespace app { namespace script {
 
 namespace {
@@ -76,30 +78,42 @@ int AppFS_get_userConfigPath(lua_State* L)
 int AppFS_isFile(lua_State* L)
 {
   const char* fn = lua_tostring(L, 1);
-  if (fn)
-    lua_pushboolean(L, base::is_file(fn));
-  else
+  if (!fn) {
     lua_pushboolean(L, false);
+    return 1;
+  }
+  const std::string abs = base::get_absolute_path(fn);
+  if (!ask_access(L, abs.c_str(), FileAccessMode::Read, ResourceType::File))
+    return luaL_error(L, "the script doesn't have access to file '%s'", abs.c_str());
+  lua_pushboolean(L, base::is_file(fn));
   return 1;
 }
 
 int AppFS_isDirectory(lua_State* L)
 {
   const char* fn = lua_tostring(L, 1);
-  if (fn)
-    lua_pushboolean(L, base::is_directory(fn));
-  else
+  if (!fn) {
     lua_pushboolean(L, false);
+    return 1;
+  }
+  const std::string abs = base::get_absolute_path(fn);
+  if (!ask_access(L, abs.c_str(), FileAccessMode::Read, ResourceType::File))
+    return luaL_error(L, "the script doesn't have access to file '%s'", abs.c_str());
+  lua_pushboolean(L, base::is_directory(fn));
   return 1;
 }
 
 int AppFS_fileSize(lua_State* L)
 {
   const char* fn = lua_tostring(L, 1);
-  if (fn)
-    lua_pushinteger(L, base::file_size(fn));
-  else
+  if (!fn) {
     lua_pushnil(L);
+    return 1;
+  }
+  const std::string abs = base::get_absolute_path(fn);
+  if (!ask_access(L, abs.c_str(), FileAccessMode::Read, ResourceType::File))
+    return luaL_error(L, "the script doesn't have access to file '%s'", abs.c_str());
+  lua_pushinteger(L, base::file_size(fn));
   return 1;
 }
 
@@ -107,12 +121,15 @@ int AppFS_listFiles(lua_State* L)
 {
   const char* path = lua_tostring(L, 1);
   lua_newtable(L);
-  if (path) {
-    int i = 0;
-    for (const auto& fn : base::list_files(path)) {
-      lua_pushstring(L, fn.c_str());
-      lua_seti(L, -2, ++i);
-    }
+  if (!path)
+    return 1;
+  const std::string abs = base::get_absolute_path(path);
+  if (!ask_access(L, abs.c_str(), FileAccessMode::Read, ResourceType::File))
+    return luaL_error(L, "the script doesn't have access to file '%s'", abs.c_str());
+  int i = 0;
+  for (const auto& fn : base::list_files(path)) {
+    lua_pushstring(L, fn.c_str());
+    lua_seti(L, -2, ++i);
   }
   return 1;
 }
@@ -125,8 +142,9 @@ int AppFS_makeDirectory(lua_State* L)
     return 1;
   }
 
-  if (!ask_access(L, path, FileAccessMode::Write, ResourceType::File))
-    return luaL_error(L, "the script doesn't have access to create the directory '%s'", path);
+  const std::string abs = base::get_absolute_path(path);
+  if (!ask_access(L, abs.c_str(), FileAccessMode::Write, ResourceType::File))
+    return luaL_error(L, "the script doesn't have access to create the directory '%s'", abs.c_str());
 
   try {
     // TODO don't throw exception from base::make_directory() function
@@ -147,8 +165,11 @@ int AppFS_makeAllDirectories(lua_State* L)
     return 1;
   }
 
-  if (!ask_access(L, path, FileAccessMode::Write, ResourceType::File))
-    return luaL_error(L, "the script doesn't have access to create all directories '%s'", path);
+  const std::string abs = base::get_absolute_path(path);
+  if (!ask_access(L, abs.c_str(), FileAccessMode::Write, ResourceType::File))
+    return luaL_error(L,
+                      "the script doesn't have access to create all directories '%s'",
+                      abs.c_str());
 
   try {
     base::make_all_directories(path);
@@ -170,8 +191,9 @@ int AppFS_removeDirectory(lua_State* L)
     return 1;
   }
 
-  if (!ask_access(L, path, FileAccessMode::Write, ResourceType::File))
-    return luaL_error(L, "the script doesn't have access to remove the directory '%s'", path);
+  const std::string abs = base::get_absolute_path(path);
+  if (!ask_access(L, abs.c_str(), FileAccessMode::Write, ResourceType::File))
+    return luaL_error(L, "the script doesn't have access to remove the directory '%s'", abs.c_str());
 
   try {
     base::remove_directory(path);

--- a/src/app/script/engine.cpp
+++ b/src/app/script/engine.cpp
@@ -124,11 +124,15 @@ int dofile(lua_State* L)
       fname = altFname;
   }
 
+  const std::string absFilename = base::get_absolute_path(fname);
+  if (!ask_access(L, absFilename.c_str(), FileAccessMode::Read, ResourceType::File))
+    return luaL_error(L, "the script doesn't have access to file '%s'", absFilename.c_str());
+
   lua_settop(L, 1);
   if (luaL_loadfile(L, fname.c_str()) != LUA_OK)
     return lua_error(L);
   {
-    AddScriptFilename add(fname);
+    AddScriptFilename add(absFilename.empty() ? fname : absFilename);
     lua_callk(L, 0, LUA_MULTRET, 0, dofilecont);
   }
   return dofilecont(L, 0, 0);
@@ -145,6 +149,12 @@ int loadfile(lua_State* L)
   // the program.
   if (auto app = App::instance(); app && app->isGui() && !lua_isstring(L, 1)) {
     return luaL_error(L, "loadfile() for stdin cannot be used running in GUI mode");
+  }
+
+  if (lua_isstring(L, 1)) {
+    const std::string absFilename = base::get_absolute_path(lua_tostring(L, 1));
+    if (!ask_access(L, absFilename.c_str(), FileAccessMode::Read, ResourceType::File))
+      return luaL_error(L, "the script doesn't have access to file '%s'", absFilename.c_str());
   }
 
   return orig_loadfile(L);
@@ -532,6 +542,13 @@ Engine::Engine() : L(luaL_newstate()), m_delegate(nullptr), m_printLastResult(fa
 
   // Check that we have a clean start (without dirty in the stack)
   ASSERT(lua_gettop(L) == top);
+}
+
+std::string Engine::currentScriptFilename()
+{
+  if (current_script_dirs.empty())
+    return std::string();
+  return current_script_dirs.top();
 }
 
 Engine::~Engine()

--- a/src/app/script/engine.h
+++ b/src/app/script/engine.h
@@ -113,6 +113,9 @@ public:
   void startDebugger(DebuggerDelegate* debuggerDelegate);
   void stopDebugger();
 
+  // Filename of the script currently executing via evalFile/dofile, or empty.
+  static std::string currentScriptFilename();
+
 private:
   void onConsoleError(const char* text);
   void onConsolePrint(const char* text);

--- a/src/app/script/plugin_class.cpp
+++ b/src/app/script/plugin_class.cpp
@@ -13,6 +13,7 @@
 #include "app/commands/command.h"
 #include "app/commands/commands.h"
 #include "app/console.h"
+#include "app/extensions.h"
 #include "app/script/engine.h"
 #include "app/script/luacpp.h"
 #include "app/ui/app_menuitem.h"
@@ -119,6 +120,11 @@ private:
 
 void deleteCommandIfExistent(Extension* ext, const std::string& id)
 {
+  // Only remove commands this extension previously registered. Never
+  // delete built-in commands (SaveFile, OpenFile, ...).
+  if (!ext->hasCommand(id))
+    return;
+
   auto cmd = Commands::instance()->byId(id.c_str());
   if (cmd) {
     Commands::instance()->remove(cmd);
@@ -189,6 +195,10 @@ int Plugin_newCommand(lua_State* L)
     type = lua_getfield(L, 2, "onclick");
     if (type == LUA_TFUNCTION) {
       int onclickRef = luaL_ref(L, LUA_REGISTRYINDEX);
+
+      auto existing = Commands::instance()->byId(id.c_str());
+      if (existing && !plugin->ext->hasCommand(id))
+        return luaL_error(L, "cannot overwrite built-in command '%s'", id.c_str());
 
       // Delete the command if it already exist (e.g. we are
       // overwriting a previous registered command)

--- a/src/app/script/security.cpp
+++ b/src/app/script/security.cpp
@@ -87,7 +87,12 @@ std::string get_key(const std::string& source)
 
 std::string get_script_filename(lua_State* L, int stackLevel)
 {
-  std::string script;
+  // Prefer the filename of the evalFile/dofile that is actually running.
+  // lua_Debug.source is attacker-controlled via load(code, chunkname).
+  std::string script = Engine::currentScriptFilename();
+  if (!script.empty())
+    return script;
+
   lua_Debug ar;
   if (!lua_getstack(L, stackLevel - 1, &ar))
     return script;
@@ -100,6 +105,32 @@ std::string get_script_filename(lua_State* L, int stackLevel)
     script = ar.source + 1;
 
   return script;
+}
+
+FileAccessMode io_mode_from_string(const char* mode)
+{
+  FileAccessMode result = FileAccessMode::Read;
+  if (!mode)
+    return result;
+  if (std::strchr(mode, 'w') || std::strchr(mode, 'a') || std::strchr(mode, '+'))
+    result = FileAccessMode::Write;
+  return result;
+}
+
+int secure_lua_searcher(lua_State* L)
+{
+  lua_pushvalue(L, lua_upvalueindex(1));
+  lua_pushvalue(L, 1);
+  lua_call(L, 1, 2);
+  if (lua_isfunction(L, -2) && lua_isstring(L, -1)) {
+    std::string fn = lua_tostring(L, -1);
+    const std::string abs = base::get_absolute_path(fn);
+    if (!abs.empty())
+      fn = abs;
+    if (!ask_access(L, fn.c_str(), FileAccessMode::Read, ResourceType::File))
+      return luaL_error(L, "the script doesn't have access to file '%s'", fn.c_str());
+  }
+  return 2;
 }
 
 int unsupported(lua_State* L)
@@ -118,11 +149,7 @@ int unsupported(lua_State* L)
 int secure_io_open(lua_State* L)
 {
   std::string absFilename = base::get_absolute_path(luaL_checkstring(L, 1));
-
-  FileAccessMode mode = FileAccessMode::Read; // Read is the default access
-  if (lua_tostring(L, 2) && std::strchr(lua_tostring(L, 2), 'w') != nullptr) {
-    mode = FileAccessMode::Write;
-  }
+  const FileAccessMode mode = io_mode_from_string(lua_tostring(L, 2));
 
   if (!ask_access(L, absFilename.c_str(), mode, ResourceType::File)) {
     return luaL_error(L, "the script doesn't have access to file '%s'", absFilename.c_str());
@@ -247,11 +274,8 @@ int secure_os_rename(lua_State* L)
     return file_result(L, false, EACCES, absSourceFilename);
 
   try {
-    // If the destination file already exists, we should ask for permission to overwrite it.
-    if (!base::get_canonical_path(absDestFilename).empty() &&
-        !ask_access(L, absDestFilename.data(), FileAccessMode::Write, ResourceType::File)) {
+    if (!ask_access(L, absDestFilename.data(), FileAccessMode::Write, ResourceType::File))
       return file_result(L, false, EACCES, absDestFilename);
-    }
 
     base::move_file(absSourceFilename, absDestFilename);
     return file_result(L, true);
@@ -301,6 +325,29 @@ void overwrite_unsecure_functions(lua_State* L)
 
     lua_pop(L, 1);
   }
+
+  // Native modules: wrap package.loadlib (above) and also disable the
+  // C searchers / cpath, which dlopen without going through loadlib.
+  lua_getglobal(L, "package");
+  lua_getfield(L, -1, "searchers");
+  if (lua_istable(L, -1)) {
+    lua_pushnil(L);
+    lua_rawseti(L, -2, 4); // searcher_Croot
+    lua_pushnil(L);
+    lua_rawseti(L, -2, 3); // searcher_C
+    lua_rawgeti(L, -1, 2); // Lua file searcher
+    if (lua_isfunction(L, -1)) {
+      lua_pushcclosure(L, secure_lua_searcher, 1);
+      lua_rawseti(L, -2, 2);
+    }
+    else {
+      lua_pop(L, 1);
+    }
+  }
+  lua_pop(L, 1); // searchers
+  lua_pushstring(L, "");
+  lua_setfield(L, -2, "cpath");
+  lua_pop(L, 1); // package
 }
 
 bool ask_access(lua_State* L,

--- a/src/dio/aseprite_decoder.cpp
+++ b/src/dio/aseprite_decoder.cpp
@@ -29,6 +29,7 @@
 #include "zlib.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <cstdio>
 #include <memory>
 #include <vector>
@@ -125,7 +126,16 @@ bool AsepriteDecoder::decode()
         // Read chunk information
         const size_t chunk_size = read32();
         const int chunk_type = read16();
+        // Chunk size includes the 4-byte size + 2-byte type fields.
+        if (chunk_size < 6) {
+          delegate()->error(fmt::format("Invalid chunk size {0}", chunk_size));
+          break;
+        }
         const size_t chunk_end = chunk_pos + chunk_size;
+        if (chunk_end < chunk_pos) { // overflow
+          delegate()->error("Invalid chunk size (overflow)");
+          break;
+        }
 
         switch (chunk_type) {
           case ASE_FILE_CHUNK_FLI_COLOR:
@@ -707,16 +717,12 @@ void read_compressed_image_templ(FileInterface* f,
   while (true) {
     size_t input_bytes;
 
-    if (f->tell() + compressed.size() > chunk_end) {
-      input_bytes = chunk_end - f->tell(); // Remaining bytes
-      ASSERT(input_bytes < compressed.size());
+    const size_t pos = f->tell();
+    if (pos >= chunk_end)
+      break; // Done, we consumed all chunk (or chunk_end is behind us)
 
-      if (input_bytes == 0)
-        break; // Done, we consumed all chunk
-    }
-    else {
-      input_bytes = compressed.size();
-    }
+    const size_t remaining = chunk_end - pos;
+    input_bytes = std::min(remaining, compressed.size());
 
     size_t bytes_read = f->readBytes(&compressed[0], input_bytes);
 
@@ -1252,8 +1258,10 @@ Tileset* AsepriteDecoder::readTilesetChunk(Sprite* sprite,
   readPadding(14);
   const std::string name = readString();
 
-  // Errors
-  if (ntiles < 0 || w < 1 || h < 1) {
+  // Errors. ntiles is unsigned, so the old "ntiles < 0" check was dead.
+  constexpr tile_index kMaxTiles = 1 << 20;
+  if (w < 1 || h < 1 || ntiles > kMaxTiles ||
+      uint64_t(w) * uint64_t(h) * uint64_t(ntiles) > (uint64_t(1024) * 1024 * 128)) {
     delegate()->error(
       fmt::format("Error: Invalid tileset (number of tiles={0}, tile size={1}x{2})", ntiles, w, h));
     return nullptr;
@@ -1291,7 +1299,16 @@ Tileset* AsepriteDecoder::readTilesetChunk(Sprite* sprite,
         seek(dataBeg);
       }
 
-      const ImageRef alltiles(Image::create(sprite->pixelFormat(), w, h * ntiles));
+      const int allH = int(uint64_t(h) * uint64_t(ntiles));
+      if (allH < 1) {
+        delegate()->error("Error: Invalid tileset image height");
+        return nullptr;
+      }
+      const ImageRef alltiles(Image::create(sprite->pixelFormat(), w, allH));
+      if (!alltiles) {
+        delegate()->error("Error: Not enough memory for tileset image");
+        return nullptr;
+      }
       alltiles->setMaskColor(sprite->transparentColor());
 
       read_compressed_image(f(), delegate(), alltiles.get(), header, dataEnd);

--- a/src/doc/palette.cpp
+++ b/src/doc/palette.cpp
@@ -124,7 +124,10 @@ void Palette::setFrame(frame_t frame)
 
 void Palette::setEntry(int i, color_t color)
 {
-  ASSERT(i >= 0 && i < size());
+  if (i < 0 || i >= size()) {
+    ASSERT(false);
+    return;
+  }
 
   m_colors[i] = color;
   ++m_modifications;

--- a/src/net/http_request.cpp
+++ b/src/net/http_request.cpp
@@ -14,9 +14,48 @@
 #include "net/http_headers.h"
 #include "net/http_response.h"
 
+#include <algorithm>
+#include <cctype>
 #include <curl/curl.h>
+#include <string>
 
 namespace net {
+
+namespace {
+
+constexpr std::size_t kMaxResponseBytes = 8 * 1024 * 1024;
+constexpr long kConnectTimeoutSec = 15;
+constexpr long kTimeoutSec = 30;
+
+bool starts_with_ci(const std::string& s, const char* prefix)
+{
+  const std::size_t n = std::char_traits<char>::length(prefix);
+  if (s.size() < n)
+    return false;
+  for (std::size_t i = 0; i < n; ++i) {
+    if (std::tolower(static_cast<unsigned char>(s[i])) !=
+        std::tolower(static_cast<unsigned char>(prefix[i])))
+      return false;
+  }
+  return true;
+}
+
+// First-party traffic must be HTTPS. Loopback HTTP is allowed for local
+// testing via CUSTOM_WEBSITE_URL.
+bool is_allowed_request_url(const std::string& url)
+{
+  if (url.find('\0') != std::string::npos || url.find('\n') != std::string::npos ||
+      url.find('\r') != std::string::npos)
+    return false;
+  if (starts_with_ci(url, "https://"))
+    return true;
+  if (starts_with_ci(url, "http://127.0.0.1") || starts_with_ci(url, "http://localhost") ||
+      starts_with_ci(url, "http://[::1]"))
+    return true;
+  return false;
+}
+
+} // namespace
 
 class HttpRequestImpl {
 public:
@@ -24,11 +63,21 @@ public:
     : m_curl(curl_easy_init())
     , m_headerlist(nullptr)
     , m_response(nullptr)
+    , m_bytesWritten(0)
+    , m_urlAllowed(is_allowed_request_url(url))
   {
     curl_easy_setopt(m_curl, CURLOPT_WRITEDATA, this);
     curl_easy_setopt(m_curl, CURLOPT_WRITEFUNCTION, &HttpRequestImpl::writeBodyCallback);
     curl_easy_setopt(m_curl, CURLOPT_URL, url.c_str());
     curl_easy_setopt(m_curl, CURLOPT_NOSIGNAL, 1);
+    curl_easy_setopt(m_curl, CURLOPT_PROTOCOLS, CURLPROTO_HTTPS | CURLPROTO_HTTP);
+    curl_easy_setopt(m_curl, CURLOPT_REDIR_PROTOCOLS, 0L);
+    curl_easy_setopt(m_curl, CURLOPT_FOLLOWLOCATION, 0L);
+    curl_easy_setopt(m_curl, CURLOPT_SSL_VERIFYPEER, 1L);
+    curl_easy_setopt(m_curl, CURLOPT_SSL_VERIFYHOST, 2L);
+    curl_easy_setopt(m_curl, CURLOPT_CONNECTTIMEOUT, kConnectTimeoutSec);
+    curl_easy_setopt(m_curl, CURLOPT_TIMEOUT, kTimeoutSec);
+    curl_easy_setopt(m_curl, CURLOPT_MAXFILESIZE, long(kMaxResponseBytes));
   }
 
   ~HttpRequestImpl()
@@ -60,7 +109,11 @@ public:
 
   bool send(HttpResponse& response)
   {
+    if (!m_urlAllowed)
+      return false;
+
     m_response = &response;
+    m_bytesWritten = 0;
     int res = curl_easy_perform(m_curl);
     if (res != CURLE_OK)
       return false;
@@ -81,7 +134,10 @@ private:
   std::size_t writeBody(char* ptr, std::size_t bytes)
   {
     ASSERT(m_response != NULL);
+    if (m_bytesWritten + bytes > kMaxResponseBytes)
+      return 0;
     m_response->write(ptr, bytes);
+    m_bytesWritten += bytes;
     return bytes;
   }
 
@@ -97,6 +153,8 @@ private:
   CURL* m_curl;
   curl_slist* m_headerlist;
   HttpResponse* m_response;
+  std::size_t m_bytesWritten;
+  bool m_urlAllowed;
 };
 
 HttpRequest::HttpRequest(const std::string& url) : m_impl(new HttpRequestImpl(url))

--- a/src/ver/info.c
+++ b/src/ver/info.c
@@ -10,11 +10,7 @@
 #define PACKAGE   "Aseprite"
 #define COPYRIGHT "Copyright (C) 2001-2025 Igara Studio S.A."
 
-#if defined(_WIN32) || defined(__APPLE__)
-  #define HTTP "https"
-#else
-  #define HTTP "http"
-#endif
+#define HTTP "https"
 
 #ifdef CUSTOM_WEBSITE_URL
   #define WEBSITE CUSTOM_WEBSITE_URL /* To test web server */


### PR DESCRIPTION
Personal-fork hardening offered upstream. **Please close if you do not accept AI-assisted patches** — Igara's contributing guide says those will not be merged. This PR is not a CLA-signed contribution and does not claim otherwise.

Companion launcher fix: https://github.com/aseprite/laf/pull/200

This tree currently points the `laf` submodule URL at https://github.com/giobuilds/laf so the fork clones with the `xdg-open` fix; that `.gitmodules` URL change should not be merged as-is.

## What this changes

**Linux network**
- Build bundled curl with OpenSSL (the previous CMake path left Linux with no TLS backend).
- First-party website / news / update URLs use `https://` on all platforms.
- `HttpRequest` allows HTTPS (and loopback HTTP only), verifies TLS, sets timeouts, and caps the body at 8 MiB.

**Lua**
- `io.open` modes `a` / `r+` / `+` are treated as write.
- Native module searchers and `package.cpath` are disabled (`package.loadlib` was wrapped; `require` of a `.so` was not).
- `dofile` / `loadfile` / the Lua `require` searcher go through `ask_access(Read)`.
- Script grants are keyed off the real `evalFile`/`dofile` path, not spoofable `load(code, chunkname)` debug source.
- `os.rename` always asks write on the destination.
- `app.fs` list/stat require read; mkdir/rmdir prompt with an absolute path.
- `plugin:newCommand` cannot delete or replace a built-in command.

**Extensions**
- Reject `..` / absolute zip members, libarchive `SECURE_NODOTDOT|SYMLINKS|NOABSOLUTEPATHS`, and destination paths that escape the extensions dir.
- Escape non-identifier keys when serializing `__pref.lua`.
- Plugin script paths must stay under the extension directory.
- Adds a zip-slip gtest.

**Parsers**
- ASE chunk size < 6 or wrap is an error; compressed reads are capped to remaining chunk bytes (closes a `size_t` wrap into `fread`).
- `Palette::setEntry` is bounds-checked in all builds.
- Tileset `ntiles` is treated as unsigned and size-capped; null image after `Image::create` is handled.
- GIF rejects a 0×0 canvas; BMP size uses 64-bit math so the 128 MiB cap cannot wrap.

CLI `--script` is still unsandboxed when there is no UI (existing automation behavior).

## Test plan

- Linux RelWithDebInfo build with Skia; binary links `libssl`/`libcrypto`; strings show `https://www.aseprite.org/` and `https://blog.aseprite.org/rss`.
- `tests/run-tests.sh` Lua scripts including `os`, `app_fs`, and `require`.
- New `Extensions.ZipSlipRejected` test is in the tree; this local build had `ENABLE_TESTS=OFF` so that gtest was not run here.