### PR TITLE
Add Context parameter to Cmd::execute/undo/redo() functions

### DIFF
--- a/src/app/cmd.cpp
+++ b/src/app/cmd.cpp
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This program is distributed under the terms of
@@ -9,6 +10,8 @@
 #endif
 
 #include "app/cmd.h"
+
+#include "app/context.h"
 #include "base/debug.h"
 #include "base/mem_utils.h"
 
@@ -34,36 +37,34 @@ void Cmd::execute(Context* ctx)
   CMD_TRACE("CMD: Executing cmd '%s'\n", typeid(*this).name());
   ASSERT(m_state == State::NotExecuted);
 
-  m_ctx = ctx;
-
-  onExecute();
-  onFireNotifications();
+  onExecute(ctx);
+  onFireNotifications(ctx);
 
 #if _DEBUG
   m_state = State::Executed;
 #endif
 }
 
-void Cmd::undo()
+void Cmd::undo(undo::UndoContext* ctx)
 {
   CMD_TRACE("CMD: Undo cmd '%s'\n", typeid(*this).name());
   ASSERT(m_state == State::Executed || m_state == State::Redone);
 
-  onUndo();
-  onFireNotifications();
+  onUndo(static_cast<Context*>(ctx));
+  onFireNotifications(static_cast<Context*>(ctx));
 
 #if _DEBUG
   m_state = State::Undone;
 #endif
 }
 
-void Cmd::redo()
+void Cmd::redo(undo::UndoContext* ctx)
 {
   CMD_TRACE("CMD: Redo cmd '%s'\n", typeid(*this).name());
   ASSERT(m_state == State::Undone);
 
-  onRedo();
-  onFireNotifications();
+  onRedo(static_cast<Context*>(ctx));
+  onFireNotifications(static_cast<Context*>(ctx));
 
 #if _DEBUG
   m_state = State::Redone;
@@ -89,23 +90,23 @@ size_t Cmd::memSize() const
   return onMemSize();
 }
 
-void Cmd::onExecute()
+void Cmd::onExecute(Context* ctx)
 {
   // Do nothing
 }
 
-void Cmd::onUndo()
+void Cmd::onUndo(Context* ctx)
 {
   // Do nothing
 }
 
-void Cmd::onRedo()
+void Cmd::onRedo(Context* ctx)
 {
   // By default onRedo() uses onExecute() implementation
-  onExecute();
+  onExecute(ctx);
 }
 
-void Cmd::onFireNotifications()
+void Cmd::onFireNotifications(Context* ctx)
 {
   // Do nothing
 }

--- a/src/app/cmd.h
+++ b/src/app/cmd.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2023  Igara Studio SA
+// Copyright (C) 2023-present  Igara Studio SA
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -26,27 +26,22 @@ public:
   void execute(Context* ctx);
 
   // undo::UndoCommand impl
-  void undo() override;
-  void redo() override;
+  void undo(undo::UndoContext* ctx) override;
+  void redo(undo::UndoContext* ctx) override;
   void dispose() override;
 
   std::string label() const;
   size_t memSize() const;
 
-  Context* context() const { return m_ctx; }
-
 protected:
-  virtual void onExecute();
-  virtual void onUndo();
-  virtual void onRedo();
-  virtual void onFireNotifications();
+  virtual void onExecute(Context* ctx);
+  virtual void onUndo(Context* ctx);
+  virtual void onRedo(Context* ctx);
+  virtual void onFireNotifications(Context* ctx);
   virtual std::string onLabel() const;
   virtual size_t onMemSize() const;
 
 private:
-  // TODO I think we could just remove this field (but we'll need to
-  //      include the Context* in all onEvent() member functions)
-  Context* m_ctx;
 #if _DEBUG
   enum class State { NotExecuted, Executed, Undone, Redone };
   State m_state;

--- a/src/app/cmd/add_cel.cpp
+++ b/src/app/cmd/add_cel.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2020-2026  Igara Studio S.A.
+// Copyright (C) 2020-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -27,7 +27,7 @@ AddCel::AddCel(Layer* layer, Cel* cel) : WithLayer(layer), WithCel(cel)
 {
 }
 
-void AddCel::onExecute()
+void AddCel::onExecute(Context* ctx)
 {
   Layer* layer = this->layer();
   Cel* cel = this->cel();
@@ -37,7 +37,7 @@ void AddCel::onExecute()
   addCel(layer, cel);
 }
 
-void AddCel::onUndo()
+void AddCel::onUndo(Context* ctx)
 {
   Layer* layer = this->layer();
   Cel* cel = this->cel();
@@ -50,7 +50,7 @@ void AddCel::onUndo()
   m_suspendedCel.suspend(cel);
 }
 
-void AddCel::onRedo()
+void AddCel::onRedo(Context* ctx)
 {
   Layer* layer = this->layer();
   Cel* cel = m_suspendedCel.restore();

--- a/src/app/cmd/add_cel.h
+++ b/src/app/cmd/add_cel.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2025  Igara Studio S.A.
+// Copyright (C) 2025-present  Igara Studio S.A.
 // Copyright (C) 2001-2016  David Capello
 //
 // This program is distributed under the terms of
@@ -29,9 +29,9 @@ public:
   AddCel(Layer* layer, Cel* cel);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onRedo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onRedo(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this) + m_suspendedCel.size(); }
 
 private:

--- a/src/app/cmd/add_frame.cpp
+++ b/src/app/cmd/add_frame.cpp
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -11,6 +12,7 @@
 #include "app/cmd/add_frame.h"
 
 #include "app/cmd/add_cel.h"
+#include "app/context.h"
 #include "app/doc.h"
 #include "app/doc_event.h"
 #include "doc/cel.h"
@@ -29,7 +31,7 @@ AddFrame::AddFrame(Sprite* sprite, frame_t newFrame)
 {
 }
 
-void AddFrame::onExecute()
+void AddFrame::onExecute(Context* ctx)
 {
   Sprite* sprite = this->sprite();
   auto doc = static_cast<Doc*>(sprite->document());
@@ -38,7 +40,7 @@ void AddFrame::onExecute()
   sprite->incrementVersion();
 
   if (m_addCel) {
-    m_addCel->redo();
+    m_addCel->redo(ctx);
   }
   else {
     LayerImage* bglayer = sprite->backgroundLayer();
@@ -47,7 +49,7 @@ void AddFrame::onExecute()
       clear_image(bgimage.get(), doc->bgColor(bglayer));
       Cel* cel = new Cel(m_newFrame, bgimage);
       m_addCel.reset(new cmd::AddCel(bglayer, cel));
-      m_addCel->execute(context());
+      m_addCel->execute(ctx);
     }
   }
 
@@ -58,13 +60,13 @@ void AddFrame::onExecute()
   doc->notify_observers<DocEvent&>(&DocObserver::onAddFrame, ev);
 }
 
-void AddFrame::onUndo()
+void AddFrame::onUndo(Context* ctx)
 {
   Sprite* sprite = this->sprite();
   auto doc = static_cast<Doc*>(sprite->document());
 
   if (m_addCel)
-    m_addCel->undo();
+    m_addCel->undo(ctx);
 
   sprite->removeFrame(m_newFrame);
   sprite->incrementVersion();

--- a/src/app/cmd/add_frame.h
+++ b/src/app/cmd/add_frame.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -28,8 +29,8 @@ public:
   AddFrame(Sprite* sprite, frame_t frame);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this) + (m_addCel ? m_addCel->memSize() : 0); }
 
 private:

--- a/src/app/cmd/add_layer.cpp
+++ b/src/app/cmd/add_layer.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2025  Igara Studio S.A.
+// Copyright (C) 2025-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -26,7 +26,7 @@ AddLayer::AddLayer(Layer* group, Layer* newLayer, Layer* afterThis)
 {
 }
 
-void AddLayer::onExecute()
+void AddLayer::onExecute(Context* ctx)
 {
   Layer* group = m_group.layer();
   Layer* newLayer = m_newLayer.layer();
@@ -35,7 +35,7 @@ void AddLayer::onExecute()
   addLayer(group, newLayer, afterThis);
 }
 
-void AddLayer::onUndo()
+void AddLayer::onUndo(Context* ctx)
 {
   Layer* group = m_group.layer();
   Layer* layer = m_newLayer.layer();
@@ -45,7 +45,7 @@ void AddLayer::onUndo()
   m_suspendedLayer.suspend(layer);
 }
 
-void AddLayer::onRedo()
+void AddLayer::onRedo(Context* ctx)
 {
   Layer* group = m_group.layer();
   Layer* newLayer = m_suspendedLayer.restore();

--- a/src/app/cmd/add_layer.h
+++ b/src/app/cmd/add_layer.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (c) 2025  Igara Studio S.A.
+// Copyright (c) 2025-present  Igara Studio S.A.
 // Copyright (C) 2001-2016  David Capello
 //
 // This program is distributed under the terms of
@@ -22,9 +22,9 @@ public:
   AddLayer(Layer* group, Layer* newLayer, Layer* afterThis);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onRedo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onRedo(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this) + m_suspendedLayer.size(); }
 
 private:

--- a/src/app/cmd/add_palette.cpp
+++ b/src/app/cmd/add_palette.cpp
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2016  David Capello
 //
 // This program is distributed under the terms of
@@ -21,7 +22,7 @@ AddPalette::AddPalette(Sprite* sprite, Palette* pal) : WithSprite(sprite), m_pal
 {
 }
 
-void AddPalette::onExecute()
+void AddPalette::onExecute(Context* ctx)
 {
   Sprite* sprite = this->sprite();
 
@@ -29,7 +30,7 @@ void AddPalette::onExecute()
   sprite->incrementVersion();
 }
 
-void AddPalette::onUndo()
+void AddPalette::onUndo(Context* ctx)
 {
   Sprite* sprite = this->sprite();
 

--- a/src/app/cmd/add_palette.h
+++ b/src/app/cmd/add_palette.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2025  Igara Studio S.A.
+// Copyright (C) 2025-present  Igara Studio S.A.
 // Copyright (C) 2001-2016  David Capello
 //
 // This program is distributed under the terms of
@@ -27,8 +27,8 @@ public:
   AddPalette(Sprite* sprite, Palette* pal);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this) + m_palette.getMemSize(); }
 
 private:

--- a/src/app/cmd/add_slice.cpp
+++ b/src/app/cmd/add_slice.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2025  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2017  David Capello
 //
 // This program is distributed under the terms of
@@ -24,7 +24,7 @@ AddSlice::AddSlice(Sprite* sprite, Slice* slice) : WithSprite(sprite), WithSlice
 {
 }
 
-void AddSlice::onExecute()
+void AddSlice::onExecute(Context* ctx)
 {
   Sprite* sprite = this->sprite();
   Slice* slice = this->slice();
@@ -32,7 +32,7 @@ void AddSlice::onExecute()
   addSlice(sprite, slice);
 }
 
-void AddSlice::onUndo()
+void AddSlice::onUndo(Context* ctx)
 {
   Sprite* sprite = this->sprite();
   Slice* slice = this->slice();
@@ -41,7 +41,7 @@ void AddSlice::onUndo()
   m_suspendedSlice.suspend(slice);
 }
 
-void AddSlice::onRedo()
+void AddSlice::onRedo(Context* ctx)
 {
   Sprite* sprite = this->sprite();
   Slice* slice = m_suspendedSlice.restore();

--- a/src/app/cmd/add_slice.h
+++ b/src/app/cmd/add_slice.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2025  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2017  David Capello
 //
 // This program is distributed under the terms of
@@ -25,9 +25,9 @@ public:
   AddSlice(Sprite* sprite, Slice* slice);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onRedo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onRedo(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this) + m_suspendedSlice.size(); }
 
 private:

--- a/src/app/cmd/add_tag.cpp
+++ b/src/app/cmd/add_tag.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2025  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -24,7 +24,7 @@ AddTag::AddTag(Sprite* sprite, Tag* tag) : WithSprite(sprite), WithTag(tag)
 {
 }
 
-void AddTag::onExecute()
+void AddTag::onExecute(Context* ctx)
 {
   Sprite* sprite = this->sprite();
   Tag* tag = this->tag();
@@ -40,7 +40,7 @@ void AddTag::onExecute()
   doc->notify_observers<DocEvent&>(&DocObserver::onAddTag, ev);
 }
 
-void AddTag::onUndo()
+void AddTag::onUndo(Context* ctx)
 {
   Sprite* sprite = this->sprite();
   Tag* tag = this->tag();
@@ -60,7 +60,7 @@ void AddTag::onUndo()
   m_suspendedTag.suspend(tag);
 }
 
-void AddTag::onRedo()
+void AddTag::onRedo(Context* ctx)
 {
   Sprite* sprite = this->sprite();
   Tag* tag = m_suspendedTag.restore();

--- a/src/app/cmd/add_tag.h
+++ b/src/app/cmd/add_tag.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2025  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2016  David Capello
 //
 // This program is distributed under the terms of
@@ -25,9 +25,9 @@ public:
   AddTag(Sprite* sprite, Tag* tag);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onRedo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onRedo(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this) + m_suspendedTag.size(); }
 
 private:

--- a/src/app/cmd/add_tile.cpp
+++ b/src/app/cmd/add_tile.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2025  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -33,7 +33,7 @@ AddTile::AddTile(doc::Tileset* tileset, const doc::tile_index ti)
 {
 }
 
-void AddTile::onExecute()
+void AddTile::onExecute(Context* ctx)
 {
   doc::Tileset* tileset = this->tileset();
   ASSERT(tileset);
@@ -47,7 +47,7 @@ void AddTile::onExecute()
   }
 }
 
-void AddTile::onUndo()
+void AddTile::onUndo(Context* ctx)
 {
   doc::Tileset* tileset = this->tileset();
   ASSERT(tileset);
@@ -62,7 +62,7 @@ void AddTile::onUndo()
   tileset->incrementVersion();
 }
 
-void AddTile::onRedo()
+void AddTile::onRedo(Context* ctx)
 {
   doc::Tileset* tileset = this->tileset();
 
@@ -73,7 +73,7 @@ void AddTile::onRedo()
   addTile(tileset, m_imageRef, m_userData);
 }
 
-void AddTile::onFireNotifications()
+void AddTile::onFireNotifications(Context* ctx)
 {
   doc::Tileset* tileset = this->tileset();
 

--- a/src/app/cmd/add_tile.h
+++ b/src/app/cmd/add_tile.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2025  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -30,10 +30,10 @@ public:
   doc::tile_index tileIndex() const { return m_tileIndex; }
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onRedo() override;
-  void onFireNotifications() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onRedo(Context* ctx) override;
+  void onFireNotifications(Context* ctx) override;
   size_t onMemSize() const override
   {
     // TODO add m_userData size

--- a/src/app/cmd/add_tileset.cpp
+++ b/src/app/cmd/add_tileset.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2025  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -32,14 +32,14 @@ AddTileset::AddTileset(doc::Sprite* sprite, const doc::tileset_index tsi)
 {
 }
 
-void AddTileset::onExecute()
+void AddTileset::onExecute(Context* ctx)
 {
   Tileset* tileset = this->tileset();
 
   addTileset(tileset);
 }
 
-void AddTileset::onUndo()
+void AddTileset::onUndo(Context* ctx)
 {
   doc::Tileset* tileset = this->tileset();
   m_suspendedTileset.suspend(tileset);
@@ -51,7 +51,7 @@ void AddTileset::onUndo()
   sprite->tilesets()->incrementVersion();
 }
 
-void AddTileset::onRedo()
+void AddTileset::onRedo(Context* ctx)
 {
   doc::Tileset* tileset = m_suspendedTileset.restore();
 

--- a/src/app/cmd/add_tileset.h
+++ b/src/app/cmd/add_tileset.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2025  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -31,9 +31,9 @@ public:
   doc::tileset_index tilesetIndex() const { return m_tilesetIndex; }
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onRedo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onRedo(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this) + m_suspendedTileset.size(); }
 
 private:

--- a/src/app/cmd/assign_color_profile.cpp
+++ b/src/app/cmd/assign_color_profile.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2020  Igara Studio S.A.
+// Copyright (C) 2018-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -23,21 +23,21 @@ AssignColorProfile::AssignColorProfile(doc::Sprite* sprite, const gfx::ColorSpac
 {
 }
 
-void AssignColorProfile::onExecute()
+void AssignColorProfile::onExecute(Context* ctx)
 {
   doc::Sprite* spr = sprite();
   spr->setColorSpace(m_newCS);
   spr->incrementVersion();
 }
 
-void AssignColorProfile::onUndo()
+void AssignColorProfile::onUndo(Context* ctx)
 {
   doc::Sprite* spr = sprite();
   spr->setColorSpace(m_oldCS);
   spr->incrementVersion();
 }
 
-void AssignColorProfile::onFireNotifications()
+void AssignColorProfile::onFireNotifications(Context* ctx)
 {
   doc::Sprite* sprite = this->sprite();
   Doc* doc = static_cast<Doc*>(sprite->document());

--- a/src/app/cmd/assign_color_profile.h
+++ b/src/app/cmd/assign_color_profile.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2020  Igara Studio S.A.
+// Copyright (C) 2018-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -20,9 +20,9 @@ public:
   AssignColorProfile(doc::Sprite* sprite, const gfx::ColorSpaceRef& cs);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onFireNotifications() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onFireNotifications(Context* ctx) override;
   size_t onMemSize() const override
   {
     return sizeof(*this) + 2 * sizeof(gfx::ColorSpace) + m_oldCS->iccSize() + m_newCS->iccSize();

--- a/src/app/cmd/background_from_layer.cpp
+++ b/src/app/cmd/background_from_layer.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2026  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2016  David Capello
 //
 // This program is distributed under the terms of
@@ -38,7 +38,7 @@ BackgroundFromLayer::BackgroundFromLayer(Layer* layer) : WithLayer(layer)
   ASSERT(layer->sprite()->backgroundLayer() == NULL);
 }
 
-void BackgroundFromLayer::onExecute()
+void BackgroundFromLayer::onExecute(Context* ctx)
 {
   Layer* layer = this->layer();
   ASSERT(!layer->isTilemap()); // TODO support background tilemaps
@@ -69,16 +69,17 @@ void BackgroundFromLayer::onExecute()
     }
 
     // now we have to copy the new image (bg_image) to the cel...
-    executeAndAdd(new cmd::SetCelPosition(cel, 0, 0));
+    executeAndAdd(ctx, new cmd::SetCelPosition(cel, 0, 0));
 
     // change opacity to 255
     if (cel->opacity() < 255)
-      executeAndAdd(new cmd::SetCelOpacity(cel, 255));
+      executeAndAdd(ctx, new cmd::SetCelOpacity(cel, 255));
 
     // Same size of cel image and background image, we can just
     // replace pixels.
     if (cel_image && bg_image->size() == cel_image->size()) {
-      executeAndAdd(new CopyRect(cel_image, bg_image.get(), gfx::Clip(0, 0, cel_image->bounds())));
+      executeAndAdd(ctx,
+                    new CopyRect(cel_image, bg_image.get(), gfx::Clip(0, 0, cel_image->bounds())));
     }
     // In other case we have to replace the whole image (this is the
     // most common case, a smaller transparent cel that is converted
@@ -86,9 +87,9 @@ void BackgroundFromLayer::onExecute()
     else {
       ImageRef bg_image2(Image::createCopy(bg_image.get()));
       if (cel->image())
-        executeAndAdd(new cmd::ReplaceImage(sprite, cel->imageRef(), bg_image2));
+        executeAndAdd(ctx, new cmd::ReplaceImage(sprite, cel->imageRef(), bg_image2));
       else
-        executeAndAdd(new cmd::SetCelImage(cel, bg_image2));
+        executeAndAdd(ctx, new cmd::SetCelImage(cel, bg_image2));
     }
   }
 
@@ -101,11 +102,11 @@ void BackgroundFromLayer::onExecute()
 
       // Create the new cel and add it to the new background layer
       cel = new Cel(frame, cel_image);
-      executeAndAdd(new cmd::AddCel(layer, cel));
+      executeAndAdd(ctx, new cmd::AddCel(layer, cel));
     }
   }
 
-  executeAndAdd(new cmd::ConfigureBackground(layer));
+  executeAndAdd(ctx, new cmd::ConfigureBackground(layer));
 }
 
 }} // namespace app::cmd

--- a/src/app/cmd/background_from_layer.h
+++ b/src/app/cmd/background_from_layer.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -20,7 +21,7 @@ public:
   BackgroundFromLayer(Layer* layer);
 
 protected:
-  void onExecute() override;
+  void onExecute(Context* ctx) override;
 };
 
 }} // namespace app::cmd

--- a/src/app/cmd/clear_cel.cpp
+++ b/src/app/cmd/clear_cel.cpp
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -12,6 +13,7 @@
 
 #include "app/cmd/clear_image.h"
 #include "app/cmd/remove_cel.h"
+#include "app/context.h"
 #include "app/doc.h"
 #include "doc/cel.h"
 #include "doc/layer.h"
@@ -33,19 +35,19 @@ ClearCel::ClearCel(Cel* cel) : WithCel(cel)
   }
 }
 
-void ClearCel::onExecute()
+void ClearCel::onExecute(Context* ctx)
 {
-  m_seq.execute(context());
+  m_seq.execute(ctx);
 }
 
-void ClearCel::onUndo()
+void ClearCel::onUndo(Context* ctx)
 {
-  m_seq.undo();
+  m_seq.undo(ctx);
 }
 
-void ClearCel::onRedo()
+void ClearCel::onRedo(Context* ctx)
 {
-  m_seq.redo();
+  m_seq.redo(ctx);
 }
 
 }} // namespace app::cmd

--- a/src/app/cmd/clear_cel.h
+++ b/src/app/cmd/clear_cel.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -21,9 +22,9 @@ public:
   ClearCel(Cel* cel);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onRedo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onRedo(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this) + m_seq.memSize(); }
 
 private:

--- a/src/app/cmd/clear_image.cpp
+++ b/src/app/cmd/clear_image.cpp
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -22,7 +23,7 @@ ClearImage::ClearImage(Image* image, color_t color) : WithImage(image), m_color(
 {
 }
 
-void ClearImage::onExecute()
+void ClearImage::onExecute(Context* ctx)
 {
   Image* image = this->image();
 
@@ -33,7 +34,7 @@ void ClearImage::onExecute()
   image->incrementVersion();
 }
 
-void ClearImage::onUndo()
+void ClearImage::onUndo(Context* ctx)
 {
   Image* image = this->image();
 

--- a/src/app/cmd/clear_image.h
+++ b/src/app/cmd/clear_image.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -22,8 +23,8 @@ public:
   ClearImage(Image* image, color_t color);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this) + (m_copy ? m_copy->getMemSize() : 0); }
 
 private:

--- a/src/app/cmd/clear_mask.cpp
+++ b/src/app/cmd/clear_mask.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2020-2026  Igara Studio S.A.
+// Copyright (C) 2020-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -12,6 +12,7 @@
 #include "app/cmd/clear_mask.h"
 
 #include "app/cmd/clear_cel.h"
+#include "app/context.h"
 #include "app/doc.h"
 #include "doc/algorithm/fill_selection.h"
 #include "doc/cel.h"
@@ -68,21 +69,21 @@ ClearMask::ClearMask(Cel* cel) : WithCel(cel)
   m_copy.reset(crop_image(image, cropBounds, m_bgcolor));
 }
 
-void ClearMask::onExecute()
+void ClearMask::onExecute(Context* ctx)
 {
-  m_seq.execute(context());
+  m_seq.execute(ctx);
   clear();
 }
 
-void ClearMask::onUndo()
+void ClearMask::onUndo(Context* ctx)
 {
   restore();
-  m_seq.undo();
+  m_seq.undo(ctx);
 }
 
-void ClearMask::onRedo()
+void ClearMask::onRedo(Context* ctx)
 {
-  m_seq.redo();
+  m_seq.redo(ctx);
   clear();
 }
 

--- a/src/app/cmd/clear_mask.h
+++ b/src/app/cmd/clear_mask.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2020  Igara Studio S.A.
+// Copyright (C) 2020-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -27,9 +27,9 @@ public:
   ClearMask(Cel* cel);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onRedo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onRedo(Context* ctx) override;
   size_t onMemSize() const override
   {
     return sizeof(*this) + m_seq.memSize() + (m_copy ? m_copy->getMemSize() : 0);

--- a/src/app/cmd/clear_rect.cpp
+++ b/src/app/cmd/clear_rect.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2025  Igara Studio S.A.
+// Copyright (C) 2025-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -11,6 +11,7 @@
 
 #include "app/cmd/clear_rect.h"
 
+#include "app/context.h"
 #include "app/doc.h"
 #include "doc/cel.h"
 #include "doc/image.h"
@@ -56,23 +57,23 @@ void ClearRect::initialize(Cel* cel, const gfx::Rect& bounds, color_t color)
   m_copy.reset(crop_image(image, bounds2.x, bounds2.y, bounds2.w, bounds2.h, m_bgcolor));
 }
 
-void ClearRect::onExecute()
+void ClearRect::onExecute(Context* ctx)
 {
-  m_seq.execute(context());
+  m_seq.execute(ctx);
   if (m_dstImage)
     clear();
 }
 
-void ClearRect::onUndo()
+void ClearRect::onUndo(Context* ctx)
 {
   if (m_dstImage)
     restore();
-  m_seq.undo();
+  m_seq.undo(ctx);
 }
 
-void ClearRect::onRedo()
+void ClearRect::onRedo(Context* ctx)
 {
-  m_seq.redo();
+  m_seq.redo(ctx);
   if (m_dstImage)
     clear();
 }

--- a/src/app/cmd/clear_rect.h
+++ b/src/app/cmd/clear_rect.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2025  Igara Studio S.A.
+// Copyright (C) 2025-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -30,9 +30,9 @@ public:
   ClearRect(Cel* cel, const gfx::Rect& bounds, color_t color);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onRedo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onRedo(Context* ctx) override;
   size_t onMemSize() const override
   {
     return sizeof(*this) + m_seq.memSize() + (m_copy ? m_copy->getMemSize() : 0);

--- a/src/app/cmd/clear_slices.cpp
+++ b/src/app/cmd/clear_slices.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2024-2026  Igara Studio S.A.
+// Copyright (C) 2024-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -10,6 +10,7 @@
 
 #include "app/cmd/clear_slices.h"
 
+#include "app/context.h"
 #include "app/doc.h"
 #include "app/site.h"
 #include "app/util/cel_ops.h"
@@ -73,25 +74,25 @@ ClearSlices::ClearSlices(const Site& site,
   }
 }
 
-void ClearSlices::onExecute()
+void ClearSlices::onExecute(Context* ctx)
 {
-  m_seq.execute(context());
-  clear();
+  m_seq.execute(ctx);
+  clear(ctx);
 }
 
-void ClearSlices::onUndo()
+void ClearSlices::onUndo(Context* ctx)
 {
   restore();
-  m_seq.undo();
+  m_seq.undo(ctx);
 }
 
-void ClearSlices::onRedo()
+void ClearSlices::onRedo(Context* ctx)
 {
-  m_seq.redo();
-  clear();
+  m_seq.redo(ctx);
+  clear(ctx);
 }
 
-void ClearSlices::clear()
+void ClearSlices::clear(Context* ctx)
 {
   for (auto& sc : m_slicesContents) {
     if (!sc.copy)
@@ -104,6 +105,7 @@ void ClearSlices::clear()
       color_t bgcolor = doc->bgColor(sc.cel()->layer());
 
       modify_tilemap_cel_region(
+        ctx,
         &m_seq,
         sc.cel(),
         nullptr,

--- a/src/app/cmd/clear_slices.h
+++ b/src/app/cmd/clear_slices.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2024  Igara Studio S.A.
+// Copyright (C) 2024-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -38,9 +38,9 @@ public:
               const std::vector<SliceKey>& slicesKeys);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onRedo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onRedo(Context* ctx) override;
   size_t onMemSize() const override
   {
     size_t sliceContentsSize = 0;
@@ -61,7 +61,7 @@ private:
     size_t memSize() const { return sizeof(*this) + (copy ? copy->getMemSize() : 0); }
   };
 
-  void clear();
+  void clear(Context* ctx);
   void restore();
 
   CmdSequence m_seq;

--- a/src/app/cmd/convert_color_profile.cpp
+++ b/src/app/cmd/convert_color_profile.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2025  Igara Studio S.A.
+// Copyright (C) 2018-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -13,6 +13,7 @@
 #include "app/cmd/assign_color_profile.h"
 #include "app/cmd/replace_image.h"
 #include "app/cmd/set_palette.h"
+#include "app/context.h"
 #include "app/doc.h"
 #include "doc/cels_range.h"
 #include "doc/palette.h"
@@ -207,19 +208,19 @@ ConvertColorProfile::ConvertColorProfile(doc::Sprite* sprite, const gfx::ColorSp
   m_seq.add(new cmd::AssignColorProfile(sprite, newCS));
 }
 
-void ConvertColorProfile::onExecute()
+void ConvertColorProfile::onExecute(Context* ctx)
 {
-  m_seq.execute(context());
+  m_seq.execute(ctx);
 }
 
-void ConvertColorProfile::onUndo()
+void ConvertColorProfile::onUndo(Context* ctx)
 {
-  m_seq.undo();
+  m_seq.undo(ctx);
 }
 
-void ConvertColorProfile::onRedo()
+void ConvertColorProfile::onRedo(Context* ctx)
 {
-  m_seq.redo();
+  m_seq.redo(ctx);
 }
 
 }} // namespace app::cmd

--- a/src/app/cmd/convert_color_profile.h
+++ b/src/app/cmd/convert_color_profile.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2020  Igara Studio S.A.
+// Copyright (C) 2018-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -30,9 +30,9 @@ public:
   ConvertColorProfile(doc::Sprite* sprite, const gfx::ColorSpaceRef& newCS);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onRedo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onRedo(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this) + m_seq.memSize(); }
 
 private:

--- a/src/app/cmd/copy_cel.cpp
+++ b/src/app/cmd/copy_cel.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2026  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2016  David Capello
 //
 // This program is distributed under the terms of
@@ -44,7 +44,7 @@ CopyCel::CopyCel(Layer* srcLayer,
 {
 }
 
-void CopyCel::onExecute()
+void CopyCel::onExecute(Context* ctx)
 {
   Layer* srcLayer = m_srcLayer.layer();
   Layer* dstLayer = m_dstLayer.layer();
@@ -66,13 +66,13 @@ void CopyCel::onExecute()
   // copy of srcCel.
   if (dstCel) {
     if (dstCel->links())
-      executeAndAdd(new cmd::UnlinkCel(dstCel));
-    executeAndAdd(new cmd::ClearCel(dstCel));
+      executeAndAdd(ctx, new cmd::UnlinkCel(dstCel));
+    executeAndAdd(ctx, new cmd::ClearCel(dstCel));
   }
 
   // Add empty frames until newFrame
   while (dstSprite->totalFrames() <= m_dstFrame)
-    executeAndAdd(new cmd::AddFrame(dstSprite, dstSprite->totalFrames()));
+    executeAndAdd(ctx, new cmd::AddFrame(dstSprite, dstSprite->totalFrames()));
 
   Image* srcImage = (srcCel ? srcCel->image() : nullptr);
   ImageRef dstImage;
@@ -91,13 +91,13 @@ void CopyCel::onExecute()
     ASSERT(!dstLayer->isTilemap()); // TODO support background tilemaps
 
     if (createLink) {
-      executeAndAdd(new cmd::SetCelData(dstCel, srcCel->dataRef()));
+      executeAndAdd(ctx, new cmd::SetCelData(dstCel, srcCel->dataRef()));
     }
     // Rasterize tilemap into the regular image background layer
     else if (srcLayer->isTilemap()) {
       ImageRef tmp(Image::createCopy(dstImage.get()));
       render::rasterize(tmp.get(), srcCel, 0, 0, false);
-      executeAndAdd(new cmd::CopyRect(dstImage.get(), tmp.get(), gfx::Clip(tmp->bounds())));
+      executeAndAdd(ctx, new cmd::CopyRect(dstImage.get(), tmp.get(), gfx::Clip(tmp->bounds())));
     }
     else {
       BlendMode blend = (srcLayer->isBackground() ? BlendMode::SRC : BlendMode::NORMAL);
@@ -110,13 +110,13 @@ void CopyCel::onExecute()
                               srcCel->y(),
                               255,
                               blend);
-      executeAndAdd(new cmd::CopyRect(dstImage.get(), tmp.get(), gfx::Clip(tmp->bounds())));
+      executeAndAdd(ctx, new cmd::CopyRect(dstImage.get(), tmp.get(), gfx::Clip(tmp->bounds())));
     }
   }
   // For transparent layers
   else {
     if (dstCel)
-      executeAndAdd(new cmd::RemoveCel(dstCel));
+      executeAndAdd(ctx, new cmd::RemoveCel(dstCel));
 
     if (srcCel) {
       if (createLink)
@@ -124,14 +124,14 @@ void CopyCel::onExecute()
       else
         dstCel = create_cel_copy(this, srcCel, dstSprite, dstLayer, m_dstFrame);
 
-      executeAndAdd(new cmd::AddCel(dstLayer, dstCel));
+      executeAndAdd(ctx, new cmd::AddCel(dstLayer, dstCel));
     }
   }
 }
 
-void CopyCel::onFireNotifications()
+void CopyCel::onFireNotifications(Context* ctx)
 {
-  CmdSequence::onFireNotifications();
+  CmdSequence::onFireNotifications(ctx);
 
   // The m_srcLayer can be nullptr now because the layer from where we
   // copied this cel might not exist anymore (e.g. if we copied the

--- a/src/app/cmd/copy_cel.h
+++ b/src/app/cmd/copy_cel.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -22,8 +22,8 @@ public:
   CopyCel(Layer* srcLayer, frame_t srcFrame, Layer* dstLayer, frame_t dstFrame, bool continuous);
 
 protected:
-  void onExecute() override;
-  void onFireNotifications() override;
+  void onExecute(Context* ctx) override;
+  void onFireNotifications(Context* ctx) override;
 
 private:
   WithLayer m_srcLayer, m_dstLayer;

--- a/src/app/cmd/copy_frame.cpp
+++ b/src/app/cmd/copy_frame.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2016  David Capello
 //
 // This program is distributed under the terms of
@@ -28,14 +28,14 @@ CopyFrame::CopyFrame(Sprite* sprite, frame_t fromFrame, frame_t newFrame)
 {
 }
 
-void CopyFrame::onExecute()
+void CopyFrame::onExecute(Context* ctx)
 {
   Sprite* sprite = this->sprite();
   frame_t fromFrame = m_fromFrame;
   int msecs = sprite->frameDuration(fromFrame);
 
-  executeAndAdd(new cmd::AddFrame(sprite, m_newFrame));
-  executeAndAdd(new cmd::SetFrameDuration(sprite, m_newFrame, msecs));
+  executeAndAdd(ctx, new cmd::AddFrame(sprite, m_newFrame));
+  executeAndAdd(ctx, new cmd::SetFrameDuration(sprite, m_newFrame, msecs));
 
   // Do not copy cels (cmd::CopyCel must be called from outside)
 }

--- a/src/app/cmd/copy_frame.h
+++ b/src/app/cmd/copy_frame.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -21,7 +22,7 @@ public:
   CopyFrame(Sprite* sprite, frame_t fromFrame, frame_t newFrame);
 
 protected:
-  void onExecute() override;
+  void onExecute(Context* ctx) override;
   size_t onMemSize() const override
   {
     return sizeof(*this) + CmdSequence::onMemSize() - sizeof(CmdSequence);

--- a/src/app/cmd/copy_rect.cpp
+++ b/src/app/cmd/copy_rect.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2023  Igara Studio S.A.
+// Copyright (C) 2023-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -38,17 +38,17 @@ CopyRect::CopyRect(Image* dst, const Image* src, const gfx::Clip& clip)
   }
 }
 
-void CopyRect::onExecute()
+void CopyRect::onExecute(Context* ctx)
 {
   swap();
 }
 
-void CopyRect::onUndo()
+void CopyRect::onUndo(Context* ctx)
 {
   swap();
 }
 
-void CopyRect::onRedo()
+void CopyRect::onRedo(Context* ctx)
 {
   swap();
 }

--- a/src/app/cmd/copy_rect.h
+++ b/src/app/cmd/copy_rect.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -27,9 +28,9 @@ public:
   CopyRect(Image* dst, const Image* src, const gfx::Clip& clip);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onRedo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onRedo(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this) + m_data.size(); }
 
 private:

--- a/src/app/cmd/copy_region.cpp
+++ b/src/app/cmd/copy_region.cpp
@@ -57,26 +57,26 @@ CopyTileRegion::CopyTileRegion(Image* dst,
 {
 }
 
-void CopyRegion::onExecute()
+void CopyRegion::onExecute(Context* ctx)
 {
   if (!m_alreadyCopied)
     swap();
 }
 
-void CopyRegion::onUndo()
+void CopyRegion::onUndo(Context* ctx)
 {
   swap();
 }
 
-void CopyRegion::onRedo()
+void CopyRegion::onRedo(Context* ctx)
 {
   swap();
 }
 
-void CopyRegion::onFireNotifications()
+void CopyRegion::onFireNotifications(Context* ctx)
 {
   // TODO save sprite in this cmd?
-  Site site = context()->activeSite();
+  Site site = ctx->activeSite();
   if (!site.document() || !site.sprite())
     return;
 

--- a/src/app/cmd/copy_region.h
+++ b/src/app/cmd/copy_region.h
@@ -37,10 +37,10 @@ public:
              bool alreadyCopied = false);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onRedo() override;
-  void onFireNotifications() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onRedo(Context* ctx) override;
+  void onFireNotifications(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this) + m_buffer.size(); }
 
 private:

--- a/src/app/cmd/crop_cel.cpp
+++ b/src/app/cmd/crop_cel.cpp
@@ -35,17 +35,17 @@ CropCel::CropCel(Cel* cel, const gfx::Rect& newBounds)
   ASSERT(m_newBounds != m_oldBounds);
 }
 
-void CropCel::onExecute()
+void CropCel::onExecute(Context* ctx)
 {
   cropImage(m_newOrigin, m_newBounds);
 }
 
-void CropCel::onUndo()
+void CropCel::onUndo(Context* ctx)
 {
   cropImage(m_oldOrigin, m_oldBounds);
 }
 
-void CropCel::onFireNotifications()
+void CropCel::onFireNotifications(Context* ctx)
 {
   Cel* cel = this->cel();
   if (!cel)

--- a/src/app/cmd/crop_cel.h
+++ b/src/app/cmd/crop_cel.h
@@ -22,9 +22,9 @@ public:
   CropCel(doc::Cel* cel, const gfx::Rect& newBounds);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onFireNotifications() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onFireNotifications(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this); }
 
 private:

--- a/src/app/cmd/deselect_mask.cpp
+++ b/src/app/cmd/deselect_mask.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2020  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -21,7 +21,7 @@ DeselectMask::DeselectMask(Doc* doc) : WithDocument(doc)
 {
 }
 
-void DeselectMask::onExecute()
+void DeselectMask::onExecute(Context* ctx)
 {
   Doc* doc = document();
   m_oldMask.reset(doc->isMaskVisible() ? new Mask(*doc->mask()) : nullptr);
@@ -29,7 +29,7 @@ void DeselectMask::onExecute()
   doc->notifySelectionChanged();
 }
 
-void DeselectMask::onUndo()
+void DeselectMask::onUndo(Context* ctx)
 {
   Doc* doc = document();
 

--- a/src/app/cmd/deselect_mask.h
+++ b/src/app/cmd/deselect_mask.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -26,8 +27,8 @@ public:
   DeselectMask(Doc* doc);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
   size_t onMemSize() const override;
 
 private:

--- a/src/app/cmd/flatten_layers.cpp
+++ b/src/app/cmd/flatten_layers.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2026  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -54,7 +54,7 @@ FlattenLayers::FlattenLayers(doc::Sprite* sprite,
     m_layerIds.push_back(layer->id());
 }
 
-void FlattenLayers::onExecute()
+void FlattenLayers::onExecute(Context* ctx)
 {
   Sprite* sprite = this->sprite();
   auto doc = static_cast<Doc*>(sprite->document());
@@ -163,7 +163,7 @@ void FlattenLayers::onExecute()
       Cel* cel = flatLayer->cel(frame);
       if (!shrink) {
         if (!newFlatLayer && cel)
-          executeAndAdd(new cmd::RemoveCel(cel));
+          executeAndAdd(ctx, new cmd::RemoveCel(cel));
 
         continue;
       }
@@ -176,26 +176,26 @@ void FlattenLayers::onExecute()
         // TODO Keep cel links when possible
 
         if (cel->links())
-          executeAndAdd(new cmd::UnlinkCel(cel));
+          executeAndAdd(ctx, new cmd::UnlinkCel(cel));
 
         const ImageRef cel_image = cel->imageRef();
 
         // Reset cel properties when flattening in-place
         if (!newFlatLayer) {
           if (cel->opacity() != 255)
-            executeAndAdd(new cmd::SetCelOpacity(cel, 255));
+            executeAndAdd(ctx, new cmd::SetCelOpacity(cel, 255));
 
           if (cel->zIndex() != 0)
-            executeAndAdd(new cmd::SetCelZIndex(cel, 0));
+            executeAndAdd(ctx, new cmd::SetCelZIndex(cel, 0));
 
-          executeAndAdd(new cmd::SetCelPosition(cel, area.x + bounds.x, area.y + bounds.y));
+          executeAndAdd(ctx, new cmd::SetCelPosition(cel, area.x + bounds.x, area.y + bounds.y));
         }
 
         // Modify destination cel
         if (cel_image)
-          executeAndAdd(new cmd::ReplaceImage(sprite, cel_image, new_image));
+          executeAndAdd(ctx, new cmd::ReplaceImage(sprite, cel_image, new_image));
         else
-          executeAndAdd(new cmd::SetCelImage(cel, new_image));
+          executeAndAdd(ctx, new cmd::SetCelImage(cel, new_image));
       }
       // Add new cel on null
       else {
@@ -209,7 +209,7 @@ void FlattenLayers::onExecute()
           flatLayer->addCel(cel);
         }
         else {
-          executeAndAdd(new cmd::AddCel(flatLayer, cel));
+          executeAndAdd(ctx, new cmd::AddCel(flatLayer, cel));
         }
       }
     }
@@ -221,15 +221,15 @@ void FlattenLayers::onExecute()
 
   // Add new flatten layer
   if (newFlatLayer) {
-    executeAndAdd(new cmd::AddLayer(list.front()->parent(), flatLayer, list.front()));
+    executeAndAdd(ctx, new cmd::AddLayer(list.front()->parent(), flatLayer, list.front()));
   }
   // Reset layer properties when flattening in-place
   else {
     if (flatLayer->opacity() != 255)
-      executeAndAdd(new cmd::SetLayerOpacity(flatLayer, 255));
+      executeAndAdd(ctx, new cmd::SetLayerOpacity(flatLayer, 255));
 
     if (flatLayer->blendMode() != doc::BlendMode::NORMAL)
-      executeAndAdd(new cmd::SetLayerBlendMode(flatLayer, doc::BlendMode::NORMAL));
+      executeAndAdd(ctx, new cmd::SetLayerBlendMode(flatLayer, doc::BlendMode::NORMAL));
   }
 
   // Delete flattened layers.
@@ -237,7 +237,7 @@ void FlattenLayers::onExecute()
     // layer can be == flatLayer when we are flattening on the
     // background layer.
     if (layer != flatLayer) {
-      executeAndAdd(new cmd::RemoveLayer(layer));
+      executeAndAdd(ctx, new cmd::RemoveLayer(layer));
     }
   }
 }

--- a/src/app/cmd/flatten_layers.h
+++ b/src/app/cmd/flatten_layers.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019 Igara Studio S.A.
+// Copyright (C) 2019-present Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -31,7 +31,7 @@ public:
   FlattenLayers(doc::Sprite* sprite, const doc::SelectedLayers& layers, const Options options);
 
 protected:
-  void onExecute() override;
+  void onExecute(Context* ctx) override;
 
 private:
   doc::ObjectIds m_layerIds;

--- a/src/app/cmd/flip_image.cpp
+++ b/src/app/cmd/flip_image.cpp
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -22,12 +23,12 @@ FlipImage::FlipImage(Image* image, const gfx::Rect& bounds, doc::algorithm::Flip
 {
 }
 
-void FlipImage::onExecute()
+void FlipImage::onExecute(Context* ctx)
 {
   swap();
 }
 
-void FlipImage::onUndo()
+void FlipImage::onUndo(Context* ctx)
 {
   swap();
 }

--- a/src/app/cmd/flip_image.h
+++ b/src/app/cmd/flip_image.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -28,8 +29,8 @@ public:
   FlipImage(Image* image, const gfx::Rect& bounds, doc::algorithm::FlipType flipType);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this); }
 
 private:

--- a/src/app/cmd/flip_mask.cpp
+++ b/src/app/cmd/flip_mask.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -25,12 +25,12 @@ FlipMask::FlipMask(Doc* doc, doc::algorithm::FlipType flipType)
 {
 }
 
-void FlipMask::onExecute()
+void FlipMask::onExecute(Context* ctx)
 {
   swap();
 }
 
-void FlipMask::onUndo()
+void FlipMask::onUndo(Context* ctx)
 {
   swap();
 }

--- a/src/app/cmd/flip_mask.h
+++ b/src/app/cmd/flip_mask.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -21,8 +22,8 @@ public:
   FlipMask(Doc* doc, doc::algorithm::FlipType flipType);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this); }
 
 private:

--- a/src/app/cmd/move_cel.cpp
+++ b/src/app/cmd/move_cel.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2026  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2016  David Capello
 //
 // This program is distributed under the terms of
@@ -46,7 +46,7 @@ MoveCel::MoveCel(Layer* srcLayer,
 {
 }
 
-void MoveCel::onExecute()
+void MoveCel::onExecute(Context* ctx)
 {
   Layer* srcLayer = m_srcLayer.layer();
   Layer* dstLayer = m_dstLayer.layer();
@@ -67,13 +67,13 @@ void MoveCel::onExecute()
   // copy of srcCel.
   if (dstCel) {
     if (dstCel->links())
-      executeAndAdd(new cmd::UnlinkCel(dstCel));
-    executeAndAdd(new cmd::ClearCel(dstCel));
+      executeAndAdd(ctx, new cmd::UnlinkCel(dstCel));
+    executeAndAdd(ctx, new cmd::ClearCel(dstCel));
   }
 
   // Add empty frames until newFrame
   while (dstSprite->totalFrames() <= m_dstFrame)
-    executeAndAdd(new cmd::AddFrame(dstSprite, dstSprite->totalFrames()));
+    executeAndAdd(ctx, new cmd::AddFrame(dstSprite, dstSprite->totalFrames()));
 
   Image* srcImage = (srcCel ? srcCel->image() : nullptr);
   ImageRef dstImage;
@@ -92,14 +92,14 @@ void MoveCel::onExecute()
     ASSERT(!dstLayer->isTilemap()); // TODO support background tilemaps
 
     if (createLink) {
-      executeAndAdd(new cmd::SetCelData(dstCel, srcCel->dataRef()));
-      executeAndAdd(new cmd::UnlinkCel(srcCel));
+      executeAndAdd(ctx, new cmd::SetCelData(dstCel, srcCel->dataRef()));
+      executeAndAdd(ctx, new cmd::UnlinkCel(srcCel));
     }
     // Rasterize tilemap into the regular image background layer
     else if (srcLayer->isTilemap()) {
       ImageRef tmp(Image::createCopy(dstImage.get()));
       render::rasterize(tmp.get(), srcCel, 0, 0, false);
-      executeAndAdd(new cmd::CopyRect(dstImage.get(), tmp.get(), gfx::Clip(tmp->bounds())));
+      executeAndAdd(ctx, new cmd::CopyRect(dstImage.get(), tmp.get(), gfx::Clip(tmp->bounds())));
     }
     else {
       BlendMode blend = (srcLayer->isBackground() ? BlendMode::SRC : BlendMode::NORMAL);
@@ -112,9 +112,9 @@ void MoveCel::onExecute()
                               srcCel->y(),
                               255,
                               blend);
-      executeAndAdd(new cmd::CopyRect(dstImage.get(), tmp.get(), gfx::Clip(tmp->bounds())));
+      executeAndAdd(ctx, new cmd::CopyRect(dstImage.get(), tmp.get(), gfx::Clip(tmp->bounds())));
     }
-    executeAndAdd(new cmd::ClearCel(srcCel));
+    executeAndAdd(ctx, new cmd::ClearCel(srcCel));
   }
   // For transparent layers
   else if (srcCel) {
@@ -124,20 +124,20 @@ void MoveCel::onExecute()
 
     // Move the cel in the same layer.
     if (srcLayer == dstLayer) {
-      executeAndAdd(new cmd::SetCelFrame(srcCel, m_dstFrame));
+      executeAndAdd(ctx, new cmd::SetCelFrame(srcCel, m_dstFrame));
     }
     else {
       dstCel = create_cel_copy(this, srcCel, dstSprite, dstLayer, m_dstFrame);
 
-      executeAndAdd(new cmd::AddCel(dstLayer, dstCel));
-      executeAndAdd(new cmd::ClearCel(srcCel));
+      executeAndAdd(ctx, new cmd::AddCel(dstLayer, dstCel));
+      executeAndAdd(ctx, new cmd::ClearCel(srcCel));
     }
   }
 }
 
-void MoveCel::onFireNotifications()
+void MoveCel::onFireNotifications(Context* ctx)
 {
-  CmdSequence::onFireNotifications();
+  CmdSequence::onFireNotifications(ctx);
   static_cast<Doc*>(m_dstLayer.layer()->sprite()->document())
     ->notifyCelMoved(m_srcLayer.layer(), m_srcFrame, m_dstLayer.layer(), m_dstFrame);
 }

--- a/src/app/cmd/move_cel.h
+++ b/src/app/cmd/move_cel.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2025  Igara Studio S.A.
+// Copyright (C) 2025-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -25,8 +25,8 @@ public:
           bool continuous);
 
 protected:
-  void onExecute() override;
-  void onFireNotifications() override;
+  void onExecute(Context* ctx) override;
+  void onFireNotifications(Context* ctx) override;
 
 private:
   WithLayer m_srcLayer, m_dstLayer;

--- a/src/app/cmd/move_layer.cpp
+++ b/src/app/cmd/move_layer.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2025  Igara Studio S.A.
+// Copyright (C) 2025-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -29,7 +29,7 @@ MoveLayer::MoveLayer(Layer* layer, Layer* newParent, Layer* afterThis)
 {
 }
 
-void MoveLayer::onExecute()
+void MoveLayer::onExecute(Context* ctx)
 {
   Layer* layer = m_layer.layer();
   Layer* afterThis = m_newAfterThis.layer();
@@ -58,7 +58,7 @@ void MoveLayer::onExecute()
   layer->sprite()->incrementVersion();
 }
 
-void MoveLayer::onUndo()
+void MoveLayer::onUndo(Context* ctx)
 {
   Layer* layer = m_layer.layer();
   Layer* afterThis = m_oldAfterThis.layer();
@@ -87,7 +87,7 @@ void MoveLayer::onUndo()
   layer->sprite()->incrementVersion();
 }
 
-void MoveLayer::onFireNotifications()
+void MoveLayer::onFireNotifications(Context* ctx)
 {
   Layer* layer = m_layer.layer();
   Doc* doc = static_cast<Doc*>(layer->sprite()->document());

--- a/src/app/cmd/move_layer.h
+++ b/src/app/cmd/move_layer.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2016  David Capello
 //
 // This program is distributed under the terms of
@@ -19,9 +20,9 @@ public:
   MoveLayer(Layer* layer, Layer* newParent, Layer* afterThis);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onFireNotifications() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onFireNotifications(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this); }
 
 private:

--- a/src/app/cmd/patch_cel.cpp
+++ b/src/app/cmd/patch_cel.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2020-2026  Igara Studio S.A.
+// Copyright (C) 2020-present  Igara Studio S.A.
 // Copyright (C) 2016  David Capello
 //
 // This program is distributed under the terms of
@@ -34,7 +34,7 @@ PatchCel::PatchCel(doc::Cel* dstCel,
   ASSERT(!patchedRegion.isEmpty());
 }
 
-void PatchCel::onExecute()
+void PatchCel::onExecute(Context* ctx)
 {
   Cel* cel = this->cel();
   ASSERT(cel->image());
@@ -54,17 +54,18 @@ void PatchCel::onExecute()
   }
 
   if (cel->bounds() != newBounds)
-    executeAndAdd(new CropCel(cel, newBounds));
+    executeAndAdd(ctx, new CropCel(cel, newBounds));
 
   if (cel->image()->pixelFormat() == IMAGE_TILEMAP) {
     executeAndAdd(
+      ctx,
       new CopyRegion(cel->image(), m_patch, regionInTiles, -grid.canvasToTile(cel->position())));
   }
   else {
-    executeAndAdd(new CopyRegion(cel->image(), m_patch, m_region, m_pos - cel->position()));
+    executeAndAdd(ctx, new CopyRegion(cel->image(), m_patch, m_region, m_pos - cel->position()));
   }
 
-  executeAndAdd(new TrimCel(cel));
+  executeAndAdd(ctx, new TrimCel(cel));
 
   m_patch = nullptr;
 }

--- a/src/app/cmd/patch_cel.h
+++ b/src/app/cmd/patch_cel.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2016  David Capello
 //
 // This program is distributed under the terms of
@@ -29,7 +30,7 @@ public:
            const gfx::Point& patchPos);
 
 protected:
-  void onExecute() override;
+  void onExecute(Context* ctx) override;
 
   const doc::Image* m_patch;
   const gfx::Region& m_region;

--- a/src/app/cmd/remap_colors.cpp
+++ b/src/app/cmd/remap_colors.cpp
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -25,7 +26,7 @@ RemapColors::RemapColors(Sprite* sprite, const Remap& remap) : WithSprite(sprite
 {
 }
 
-void RemapColors::onExecute()
+void RemapColors::onExecute(Context* ctx)
 {
   Sprite* spr = sprite();
   if (spr->pixelFormat() == IMAGE_INDEXED) {
@@ -34,7 +35,7 @@ void RemapColors::onExecute()
   }
 }
 
-void RemapColors::onUndo()
+void RemapColors::onUndo(Context* ctx)
 {
   Sprite* spr = this->sprite();
   if (spr->pixelFormat() == IMAGE_INDEXED) {

--- a/src/app/cmd/remap_colors.h
+++ b/src/app/cmd/remap_colors.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -21,8 +22,8 @@ public:
   RemapColors(Sprite* sprite, const Remap& remap);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this) + m_remap.getMemSize(); }
 
 private:

--- a/src/app/cmd/remap_tilemaps.cpp
+++ b/src/app/cmd/remap_tilemaps.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2026  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -30,14 +30,14 @@ RemapTilemaps::RemapTilemaps(Tileset* tileset, const Remap& remap)
 {
 }
 
-void RemapTilemaps::onExecute()
+void RemapTilemaps::onExecute(Context* ctx)
 {
   Tileset* tileset = this->tileset();
   remapTileset(tileset, m_remap);
   incrementVersions(tileset);
 }
 
-void RemapTilemaps::onUndo()
+void RemapTilemaps::onUndo(Context* ctx)
 {
   Tileset* tileset = this->tileset();
   remapTileset(tileset, m_remap.invert());

--- a/src/app/cmd/remap_tilemaps.h
+++ b/src/app/cmd/remap_tilemaps.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2022  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -21,8 +21,8 @@ public:
   RemapTilemaps(Tileset* tileset, const Remap& remap);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this) + m_remap.getMemSize(); }
 
 private:

--- a/src/app/cmd/remap_tileset.cpp
+++ b/src/app/cmd/remap_tileset.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -29,13 +29,13 @@ RemapTileset::RemapTileset(Tileset* tileset, const Remap& remap)
 {
 }
 
-void RemapTileset::onExecute()
+void RemapTileset::onExecute(Context* ctx)
 {
   Tileset* tileset = this->tileset();
   applyRemap(tileset, m_remap);
 }
 
-void RemapTileset::onUndo()
+void RemapTileset::onUndo(Context* ctx)
 {
   Tileset* tileset = this->tileset();
   applyRemap(tileset, m_remap.invert());

--- a/src/app/cmd/remap_tileset.h
+++ b/src/app/cmd/remap_tileset.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -21,8 +21,8 @@ public:
   RemapTileset(Tileset* tileset, const Remap& remap);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this) + m_remap.getMemSize(); }
 
 private:

--- a/src/app/cmd/remove_cel.cpp
+++ b/src/app/cmd/remove_cel.cpp
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -21,19 +22,19 @@ RemoveCel::RemoveCel(Cel* cel) : AddCel(cel->layer(), cel)
 {
 }
 
-void RemoveCel::onExecute()
+void RemoveCel::onExecute(Context* ctx)
 {
-  AddCel::onUndo();
+  AddCel::onUndo(ctx);
 }
 
-void RemoveCel::onUndo()
+void RemoveCel::onUndo(Context* ctx)
 {
-  AddCel::onRedo();
+  AddCel::onRedo(ctx);
 }
 
-void RemoveCel::onRedo()
+void RemoveCel::onRedo(Context* ctx)
 {
-  AddCel::onUndo();
+  AddCel::onUndo(ctx);
 }
 
 }} // namespace app::cmd

--- a/src/app/cmd/remove_cel.h
+++ b/src/app/cmd/remove_cel.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -18,9 +19,9 @@ public:
   RemoveCel(Cel* cel);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onRedo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onRedo(Context* ctx) override;
 };
 
 }} // namespace app::cmd

--- a/src/app/cmd/remove_frame.cpp
+++ b/src/app/cmd/remove_frame.cpp
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -11,6 +12,7 @@
 #include "app/cmd/remove_frame.h"
 
 #include "app/cmd/remove_cel.h"
+#include "app/context.h"
 #include "app/doc.h"
 #include "app/doc_event.h"
 #include "doc/cels_range.h"
@@ -31,17 +33,17 @@ RemoveFrame::RemoveFrame(Sprite* sprite, frame_t frame)
     m_seq.add(new cmd::RemoveCel(cel));
 }
 
-void RemoveFrame::onExecute()
+void RemoveFrame::onExecute(Context* ctx)
 {
   Sprite* sprite = this->sprite();
   Doc* doc = static_cast<Doc*>(sprite->document());
 
   if (m_firstTime) {
     m_firstTime = false;
-    m_seq.execute(context());
+    m_seq.execute(ctx);
   }
   else
-    m_seq.redo();
+    m_seq.redo(ctx);
 
   int oldTotalFrames = sprite->totalFrames();
 
@@ -60,7 +62,7 @@ void RemoveFrame::onExecute()
   doc->notify_observers<DocEvent&>(&DocObserver::onRemoveFrame, ev);
 }
 
-void RemoveFrame::onUndo()
+void RemoveFrame::onUndo(Context* ctx)
 {
   Sprite* sprite = this->sprite();
   Doc* doc = static_cast<Doc*>(sprite->document());
@@ -69,7 +71,7 @@ void RemoveFrame::onUndo()
     sprite->addFrame(m_frame);
   sprite->setFrameDuration(m_frame, m_frameDuration);
   sprite->incrementVersion();
-  m_seq.undo();
+  m_seq.undo(ctx);
 
   // Notify observers about the new frame.
   DocEvent ev(doc);

--- a/src/app/cmd/remove_frame.h
+++ b/src/app/cmd/remove_frame.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -22,8 +23,8 @@ public:
   RemoveFrame(Sprite* sprite, frame_t frame);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this) + m_seq.memSize(); }
 
 private:

--- a/src/app/cmd/remove_layer.cpp
+++ b/src/app/cmd/remove_layer.cpp
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -20,19 +21,19 @@ RemoveLayer::RemoveLayer(Layer* layer) : AddLayer(layer->parent(), layer, layer-
 {
 }
 
-void RemoveLayer::onExecute()
+void RemoveLayer::onExecute(Context* ctx)
 {
-  AddLayer::onUndo();
+  AddLayer::onUndo(ctx);
 }
 
-void RemoveLayer::onUndo()
+void RemoveLayer::onUndo(Context* ctx)
 {
-  AddLayer::onRedo();
+  AddLayer::onRedo(ctx);
 }
 
-void RemoveLayer::onRedo()
+void RemoveLayer::onRedo(Context* ctx)
 {
-  AddLayer::onUndo();
+  AddLayer::onUndo(ctx);
 }
 
 }} // namespace app::cmd

--- a/src/app/cmd/remove_layer.h
+++ b/src/app/cmd/remove_layer.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -18,9 +19,9 @@ public:
   RemoveLayer(Layer* layer);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onRedo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onRedo(Context* ctx) override;
 };
 
 }} // namespace app::cmd

--- a/src/app/cmd/remove_palette.cpp
+++ b/src/app/cmd/remove_palette.cpp
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -18,14 +19,14 @@ RemovePalette::RemovePalette(Sprite* sprite, Palette* pal) : AddPalette(sprite, 
 {
 }
 
-void RemovePalette::onExecute()
+void RemovePalette::onExecute(Context* ctx)
 {
-  AddPalette::onUndo();
+  AddPalette::onUndo(ctx);
 }
 
-void RemovePalette::onUndo()
+void RemovePalette::onUndo(Context* ctx)
 {
-  AddPalette::onRedo();
+  AddPalette::onRedo(ctx);
 }
 
 }} // namespace app::cmd

--- a/src/app/cmd/remove_palette.h
+++ b/src/app/cmd/remove_palette.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -18,8 +19,8 @@ public:
   RemovePalette(Sprite* sprite, Palette* pal);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
 };
 
 }} // namespace app::cmd

--- a/src/app/cmd/remove_slice.cpp
+++ b/src/app/cmd/remove_slice.cpp
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2017  David Capello
 //
 // This program is distributed under the terms of
@@ -18,19 +19,19 @@ RemoveSlice::RemoveSlice(Sprite* sprite, Slice* slice) : AddSlice(sprite, slice)
 {
 }
 
-void RemoveSlice::onExecute()
+void RemoveSlice::onExecute(Context* ctx)
 {
-  AddSlice::onUndo();
+  AddSlice::onUndo(ctx);
 }
 
-void RemoveSlice::onUndo()
+void RemoveSlice::onUndo(Context* ctx)
 {
-  AddSlice::onRedo();
+  AddSlice::onRedo(ctx);
 }
 
-void RemoveSlice::onRedo()
+void RemoveSlice::onRedo(Context* ctx)
 {
-  AddSlice::onUndo();
+  AddSlice::onUndo(ctx);
 }
 
 }} // namespace app::cmd

--- a/src/app/cmd/remove_slice.h
+++ b/src/app/cmd/remove_slice.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2017  David Capello
 //
 // This program is distributed under the terms of
@@ -18,9 +19,9 @@ public:
   RemoveSlice(Sprite* sprite, Slice* slice);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onRedo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onRedo(Context* ctx) override;
 };
 
 }} // namespace app::cmd

--- a/src/app/cmd/remove_tag.cpp
+++ b/src/app/cmd/remove_tag.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -19,19 +19,19 @@ RemoveTag::RemoveTag(Sprite* sprite, Tag* tag) : AddTag(sprite, tag)
 {
 }
 
-void RemoveTag::onExecute()
+void RemoveTag::onExecute(Context* ctx)
 {
-  AddTag::onUndo();
+  AddTag::onUndo(ctx);
 }
 
-void RemoveTag::onUndo()
+void RemoveTag::onUndo(Context* ctx)
 {
-  AddTag::onRedo();
+  AddTag::onRedo(ctx);
 }
 
-void RemoveTag::onRedo()
+void RemoveTag::onRedo(Context* ctx)
 {
-  AddTag::onUndo();
+  AddTag::onUndo(ctx);
 }
 
 }} // namespace app::cmd

--- a/src/app/cmd/remove_tag.h
+++ b/src/app/cmd/remove_tag.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -19,9 +19,9 @@ public:
   RemoveTag(Sprite* sprite, Tag* tag);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onRedo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onRedo(Context* ctx) override;
 };
 
 }} // namespace app::cmd

--- a/src/app/cmd/remove_tile.cpp
+++ b/src/app/cmd/remove_tile.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -21,19 +21,19 @@ RemoveTile::RemoveTile(Tileset* tileset, const tile_index ti) : AddTile(tileset,
 {
 }
 
-void RemoveTile::onExecute()
+void RemoveTile::onExecute(Context* ctx)
 {
-  AddTile::onUndo();
+  AddTile::onUndo(ctx);
 }
 
-void RemoveTile::onUndo()
+void RemoveTile::onUndo(Context* ctx)
 {
-  AddTile::onRedo();
+  AddTile::onRedo(ctx);
 }
 
-void RemoveTile::onRedo()
+void RemoveTile::onRedo(Context* ctx)
 {
-  AddTile::onUndo();
+  AddTile::onUndo(ctx);
 }
 
 }} // namespace app::cmd

--- a/src/app/cmd/remove_tile.h
+++ b/src/app/cmd/remove_tile.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -18,9 +18,9 @@ public:
   RemoveTile(Tileset* tileset, const tile_index ti);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onRedo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onRedo(Context* ctx) override;
 };
 
 }} // namespace app::cmd

--- a/src/app/cmd/remove_tileset.cpp
+++ b/src/app/cmd/remove_tileset.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -21,19 +21,19 @@ RemoveTileset::RemoveTileset(Sprite* sprite, const tileset_index si) : AddTilese
 {
 }
 
-void RemoveTileset::onExecute()
+void RemoveTileset::onExecute(Context* ctx)
 {
-  AddTileset::onUndo();
+  AddTileset::onUndo(ctx);
 }
 
-void RemoveTileset::onUndo()
+void RemoveTileset::onUndo(Context* ctx)
 {
-  AddTileset::onRedo();
+  AddTileset::onRedo(ctx);
 }
 
-void RemoveTileset::onRedo()
+void RemoveTileset::onRedo(Context* ctx)
 {
-  AddTileset::onUndo();
+  AddTileset::onUndo(ctx);
 }
 
 }} // namespace app::cmd

--- a/src/app/cmd/remove_tileset.h
+++ b/src/app/cmd/remove_tileset.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -18,9 +18,9 @@ public:
   RemoveTileset(Sprite* sprite, const tileset_index si);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onRedo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onRedo(Context* ctx) override;
 };
 
 }} // namespace app::cmd

--- a/src/app/cmd/replace_image.cpp
+++ b/src/app/cmd/replace_image.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2023-2026  Igara Studio S.A.
+// Copyright (C) 2023-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -30,7 +30,7 @@ ReplaceImage::ReplaceImage(Sprite* sprite, const ImageRef& oldImage, const Image
 {
 }
 
-void ReplaceImage::onExecute()
+void ReplaceImage::onExecute(Context* ctx)
 {
   // Save old image in m_copy. We cannot keep an ImageRef to this
   // image, because there are other undo branches that could try to
@@ -43,7 +43,7 @@ void ReplaceImage::onExecute()
   m_newImage.reset();
 }
 
-void ReplaceImage::onUndo()
+void ReplaceImage::onUndo(Context* ctx)
 {
   ImageRef newImage = sprite()->getImageRef(m_newImageId);
   ASSERT(newImage);
@@ -54,7 +54,7 @@ void ReplaceImage::onUndo()
   m_copy.reset(Image::createCopy(newImage.get()));
 }
 
-void ReplaceImage::onRedo()
+void ReplaceImage::onRedo(Context* ctx)
 {
   ImageRef oldImage = sprite()->getImageRef(m_oldImageId);
   ASSERT(oldImage);

--- a/src/app/cmd/replace_image.h
+++ b/src/app/cmd/replace_image.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -21,9 +22,9 @@ public:
   ReplaceImage(Sprite* sprite, const ImageRef& oldImage, const ImageRef& newImage);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onRedo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onRedo(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this) + (m_copy ? m_copy->getMemSize() : 0); }
 
 private:
@@ -33,7 +34,7 @@ private:
   ObjectId m_newImageId;
 
   // Reference used only to keep the copy of the new image from the
-  // ReplaceImage() ctor until the ReplaceImage::onExecute() call.
+  // ReplaceImage() ctor until the ReplaceImage::onExecute(Context* ctx) call.
   // Then the reference is not used anymore.
   ImageRef m_newImage;
   ImageRef m_copy;

--- a/src/app/cmd/replace_tileset.cpp
+++ b/src/app/cmd/replace_tileset.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2021-2025  Igara Studio S.A.
+// Copyright (C) 2021-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -29,7 +29,7 @@ ReplaceTileset::ReplaceTileset(doc::Sprite* sprite,
 {
 }
 
-void ReplaceTileset::onExecute()
+void ReplaceTileset::onExecute(Context* ctx)
 {
   Sprite* spr = sprite();
   doc::Tileset* actualTileset = spr->tilesets()->get(m_tsi);

--- a/src/app/cmd/replace_tileset.h
+++ b/src/app/cmd/replace_tileset.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2021-2025  Igara Studio S.A.
+// Copyright (C) 2021-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -21,9 +21,9 @@ public:
   ReplaceTileset(doc::Sprite* sprite, const doc::tileset_index tsi, doc::Tileset* newTileset);
 
 protected:
-  void onExecute() override;
-  void onUndo() override { onExecute(); }
-  void onRedo() override { onExecute(); }
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override { onExecute(ctx); }
+  void onRedo(Context* ctx) override { onExecute(ctx); }
   size_t onMemSize() const override { return sizeof(*this) + m_suspendedTileset.size(); }
 
 private:

--- a/src/app/cmd/reselect_mask.cpp
+++ b/src/app/cmd/reselect_mask.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -21,7 +21,7 @@ ReselectMask::ReselectMask(Doc* doc) : WithDocument(doc)
 {
 }
 
-void ReselectMask::onExecute()
+void ReselectMask::onExecute(Context* ctx)
 {
   Doc* doc = document();
 
@@ -34,7 +34,7 @@ void ReselectMask::onExecute()
   doc->notifySelectionChanged();
 }
 
-void ReselectMask::onUndo()
+void ReselectMask::onUndo(Context* ctx)
 {
   Doc* doc = document();
 

--- a/src/app/cmd/reselect_mask.h
+++ b/src/app/cmd/reselect_mask.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -26,8 +27,8 @@ public:
   ReselectMask(Doc* doc);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
   size_t onMemSize() const override;
 
 private:

--- a/src/app/cmd/set_cel_bounds.cpp
+++ b/src/app/cmd/set_cel_bounds.cpp
@@ -26,12 +26,12 @@ SetCelBoundsF::SetCelBoundsF(Cel* cel, const gfx::RectF& bounds)
 {
 }
 
-void SetCelBoundsF::onExecute()
+void SetCelBoundsF::onExecute(Context* ctx)
 {
   setBounds(m_newBounds);
 }
 
-void SetCelBoundsF::onUndo()
+void SetCelBoundsF::onUndo(Context* ctx)
 {
   setBounds(m_oldBounds);
 }

--- a/src/app/cmd/set_cel_bounds.h
+++ b/src/app/cmd/set_cel_bounds.h
@@ -22,8 +22,8 @@ public:
   SetCelBoundsF(Cel* cel, const gfx::RectF& bounds);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this); }
 
 private:

--- a/src/app/cmd/set_cel_data.cpp
+++ b/src/app/cmd/set_cel_data.cpp
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -29,7 +30,7 @@ SetCelData::SetCelData(Cel* cel, const CelDataRef& newData)
 {
 }
 
-void SetCelData::onExecute()
+void SetCelData::onExecute(Context* ctx)
 {
   Cel* cel = this->cel();
   if (!cel->links())
@@ -40,7 +41,7 @@ void SetCelData::onExecute()
   m_newData.reset();
 }
 
-void SetCelData::onUndo()
+void SetCelData::onUndo(Context* ctx)
 {
   Cel* cel = this->cel();
 
@@ -62,7 +63,7 @@ void SetCelData::onUndo()
   cel->incrementVersion();
 }
 
-void SetCelData::onRedo()
+void SetCelData::onRedo(Context* ctx)
 {
   Cel* cel = this->cel();
   if (!cel->links())

--- a/src/app/cmd/set_cel_data.h
+++ b/src/app/cmd/set_cel_data.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -21,9 +22,9 @@ public:
   SetCelData(Cel* cel, const CelDataRef& newData);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onRedo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onRedo(Context* ctx) override;
   size_t onMemSize() const override
   {
     return sizeof(*this) + (m_dataCopy ? m_dataCopy->getMemSize() : 0);
@@ -38,7 +39,7 @@ private:
   CelDataRef m_dataCopy;
 
   // Reference used only to keep the copy of the new CelData from
-  // the SetCelData() ctor until the SetCelData::onExecute() call.
+  // the SetCelData() ctor until the SetCelData::onExecute(Context* ctx) call.
   // Then the reference is not used anymore.
   CelDataRef m_newData;
 };

--- a/src/app/cmd/set_cel_frame.cpp
+++ b/src/app/cmd/set_cel_frame.cpp
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -27,21 +28,21 @@ SetCelFrame::SetCelFrame(Cel* cel, frame_t frame)
 {
 }
 
-void SetCelFrame::onExecute()
+void SetCelFrame::onExecute(Context* ctx)
 {
   Cel* cel = this->cel();
   cel->layer()->moveCel(cel, m_newFrame);
   cel->incrementVersion();
 }
 
-void SetCelFrame::onUndo()
+void SetCelFrame::onUndo(Context* ctx)
 {
   Cel* cel = this->cel();
   cel->layer()->moveCel(cel, m_oldFrame);
   cel->incrementVersion();
 }
 
-void SetCelFrame::onFireNotifications()
+void SetCelFrame::onFireNotifications(Context* ctx)
 {
   Cel* cel = this->cel();
   Doc* doc = static_cast<Doc*>(cel->sprite()->document());

--- a/src/app/cmd/set_cel_frame.h
+++ b/src/app/cmd/set_cel_frame.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -21,9 +22,9 @@ public:
   SetCelFrame(Cel* cel, frame_t frame);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onFireNotifications() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onFireNotifications(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this); }
 
 private:

--- a/src/app/cmd/set_cel_image.cpp
+++ b/src/app/cmd/set_cel_image.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2025-2026  Igara Studio S.A.
+// Copyright (C) 2025-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -23,7 +23,7 @@ SetCelImage::SetCelImage(Cel* cel, const ImageRef& newImage)
 {
 }
 
-void SetCelImage::onExecute()
+void SetCelImage::onExecute(Context* ctx)
 {
   Cel* cel = this->cel();
   ImageRef oldImage = cel->imageRef();
@@ -37,7 +37,7 @@ void SetCelImage::onExecute()
   m_newImage.reset();
 }
 
-void SetCelImage::onUndo()
+void SetCelImage::onUndo(Context* ctx)
 {
   Cel* cel = this->cel();
   ImageRef currentImage = cel->imageRef();
@@ -56,9 +56,9 @@ void SetCelImage::onUndo()
     m_suspendedImage.suspend(currentImage);
 }
 
-void SetCelImage::onRedo()
+void SetCelImage::onRedo(Context* ctx)
 {
-  onUndo();
+  onUndo(ctx);
 }
 
 }} // namespace app::cmd

--- a/src/app/cmd/set_cel_image.h
+++ b/src/app/cmd/set_cel_image.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2025-2026  Igara Studio S.A.
+// Copyright (C) 2025-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -23,9 +23,9 @@ public:
   SetCelImage(doc::Cel* cel, const doc::ImageRef& newImage);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onRedo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onRedo(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this); }
 
 private:

--- a/src/app/cmd/set_cel_opacity.cpp
+++ b/src/app/cmd/set_cel_opacity.cpp
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -25,19 +26,19 @@ SetCelOpacity::SetCelOpacity(Cel* cel, int opacity)
 {
 }
 
-void SetCelOpacity::onExecute()
+void SetCelOpacity::onExecute(Context* ctx)
 {
   cel()->setOpacity(m_newOpacity);
   cel()->data()->incrementVersion();
 }
 
-void SetCelOpacity::onUndo()
+void SetCelOpacity::onUndo(Context* ctx)
 {
   cel()->setOpacity(m_oldOpacity);
   cel()->data()->incrementVersion();
 }
 
-void SetCelOpacity::onFireNotifications()
+void SetCelOpacity::onFireNotifications(Context* ctx)
 {
   Cel* cel = this->cel();
   Doc* doc = static_cast<Doc*>(cel->document());

--- a/src/app/cmd/set_cel_opacity.h
+++ b/src/app/cmd/set_cel_opacity.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -20,9 +21,9 @@ public:
   SetCelOpacity(Cel* cel, int opacity);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onFireNotifications() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onFireNotifications(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this); }
 
 private:

--- a/src/app/cmd/set_cel_position.cpp
+++ b/src/app/cmd/set_cel_position.cpp
@@ -26,12 +26,12 @@ SetCelPosition::SetCelPosition(Cel* cel, const gfx::Point& newPosition)
 {
 }
 
-void SetCelPosition::onExecute()
+void SetCelPosition::onExecute(Context* ctx)
 {
   setPosition(m_new);
 }
 
-void SetCelPosition::onUndo()
+void SetCelPosition::onUndo(Context* ctx)
 {
   setPosition(m_old);
 }

--- a/src/app/cmd/set_cel_position.h
+++ b/src/app/cmd/set_cel_position.h
@@ -23,8 +23,8 @@ public:
   SetCelPosition(Cel* cel, int x, int y) : SetCelPosition(cel, gfx::Point(x, y)) {}
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this); }
 
 private:

--- a/src/app/cmd/set_cel_zindex.cpp
+++ b/src/app/cmd/set_cel_zindex.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2023  Igara Studio S.A.
+// Copyright (C) 2023-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -25,19 +25,19 @@ SetCelZIndex::SetCelZIndex(Cel* cel, int zindex)
 {
 }
 
-void SetCelZIndex::onExecute()
+void SetCelZIndex::onExecute(Context* ctx)
 {
   cel()->setZIndex(m_newZIndex);
   cel()->incrementVersion();
 }
 
-void SetCelZIndex::onUndo()
+void SetCelZIndex::onUndo(Context* ctx)
 {
   cel()->setZIndex(m_oldZIndex);
   cel()->incrementVersion();
 }
 
-void SetCelZIndex::onFireNotifications()
+void SetCelZIndex::onFireNotifications(Context* ctx)
 {
   Cel* cel = this->cel();
   Doc* doc = static_cast<Doc*>(cel->document());

--- a/src/app/cmd/set_cel_zindex.h
+++ b/src/app/cmd/set_cel_zindex.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2023  Igara Studio S.A.
+// Copyright (C) 2023-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -20,9 +20,9 @@ public:
   SetCelZIndex(Cel* cel, int zindex);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onFireNotifications() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onFireNotifications(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this); }
 
 private:

--- a/src/app/cmd/set_frame_duration.cpp
+++ b/src/app/cmd/set_frame_duration.cpp
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -24,19 +25,19 @@ SetFrameDuration::SetFrameDuration(Sprite* sprite, frame_t frame, int duration)
 {
 }
 
-void SetFrameDuration::onExecute()
+void SetFrameDuration::onExecute(Context* ctx)
 {
   sprite()->setFrameDuration(m_frame, m_newDuration);
   sprite()->incrementVersion();
 }
 
-void SetFrameDuration::onUndo()
+void SetFrameDuration::onUndo(Context* ctx)
 {
   sprite()->setFrameDuration(m_frame, m_oldDuration);
   sprite()->incrementVersion();
 }
 
-void SetFrameDuration::onFireNotifications()
+void SetFrameDuration::onFireNotifications(Context* ctx)
 {
   Sprite* sprite = this->sprite();
   Doc* doc = static_cast<Doc*>(sprite->document());

--- a/src/app/cmd/set_frame_duration.h
+++ b/src/app/cmd/set_frame_duration.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -21,9 +22,9 @@ public:
   SetFrameDuration(Sprite* sprite, frame_t frame, int duration);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onFireNotifications() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onFireNotifications(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this); }
 
 private:

--- a/src/app/cmd/set_grid_bounds.cpp
+++ b/src/app/cmd/set_grid_bounds.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -27,12 +27,12 @@ SetGridBounds::SetGridBounds(Sprite* sprite, const gfx::Rect& bounds)
 {
 }
 
-void SetGridBounds::onExecute()
+void SetGridBounds::onExecute(Context* ctx)
 {
   setGrid(m_newBounds);
 }
 
-void SetGridBounds::onUndo()
+void SetGridBounds::onUndo(Context* ctx)
 {
   setGrid(m_oldBounds);
 }
@@ -49,7 +49,7 @@ void SetGridBounds::setGrid(const gfx::Rect& grid)
   spr->incrementVersion();
 }
 
-void SetGridBounds::onFireNotifications()
+void SetGridBounds::onFireNotifications(Context* ctx)
 {
   Sprite* sprite = this->sprite();
   Doc* doc = static_cast<Doc*>(sprite->document());

--- a/src/app/cmd/set_grid_bounds.h
+++ b/src/app/cmd/set_grid_bounds.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -24,9 +24,9 @@ public:
   SetGridBounds(doc::Sprite* sprite, const gfx::Rect& bounds);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onFireNotifications() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onFireNotifications(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this); }
 
 private:

--- a/src/app/cmd/set_last_point.cpp
+++ b/src/app/cmd/set_last_point.cpp
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2017  David Capello
 //
 // This program is distributed under the terms of
@@ -21,12 +22,12 @@ SetLastPoint::SetLastPoint(Doc* doc, const gfx::Point& pos)
 {
 }
 
-void SetLastPoint::onExecute()
+void SetLastPoint::onExecute(Context* ctx)
 {
   setLastPoint(m_newPoint);
 }
 
-void SetLastPoint::onUndo()
+void SetLastPoint::onUndo(Context* ctx)
 {
   setLastPoint(m_oldPoint);
 }

--- a/src/app/cmd/set_last_point.h
+++ b/src/app/cmd/set_last_point.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2017  David Capello
 //
 // This program is distributed under the terms of
@@ -21,8 +22,8 @@ public:
   SetLastPoint(Doc* doc, const gfx::Point& pos);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this); }
 
 private:

--- a/src/app/cmd/set_layer_blend_mode.cpp
+++ b/src/app/cmd/set_layer_blend_mode.cpp
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -24,19 +25,19 @@ SetLayerBlendMode::SetLayerBlendMode(LayerImage* layer, BlendMode blendMode)
 {
 }
 
-void SetLayerBlendMode::onExecute()
+void SetLayerBlendMode::onExecute(Context* ctx)
 {
   static_cast<LayerImage*>(layer())->setBlendMode(m_newBlendMode);
   layer()->incrementVersion();
 }
 
-void SetLayerBlendMode::onUndo()
+void SetLayerBlendMode::onUndo(Context* ctx)
 {
   static_cast<LayerImage*>(layer())->setBlendMode(m_oldBlendMode);
   layer()->incrementVersion();
 }
 
-void SetLayerBlendMode::onFireNotifications()
+void SetLayerBlendMode::onFireNotifications(Context* ctx)
 {
   Layer* layer = this->layer();
   Doc* doc = static_cast<Doc*>(layer->sprite()->document());

--- a/src/app/cmd/set_layer_blend_mode.h
+++ b/src/app/cmd/set_layer_blend_mode.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -25,9 +26,9 @@ public:
   SetLayerBlendMode(LayerImage* layer, BlendMode blendMode);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onFireNotifications() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onFireNotifications(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this); }
 
 private:

--- a/src/app/cmd/set_layer_flags.cpp
+++ b/src/app/cmd/set_layer_flags.cpp
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -19,13 +20,13 @@ SetLayerFlags::SetLayerFlags(Layer* layer, LayerFlags flags)
 {
 }
 
-void SetLayerFlags::onExecute()
+void SetLayerFlags::onExecute(Context* ctx)
 {
   layer()->setFlags(m_newFlags);
   layer()->incrementVersion();
 }
 
-void SetLayerFlags::onUndo()
+void SetLayerFlags::onUndo(Context* ctx)
 {
   layer()->setFlags(m_oldFlags);
   layer()->incrementVersion();

--- a/src/app/cmd/set_layer_flags.h
+++ b/src/app/cmd/set_layer_flags.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -21,8 +22,8 @@ public:
   SetLayerFlags(Layer* layer, LayerFlags flags);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this); }
 
 private:

--- a/src/app/cmd/set_layer_name.cpp
+++ b/src/app/cmd/set_layer_name.cpp
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -24,19 +25,19 @@ SetLayerName::SetLayerName(Layer* layer, const std::string& name)
 {
 }
 
-void SetLayerName::onExecute()
+void SetLayerName::onExecute(Context* ctx)
 {
   layer()->setName(m_newName);
   layer()->incrementVersion();
 }
 
-void SetLayerName::onUndo()
+void SetLayerName::onUndo(Context* ctx)
 {
   layer()->setName(m_oldName);
   layer()->incrementVersion();
 }
 
-void SetLayerName::onFireNotifications()
+void SetLayerName::onFireNotifications(Context* ctx)
 {
   Layer* layer = this->layer();
   Doc* doc = static_cast<Doc*>(layer->sprite()->document());

--- a/src/app/cmd/set_layer_name.h
+++ b/src/app/cmd/set_layer_name.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -22,9 +23,9 @@ public:
   SetLayerName(Layer* layer, const std::string& name);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onFireNotifications() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onFireNotifications(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this); }
 
 private:

--- a/src/app/cmd/set_layer_opacity.cpp
+++ b/src/app/cmd/set_layer_opacity.cpp
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -24,19 +25,19 @@ SetLayerOpacity::SetLayerOpacity(LayerImage* layer, int opacity)
 {
 }
 
-void SetLayerOpacity::onExecute()
+void SetLayerOpacity::onExecute(Context* ctx)
 {
   static_cast<LayerImage*>(layer())->setOpacity(m_newOpacity);
   layer()->incrementVersion();
 }
 
-void SetLayerOpacity::onUndo()
+void SetLayerOpacity::onUndo(Context* ctx)
 {
   static_cast<LayerImage*>(layer())->setOpacity(m_oldOpacity);
   layer()->incrementVersion();
 }
 
-void SetLayerOpacity::onFireNotifications()
+void SetLayerOpacity::onFireNotifications(Context* ctx)
 {
   Layer* layer = this->layer();
   Doc* doc = static_cast<Doc*>(layer->sprite()->document());

--- a/src/app/cmd/set_layer_opacity.h
+++ b/src/app/cmd/set_layer_opacity.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -24,9 +25,9 @@ public:
   SetLayerOpacity(LayerImage* layer, int opacity);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onFireNotifications() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onFireNotifications(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this); }
 
 private:

--- a/src/app/cmd/set_layer_tileset.cpp
+++ b/src/app/cmd/set_layer_tileset.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2023  Igara Studio S.A.
+// Copyright (C) 2023-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -24,21 +24,21 @@ SetLayerTileset::SetLayerTileset(doc::LayerTilemap* layer, doc::tileset_index ne
 {
 }
 
-void SetLayerTileset::onExecute()
+void SetLayerTileset::onExecute(Context* ctx)
 {
   auto layer = static_cast<LayerTilemap*>(this->layer());
   layer->setTilesetIndex(m_newTsi);
   layer->incrementVersion();
 }
 
-void SetLayerTileset::onUndo()
+void SetLayerTileset::onUndo(Context* ctx)
 {
   auto layer = static_cast<LayerTilemap*>(this->layer());
   layer->setTilesetIndex(m_oldTsi);
   layer->incrementVersion();
 }
 
-void SetLayerTileset::onFireNotifications()
+void SetLayerTileset::onFireNotifications(Context* ctx)
 {
   auto layer = static_cast<LayerTilemap*>(this->layer());
   Doc* doc = static_cast<Doc*>(layer->sprite()->document());

--- a/src/app/cmd/set_layer_tileset.h
+++ b/src/app/cmd/set_layer_tileset.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2023  Igara Studio S.A.
+// Copyright (C) 2023-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -25,9 +25,9 @@ public:
   SetLayerTileset(doc::LayerTilemap* layer, doc::tileset_index tsi);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onFireNotifications() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onFireNotifications(Context* ctx) override;
 
   size_t onMemSize() const override { return sizeof(*this); }
 

--- a/src/app/cmd/set_mask.cpp
+++ b/src/app/cmd/set_mask.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -29,12 +29,12 @@ void SetMask::setNewMask(const Mask* newMask)
   setMask(m_newMask.get());
 }
 
-void SetMask::onExecute()
+void SetMask::onExecute(Context* ctx)
 {
   setMask(m_newMask.get());
 }
 
-void SetMask::onUndo()
+void SetMask::onUndo(Context* ctx)
 {
   setMask(m_oldMask.get());
 }

--- a/src/app/cmd/set_mask.h
+++ b/src/app/cmd/set_mask.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2025  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -30,8 +30,8 @@ public:
   void setNewMask(const Mask* newMask);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
   size_t onMemSize() const override;
 
 private:

--- a/src/app/cmd/set_mask_position.cpp
+++ b/src/app/cmd/set_mask_position.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -23,12 +23,12 @@ SetMaskPosition::SetMaskPosition(Doc* doc, const gfx::Point& pos)
 {
 }
 
-void SetMaskPosition::onExecute()
+void SetMaskPosition::onExecute(Context* ctx)
 {
   setMaskPosition(m_newPosition);
 }
 
-void SetMaskPosition::onUndo()
+void SetMaskPosition::onUndo(Context* ctx)
 {
   setMaskPosition(m_oldPosition);
 }

--- a/src/app/cmd/set_mask_position.h
+++ b/src/app/cmd/set_mask_position.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -21,8 +22,8 @@ public:
   SetMaskPosition(Doc* doc, const gfx::Point& pos);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this); }
 
 private:

--- a/src/app/cmd/set_palette.cpp
+++ b/src/app/cmd/set_palette.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2021  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -67,7 +67,7 @@ SetPalette::SetPalette(Sprite* sprite, frame_t frame, const Palette* newPalette)
   }
 }
 
-void SetPalette::onExecute()
+void SetPalette::onExecute(Context* ctx)
 {
   Sprite* sprite = this->sprite();
   Palette* palette = sprite->palette(m_frame);
@@ -82,7 +82,7 @@ void SetPalette::onExecute()
   palette->incrementVersion();
 }
 
-void SetPalette::onUndo()
+void SetPalette::onUndo(Context* ctx)
 {
   Sprite* sprite = this->sprite();
   Palette* palette = sprite->palette(m_frame);
@@ -97,7 +97,7 @@ void SetPalette::onUndo()
   palette->incrementVersion();
 }
 
-void SetPalette::onFireNotifications()
+void SetPalette::onFireNotifications(Context* ctx)
 {
   doc::Sprite* sprite = this->sprite();
   Doc* doc = static_cast<Doc*>(sprite->document());

--- a/src/app/cmd/set_palette.h
+++ b/src/app/cmd/set_palette.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2021  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -30,9 +30,9 @@ public:
   SetPalette(Sprite* sprite, frame_t frame, const Palette* newPalette);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onFireNotifications() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onFireNotifications(Context* ctx) override;
   size_t onMemSize() const override
   {
     return sizeof(*this) + sizeof(doc::color_t) * (m_oldColors.size() + m_newColors.size());

--- a/src/app/cmd/set_pixel_format.cpp
+++ b/src/app/cmd/set_pixel_format.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2026  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -16,6 +16,7 @@
 #include "app/cmd/set_cel_opacity.h"
 #include "app/cmd/set_palette.h"
 #include "app/cmd/set_transparent_color.h"
+#include "app/context.h"
 #include "app/doc.h"
 #include "app/doc_event.h"
 #include "doc/cel.h"
@@ -193,25 +194,25 @@ SetPixelFormat::SetPixelFormat(Sprite* sprite,
   }
 }
 
-void SetPixelFormat::onExecute()
+void SetPixelFormat::onExecute(Context* ctx)
 {
-  m_pre.execute(context());
+  m_pre.execute(ctx);
   setFormat(m_newFormat);
-  m_post.execute(context());
+  m_post.execute(ctx);
 }
 
-void SetPixelFormat::onUndo()
+void SetPixelFormat::onUndo(Context* ctx)
 {
-  m_post.undo();
+  m_post.undo(ctx);
   setFormat(m_oldFormat);
-  m_pre.undo();
+  m_pre.undo(ctx);
 }
 
-void SetPixelFormat::onRedo()
+void SetPixelFormat::onRedo(Context* ctx)
 {
-  m_pre.redo();
+  m_pre.redo(ctx);
   setFormat(m_newFormat);
-  m_post.redo();
+  m_post.redo(ctx);
 }
 
 void SetPixelFormat::setFormat(PixelFormat format)

--- a/src/app/cmd/set_pixel_format.h
+++ b/src/app/cmd/set_pixel_format.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2024  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2017  David Capello
 //
 // This program is distributed under the terms of
@@ -41,9 +41,9 @@ public:
                  const doc::FitCriteria fitCriteria);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onRedo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onRedo(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this) + m_pre.memSize() + m_post.memSize(); }
 
 private:

--- a/src/app/cmd/set_pixel_ratio.cpp
+++ b/src/app/cmd/set_pixel_ratio.cpp
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2016-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -26,21 +27,21 @@ SetPixelRatio::SetPixelRatio(Sprite* sprite, PixelRatio pixelRatio)
 {
 }
 
-void SetPixelRatio::onExecute()
+void SetPixelRatio::onExecute(Context* ctx)
 {
   Sprite* spr = sprite();
   spr->setPixelRatio(m_newRatio);
   spr->incrementVersion();
 }
 
-void SetPixelRatio::onUndo()
+void SetPixelRatio::onUndo(Context* ctx)
 {
   Sprite* spr = sprite();
   spr->setPixelRatio(m_oldRatio);
   spr->incrementVersion();
 }
 
-void SetPixelRatio::onFireNotifications()
+void SetPixelRatio::onFireNotifications(Context* ctx)
 {
   Sprite* sprite = this->sprite();
   Doc* doc = static_cast<Doc*>(sprite->document());

--- a/src/app/cmd/set_pixel_ratio.h
+++ b/src/app/cmd/set_pixel_ratio.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2016  David Capello
 //
 // This program is distributed under the terms of
@@ -25,9 +26,9 @@ public:
   SetPixelRatio(Sprite* sprite, PixelRatio pixelRatio);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onFireNotifications() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onFireNotifications(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this); }
 
 private:

--- a/src/app/cmd/set_slice_key.cpp
+++ b/src/app/cmd/set_slice_key.cpp
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2017  David Capello
 //
 // This program is distributed under the terms of
@@ -26,7 +27,7 @@ SetSliceKey::SetSliceKey(Slice* slice, const doc::frame_t frame, const doc::Slic
     m_oldSliceKey = *it->value();
 }
 
-void SetSliceKey::onExecute()
+void SetSliceKey::onExecute(Context* ctx)
 {
   if (!m_newSliceKey.isEmpty())
     slice()->insert(m_frame, m_newSliceKey);
@@ -37,7 +38,7 @@ void SetSliceKey::onExecute()
   slice()->owner()->sprite()->incrementVersion();
 }
 
-void SetSliceKey::onUndo()
+void SetSliceKey::onUndo(Context* ctx)
 {
   if (!m_oldSliceKey.isEmpty())
     slice()->insert(m_frame, m_oldSliceKey);

--- a/src/app/cmd/set_slice_key.h
+++ b/src/app/cmd/set_slice_key.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2017  David Capello
 //
 // This program is distributed under the terms of
@@ -22,8 +23,8 @@ public:
   SetSliceKey(Slice* slice, const doc::frame_t frame, const doc::SliceKey& sliceKey);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this); }
 
 private:

--- a/src/app/cmd/set_slice_name.cpp
+++ b/src/app/cmd/set_slice_name.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2017-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -26,21 +26,21 @@ SetSliceName::SetSliceName(Slice* slice, const std::string& name)
 {
 }
 
-void SetSliceName::onExecute()
+void SetSliceName::onExecute(Context* ctx)
 {
   Slice* slice = this->slice();
   slice->setName(m_newName);
   slice->incrementVersion();
 }
 
-void SetSliceName::onUndo()
+void SetSliceName::onUndo(Context* ctx)
 {
   Slice* slice = this->slice();
   slice->setName(m_oldName);
   slice->incrementVersion();
 }
 
-void SetSliceName::onFireNotifications()
+void SetSliceName::onFireNotifications(Context* ctx)
 {
   Slice* slice = this->slice();
   Sprite* sprite = slice->owner()->sprite();

--- a/src/app/cmd/set_slice_name.h
+++ b/src/app/cmd/set_slice_name.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2017  David Capello
 //
 // This program is distributed under the terms of
@@ -22,9 +23,9 @@ public:
   SetSliceName(Slice* slice, const std::string& name);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onFireNotifications() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onFireNotifications(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this) + m_oldName.size() + m_newName.size(); }
 
   std::string m_oldName;

--- a/src/app/cmd/set_sprite_size.cpp
+++ b/src/app/cmd/set_sprite_size.cpp
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -27,21 +28,21 @@ SetSpriteSize::SetSpriteSize(Sprite* sprite, int newWidth, int newHeight)
   ASSERT(m_newHeight > 0);
 }
 
-void SetSpriteSize::onExecute()
+void SetSpriteSize::onExecute(Context* ctx)
 {
   Sprite* spr = sprite();
   spr->setSize(m_newWidth, m_newHeight);
   spr->incrementVersion();
 }
 
-void SetSpriteSize::onUndo()
+void SetSpriteSize::onUndo(Context* ctx)
 {
   Sprite* spr = sprite();
   spr->setSize(m_oldWidth, m_oldHeight);
   spr->incrementVersion();
 }
 
-void SetSpriteSize::onFireNotifications()
+void SetSpriteSize::onFireNotifications(Context* ctx)
 {
   Sprite* sprite = this->sprite();
   Doc* doc = static_cast<Doc*>(sprite->document());

--- a/src/app/cmd/set_sprite_size.h
+++ b/src/app/cmd/set_sprite_size.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -20,9 +21,9 @@ public:
   SetSpriteSize(Sprite* sprite, int newWidth, int newHeight);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onFireNotifications() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onFireNotifications(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this); }
 
 private:

--- a/src/app/cmd/set_sprite_tile_management_plugin.cpp
+++ b/src/app/cmd/set_sprite_tile_management_plugin.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (c) 2023  Igara Studio S.A.
+// Copyright (c) 2023-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -24,21 +24,21 @@ SetSpriteTileManagementPlugin::SetSpriteTileManagementPlugin(Sprite* sprite,
 {
 }
 
-void SetSpriteTileManagementPlugin::onExecute()
+void SetSpriteTileManagementPlugin::onExecute(Context* ctx)
 {
   Sprite* spr = sprite();
   spr->setTileManagementPlugin(m_newValue);
   spr->incrementVersion();
 }
 
-void SetSpriteTileManagementPlugin::onUndo()
+void SetSpriteTileManagementPlugin::onUndo(Context* ctx)
 {
   Sprite* spr = sprite();
   spr->setTileManagementPlugin(m_oldValue);
   spr->incrementVersion();
 }
 
-void SetSpriteTileManagementPlugin::onFireNotifications()
+void SetSpriteTileManagementPlugin::onFireNotifications(Context* ctx)
 {
   Sprite* spr = sprite();
   Doc* doc = static_cast<Doc*>(spr->document());

--- a/src/app/cmd/set_sprite_tile_management_plugin.h
+++ b/src/app/cmd/set_sprite_tile_management_plugin.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (c) 2023  Igara Studio S.A.
+// Copyright (c) 2023-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -22,9 +22,9 @@ public:
   SetSpriteTileManagementPlugin(Sprite* sprite, const std::string& value);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onFireNotifications() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onFireNotifications(Context* ctx) override;
   size_t onMemSize() const override
   {
     return sizeof(*this) + m_oldValue.size() + m_newValue.size();

--- a/src/app/cmd/set_tag_anidir.cpp
+++ b/src/app/cmd/set_tag_anidir.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -22,13 +22,13 @@ SetTagAniDir::SetTagAniDir(Tag* tag, doc::AniDir anidir)
 {
 }
 
-void SetTagAniDir::onExecute()
+void SetTagAniDir::onExecute(Context* ctx)
 {
   tag()->setAniDir(m_newAniDir);
   tag()->incrementVersion();
 }
 
-void SetTagAniDir::onUndo()
+void SetTagAniDir::onUndo(Context* ctx)
 {
   tag()->setAniDir(m_oldAniDir);
   tag()->incrementVersion();

--- a/src/app/cmd/set_tag_anidir.h
+++ b/src/app/cmd/set_tag_anidir.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -22,8 +22,8 @@ public:
   SetTagAniDir(Tag* tag, doc::AniDir anidir);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this); }
 
 private:

--- a/src/app/cmd/set_tag_color.cpp
+++ b/src/app/cmd/set_tag_color.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -22,13 +22,13 @@ SetTagColor::SetTagColor(Tag* tag, doc::color_t color)
 {
 }
 
-void SetTagColor::onExecute()
+void SetTagColor::onExecute(Context* ctx)
 {
   tag()->setColor(m_newColor);
   tag()->incrementVersion();
 }
 
-void SetTagColor::onUndo()
+void SetTagColor::onUndo(Context* ctx)
 {
   tag()->setColor(m_oldColor);
   tag()->incrementVersion();

--- a/src/app/cmd/set_tag_color.h
+++ b/src/app/cmd/set_tag_color.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -22,8 +22,8 @@ public:
   SetTagColor(Tag* tag, doc::color_t color);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this); }
 
 private:

--- a/src/app/cmd/set_tag_name.cpp
+++ b/src/app/cmd/set_tag_name.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2022  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -26,19 +26,19 @@ SetTagName::SetTagName(doc::Tag* tag, const std::string& name)
 {
 }
 
-void SetTagName::onExecute()
+void SetTagName::onExecute(Context* ctx)
 {
   tag()->setName(m_newName);
   tag()->incrementVersion();
 }
 
-void SetTagName::onUndo()
+void SetTagName::onUndo(Context* ctx)
 {
   tag()->setName(m_oldName);
   tag()->incrementVersion();
 }
 
-void SetTagName::onFireNotifications()
+void SetTagName::onFireNotifications(Context* ctx)
 {
   Tag* tag = this->tag();
   Sprite* sprite = tag->owner()->sprite();

--- a/src/app/cmd/set_tag_name.h
+++ b/src/app/cmd/set_tag_name.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2022  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -23,9 +23,9 @@ public:
   SetTagName(Tag* tag, const std::string& name);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onFireNotifications() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onFireNotifications(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this); }
 
 private:

--- a/src/app/cmd/set_tag_range.cpp
+++ b/src/app/cmd/set_tag_range.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2020  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -28,19 +28,19 @@ SetTagRange::SetTagRange(Tag* tag, frame_t from, frame_t to)
 {
 }
 
-void SetTagRange::onExecute()
+void SetTagRange::onExecute(Context* ctx)
 {
   tag()->setFrameRange(m_newFrom, m_newTo);
   tag()->incrementVersion();
 }
 
-void SetTagRange::onUndo()
+void SetTagRange::onUndo(Context* ctx)
 {
   tag()->setFrameRange(m_oldFrom, m_oldTo);
   tag()->incrementVersion();
 }
 
-void SetTagRange::onFireNotifications()
+void SetTagRange::onFireNotifications(Context* ctx)
 {
   Tag* tag = this->tag();
   Sprite* sprite = tag->owner()->sprite();

--- a/src/app/cmd/set_tag_range.h
+++ b/src/app/cmd/set_tag_range.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2020  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -22,9 +22,9 @@ public:
   SetTagRange(Tag* tag, frame_t from, frame_t to);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onFireNotifications() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onFireNotifications(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this); }
 
 private:

--- a/src/app/cmd/set_tag_repeat.cpp
+++ b/src/app/cmd/set_tag_repeat.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2021  Igara Studio S.A.
+// Copyright (C) 2021-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -21,13 +21,13 @@ SetTagRepeat::SetTagRepeat(Tag* tag, int repeat)
 {
 }
 
-void SetTagRepeat::onExecute()
+void SetTagRepeat::onExecute(Context* ctx)
 {
   tag()->setRepeat(m_newRepeat);
   tag()->incrementVersion();
 }
 
-void SetTagRepeat::onUndo()
+void SetTagRepeat::onUndo(Context* ctx)
 {
   tag()->setRepeat(m_oldRepeat);
   tag()->incrementVersion();

--- a/src/app/cmd/set_tag_repeat.h
+++ b/src/app/cmd/set_tag_repeat.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2021  Igara Studio S.A.
+// Copyright (C) 2021-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -20,8 +20,8 @@ public:
   SetTagRepeat(Tag* tag, int repeat);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this); }
 
 private:

--- a/src/app/cmd/set_tile_data.cpp
+++ b/src/app/cmd/set_tile_data.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2023  Igara Studio S.A.
+// Copyright (C) 2023-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -22,14 +22,14 @@ SetTileData::SetTileData(doc::Tileset* ts, doc::tile_index ti, const doc::UserDa
 {
 }
 
-void SetTileData::onExecute()
+void SetTileData::onExecute(Context* ctx)
 {
   auto ts = tileset();
   ts->setTileData(m_ti, m_newUserData);
   ts->incrementVersion();
 }
 
-void SetTileData::onUndo()
+void SetTileData::onUndo(Context* ctx)
 {
   auto ts = tileset();
   ts->setTileData(m_ti, m_oldUserData);

--- a/src/app/cmd/set_tile_data.h
+++ b/src/app/cmd/set_tile_data.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2023  Igara Studio S.A.
+// Copyright (C) 2023-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -21,8 +21,8 @@ public:
   SetTileData(doc::Tileset* ts, doc::tile_index ti, const doc::UserData& ud);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
   size_t onMemSize() const override
   {
     return sizeof(*this); // TODO + properties size

--- a/src/app/cmd/set_tile_data_properties.cpp
+++ b/src/app/cmd/set_tile_data_properties.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2023-2025  Igara Studio S.A.
+// Copyright (C) 2023-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -25,7 +25,7 @@ SetTileDataProperties::SetTileDataProperties(doc::Tileset* ts,
 {
 }
 
-void SetTileDataProperties::onExecute()
+void SetTileDataProperties::onExecute(Context* ctx)
 {
   auto ts = tileset();
   auto& properties = ts->getTileData(m_ti).properties(m_group);
@@ -37,9 +37,9 @@ void SetTileDataProperties::onExecute()
   ts->incrementVersion();
 }
 
-void SetTileDataProperties::onUndo()
+void SetTileDataProperties::onUndo(Context* ctx)
 {
-  onExecute();
+  onExecute(ctx);
 }
 
 }} // namespace app::cmd

--- a/src/app/cmd/set_tile_data_properties.h
+++ b/src/app/cmd/set_tile_data_properties.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2023-2025  Igara Studio S.A.
+// Copyright (C) 2023-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -24,8 +24,8 @@ public:
                         doc::UserData::Properties&& newProperties);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
   size_t onMemSize() const override
   {
     return sizeof(*this); // TODO + properties size

--- a/src/app/cmd/set_tile_data_property.cpp
+++ b/src/app/cmd/set_tile_data_property.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2023-2025  Igara Studio S.A.
+// Copyright (C) 2023-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -27,7 +27,7 @@ SetTileDataProperty::SetTileDataProperty(doc::Tileset* ts,
 {
 }
 
-void SetTileDataProperty::onExecute()
+void SetTileDataProperty::onExecute(Context* ctx)
 {
   auto ts = tileset();
   auto& properties = ts->getTileData(m_ti).properties(m_group);
@@ -39,9 +39,9 @@ void SetTileDataProperty::onExecute()
   ts->incrementVersion();
 }
 
-void SetTileDataProperty::onUndo()
+void SetTileDataProperty::onUndo(Context* ctx)
 {
-  onExecute();
+  onExecute(ctx);
 }
 
 }} // namespace app::cmd

--- a/src/app/cmd/set_tile_data_property.h
+++ b/src/app/cmd/set_tile_data_property.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2023-2025  Igara Studio S.A.
+// Copyright (C) 2023-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -25,8 +25,8 @@ public:
                       doc::UserData::Variant&& newValue);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
   size_t onMemSize() const override
   {
     return sizeof(*this); // TODO + variant size

--- a/src/app/cmd/set_tileset_base_index.cpp
+++ b/src/app/cmd/set_tileset_base_index.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2020  Igara Studio S.A.
+// Copyright (C) 2020-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -23,7 +23,7 @@ SetTilesetBaseIndex::SetTilesetBaseIndex(Tileset* tileset, int baseIndex)
 {
 }
 
-void SetTilesetBaseIndex::onExecute()
+void SetTilesetBaseIndex::onExecute(Context* ctx)
 {
   auto ts = tileset();
   ts->setBaseIndex(m_newBaseIndex);
@@ -31,7 +31,7 @@ void SetTilesetBaseIndex::onExecute()
   ts->sprite()->incrementVersion();
 }
 
-void SetTilesetBaseIndex::onUndo()
+void SetTilesetBaseIndex::onUndo(Context* ctx)
 {
   auto ts = tileset();
   ts->setBaseIndex(m_oldBaseIndex);

--- a/src/app/cmd/set_tileset_base_index.h
+++ b/src/app/cmd/set_tileset_base_index.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2020  Igara Studio S.A.
+// Copyright (C) 2020-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -20,8 +20,8 @@ public:
   SetTilesetBaseIndex(Tileset* tileset, int baseIndex);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this); }
 
 private:

--- a/src/app/cmd/set_tileset_match_flags.cpp
+++ b/src/app/cmd/set_tileset_match_flags.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2023  Igara Studio S.A.
+// Copyright (C) 2023-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -23,7 +23,7 @@ SetTilesetMatchFlags::SetTilesetMatchFlags(Tileset* tileset, const tile_flags ma
 {
 }
 
-void SetTilesetMatchFlags::onExecute()
+void SetTilesetMatchFlags::onExecute(Context* ctx)
 {
   auto ts = tileset();
   ts->setMatchFlags(m_newMatchFlags);
@@ -31,7 +31,7 @@ void SetTilesetMatchFlags::onExecute()
   ts->sprite()->incrementVersion();
 }
 
-void SetTilesetMatchFlags::onUndo()
+void SetTilesetMatchFlags::onUndo(Context* ctx)
 {
   auto ts = tileset();
   ts->setMatchFlags(m_oldMatchFlags);

--- a/src/app/cmd/set_tileset_match_flags.h
+++ b/src/app/cmd/set_tileset_match_flags.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2023  Igara Studio S.A.
+// Copyright (C) 2023-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -21,8 +21,8 @@ public:
   SetTilesetMatchFlags(Tileset* tileset, const tile_flags matchFlags);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this); }
 
 private:

--- a/src/app/cmd/set_tileset_name.cpp
+++ b/src/app/cmd/set_tileset_name.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2020  Igara Studio S.A.
+// Copyright (C) 2020-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -23,7 +23,7 @@ SetTilesetName::SetTilesetName(Tileset* tileset, const std::string& name)
 {
 }
 
-void SetTilesetName::onExecute()
+void SetTilesetName::onExecute(Context* ctx)
 {
   auto ts = tileset();
   ts->setName(m_newName);
@@ -31,7 +31,7 @@ void SetTilesetName::onExecute()
   ts->sprite()->incrementVersion();
 }
 
-void SetTilesetName::onUndo()
+void SetTilesetName::onUndo(Context* ctx)
 {
   auto ts = tileset();
   ts->setName(m_oldName);

--- a/src/app/cmd/set_tileset_name.h
+++ b/src/app/cmd/set_tileset_name.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2020  Igara Studio S.A.
+// Copyright (C) 2020-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -22,8 +22,8 @@ public:
   SetTilesetName(Tileset* tileset, const std::string& name);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this); }
 
 private:

--- a/src/app/cmd/set_total_frames.cpp
+++ b/src/app/cmd/set_total_frames.cpp
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -23,21 +24,21 @@ SetTotalFrames::SetTotalFrames(Sprite* sprite, frame_t frames)
 {
 }
 
-void SetTotalFrames::onExecute()
+void SetTotalFrames::onExecute(Context* ctx)
 {
   Sprite* spr = sprite();
   spr->setTotalFrames(m_newFrames);
   spr->incrementVersion();
 }
 
-void SetTotalFrames::onUndo()
+void SetTotalFrames::onUndo(Context* ctx)
 {
   Sprite* spr = sprite();
   spr->setTotalFrames(m_oldFrames);
   spr->incrementVersion();
 }
 
-void SetTotalFrames::onFireNotifications()
+void SetTotalFrames::onFireNotifications(Context* ctx)
 {
   Sprite* sprite = this->sprite();
   Doc* doc = static_cast<Doc*>(sprite->document());

--- a/src/app/cmd/set_total_frames.h
+++ b/src/app/cmd/set_total_frames.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -21,9 +22,9 @@ public:
   SetTotalFrames(Sprite* sprite, frame_t frames);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onFireNotifications() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onFireNotifications(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this); }
 
 private:

--- a/src/app/cmd/set_transparent_color.cpp
+++ b/src/app/cmd/set_transparent_color.cpp
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -23,21 +24,21 @@ SetTransparentColor::SetTransparentColor(Sprite* sprite, color_t newMask)
 {
 }
 
-void SetTransparentColor::onExecute()
+void SetTransparentColor::onExecute(Context* ctx)
 {
   Sprite* spr = sprite();
   spr->setTransparentColor(m_newMaskColor);
   spr->incrementVersion();
 }
 
-void SetTransparentColor::onUndo()
+void SetTransparentColor::onUndo(Context* ctx)
 {
   Sprite* spr = sprite();
   spr->setTransparentColor(m_oldMaskColor);
   spr->incrementVersion();
 }
 
-void SetTransparentColor::onFireNotifications()
+void SetTransparentColor::onFireNotifications(Context* ctx)
 {
   Sprite* sprite = this->sprite();
   auto doc = static_cast<Doc*>(sprite->document());

--- a/src/app/cmd/set_transparent_color.h
+++ b/src/app/cmd/set_transparent_color.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -21,9 +22,9 @@ public:
   SetTransparentColor(Sprite* sprite, color_t newMask);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onFireNotifications() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onFireNotifications(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this); }
 
 private:

--- a/src/app/cmd/set_user_data.cpp
+++ b/src/app/cmd/set_user_data.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2020  Igara Studio S.A.
+// Copyright (C) 2020-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -26,21 +26,21 @@ SetUserData::SetUserData(doc::WithUserData* obj, const doc::UserData& userData, 
 {
 }
 
-void SetUserData::onExecute()
+void SetUserData::onExecute(Context* ctx)
 {
   auto obj = doc::get<doc::WithUserData>(m_objId);
   obj->setUserData(m_newUserData);
   obj->incrementVersion();
 }
 
-void SetUserData::onUndo()
+void SetUserData::onUndo(Context* ctx)
 {
   auto obj = doc::get<doc::WithUserData>(m_objId);
   obj->setUserData(m_oldUserData);
   obj->incrementVersion();
 }
 
-void SetUserData::onFireNotifications()
+void SetUserData::onFireNotifications(Context* ctx)
 {
   auto obj = doc::get<doc::WithUserData>(m_objId);
   app::Doc* doc = document();

--- a/src/app/cmd/set_user_data.h
+++ b/src/app/cmd/set_user_data.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2020  Igara Studio S.A.
+// Copyright (C) 2020-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -26,9 +26,9 @@ public:
   SetUserData(doc::WithUserData* obj, const doc::UserData& userData, app::Doc* doc);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onFireNotifications() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onFireNotifications(Context* ctx) override;
   size_t onMemSize() const override
   {
     return sizeof(*this) + m_oldUserData.size() + m_newUserData.size();

--- a/src/app/cmd/set_user_data_properties.cpp
+++ b/src/app/cmd/set_user_data_properties.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2023-2025  Igara Studio S.A.
+// Copyright (C) 2023-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -23,7 +23,7 @@ SetUserDataProperties::SetUserDataProperties(doc::WithUserData* obj,
 {
 }
 
-void SetUserDataProperties::onExecute()
+void SetUserDataProperties::onExecute(Context* ctx)
 {
   auto obj = doc::get<doc::WithUserData>(m_objId);
   auto& properties = obj->userData().properties(m_group);
@@ -35,9 +35,9 @@ void SetUserDataProperties::onExecute()
   obj->incrementVersion();
 }
 
-void SetUserDataProperties::onUndo()
+void SetUserDataProperties::onUndo(Context* ctx)
 {
-  onExecute();
+  onExecute(ctx);
 }
 
 }} // namespace app::cmd

--- a/src/app/cmd/set_user_data_properties.h
+++ b/src/app/cmd/set_user_data_properties.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2023-2025  Igara Studio S.A.
+// Copyright (C) 2023-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -25,8 +25,8 @@ public:
                         doc::UserData::Properties&& newProperties);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
   size_t onMemSize() const override
   {
     return sizeof(*this); // TODO + properties size

--- a/src/app/cmd/set_user_data_property.cpp
+++ b/src/app/cmd/set_user_data_property.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2023-2025  Igara Studio S.A.
+// Copyright (C) 2023-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -25,7 +25,7 @@ SetUserDataProperty::SetUserDataProperty(doc::WithUserData* obj,
 {
 }
 
-void SetUserDataProperty::onExecute()
+void SetUserDataProperty::onExecute(Context* ctx)
 {
   auto obj = doc::get<doc::WithUserData>(m_objId);
   auto& properties = obj->userData().properties(m_group);
@@ -37,9 +37,9 @@ void SetUserDataProperty::onExecute()
   obj->incrementVersion();
 }
 
-void SetUserDataProperty::onUndo()
+void SetUserDataProperty::onUndo(Context* ctx)
 {
-  onExecute();
+  onExecute(ctx);
 }
 
 }} // namespace app::cmd

--- a/src/app/cmd/set_user_data_property.h
+++ b/src/app/cmd/set_user_data_property.h
@@ -26,8 +26,8 @@ public:
                       doc::UserData::Variant&& newValue);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
   size_t onMemSize() const override
   {
     return sizeof(*this); // TODO + variant size

--- a/src/app/cmd/shift_masked_cel.cpp
+++ b/src/app/cmd/shift_masked_cel.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2026  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -24,12 +24,12 @@ ShiftMaskedCel::ShiftMaskedCel(Cel* cel, int dx, int dy) : WithCel(cel), m_dx(dx
 {
 }
 
-void ShiftMaskedCel::onExecute()
+void ShiftMaskedCel::onExecute(Context* ctx)
 {
   shift(m_dx, m_dy);
 }
 
-void ShiftMaskedCel::onUndo()
+void ShiftMaskedCel::onUndo(Context* ctx)
 {
   shift(-m_dx, -m_dy);
 }

--- a/src/app/cmd/shift_masked_cel.h
+++ b/src/app/cmd/shift_masked_cel.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -20,8 +21,8 @@ public:
   ShiftMaskedCel(Cel* cel, int dx, int dy);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
   size_t onMemSize() const override { return sizeof(*this); }
 
 private:

--- a/src/app/cmd/unlink_cel.cpp
+++ b/src/app/cmd/unlink_cel.cpp
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2016  David Capello
 //
 // This program is distributed under the terms of
@@ -28,7 +29,7 @@ UnlinkCel::UnlinkCel(Cel* cel)
   ASSERT(cel->links());
 }
 
-void UnlinkCel::onExecute()
+void UnlinkCel::onExecute(Context* ctx)
 {
   Cel* cel = this->cel();
   CelDataRef oldCelData = cel->sprite()->getCelDataRef(m_oldCelDataId);
@@ -56,7 +57,7 @@ void UnlinkCel::onExecute()
   cel->incrementVersion();
 }
 
-void UnlinkCel::onUndo()
+void UnlinkCel::onUndo(Context* ctx)
 {
   Cel* cel = this->cel();
   CelDataRef oldCelData = cel->sprite()->getCelDataRef(m_oldCelDataId);

--- a/src/app/cmd/unlink_cel.h
+++ b/src/app/cmd/unlink_cel.h
@@ -1,4 +1,5 @@
 // Aseprite
+// Copyright (C) 2026-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -20,8 +21,8 @@ public:
   UnlinkCel(Cel* cel);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
 
 private:
   ObjectId m_newImageId;

--- a/src/app/cmd_sequence.cpp
+++ b/src/app/cmd_sequence.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2023  Igara Studio S.A.
+// Copyright (C) 2023-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -10,6 +10,8 @@
 #endif
 
 #include "app/cmd_sequence.h"
+
+#include "app/context.h"
 
 namespace app {
 
@@ -52,22 +54,22 @@ void CmdSequence::addAndExecute(Context* ctx, Cmd* cmd)
   }
 }
 
-void CmdSequence::onExecute()
+void CmdSequence::onExecute(Context* ctx)
 {
   for (auto it = m_cmds.begin(), end = m_cmds.end(); it != end; ++it)
-    (*it)->execute(context());
+    (*it)->execute(ctx);
 }
 
-void CmdSequence::onUndo()
+void CmdSequence::onUndo(Context* ctx)
 {
   for (auto it = m_cmds.rbegin(), end = m_cmds.rend(); it != end; ++it)
-    (*it)->undo();
+    (*it)->undo(ctx);
 }
 
-void CmdSequence::onRedo()
+void CmdSequence::onRedo(Context* ctx)
 {
   for (auto it = m_cmds.begin(), end = m_cmds.end(); it != end; ++it)
-    (*it)->redo();
+    (*it)->redo(ctx);
 }
 
 size_t CmdSequence::onMemSize() const
@@ -80,9 +82,9 @@ size_t CmdSequence::onMemSize() const
   return size;
 }
 
-void CmdSequence::executeAndAdd(Cmd* cmd)
+void CmdSequence::executeAndAdd(Context* ctx, Cmd* cmd)
 {
-  addAndExecute(context(), cmd);
+  addAndExecute(ctx, cmd);
 }
 
 } // namespace app

--- a/src/app/cmd_sequence.h
+++ b/src/app/cmd_sequence.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2023  Igara Studio S.A.
+// Copyright (C) 2023-present  Igara Studio S.A.
 // Copyright (C) 2001-2015  David Capello
 //
 // This program is distributed under the terms of
@@ -25,12 +25,12 @@ public:
 
   // Helper to create a CmdSequence in the same onExecute() member
   // function.
-  void executeAndAdd(Cmd* cmd);
+  void executeAndAdd(Context* ctx, Cmd* cmd);
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onRedo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onRedo(Context* ctx) override;
   size_t onMemSize() const override;
 
 private:

--- a/src/app/cmd_transaction.cpp
+++ b/src/app/cmd_transaction.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2023  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -43,9 +43,9 @@ void CmdTransaction::setNewDocRange(const view::RealRange& range)
     range.write(m_ranges->m_after);
 }
 
-void CmdTransaction::updateSpritePositionAfter()
+void CmdTransaction::updateSpritePositionAfter(Context* ctx)
 {
-  m_spritePositionAfter = calcSpritePosition();
+  m_spritePositionAfter = calcSpritePosition(ctx);
 
   // We cannot capture m_ranges->m_after from the Timeline here
   // because the document range in the Timeline is updated after the
@@ -75,27 +75,27 @@ std::istream* CmdTransaction::documentRangeAfterExecute() const
     return nullptr;
 }
 
-void CmdTransaction::onExecute()
+void CmdTransaction::onExecute(Context* ctx)
 {
   // Save the current site and doc range
-  m_spritePositionBefore = calcSpritePosition();
-  if (isDocRangeEnabled()) {
+  m_spritePositionBefore = calcSpritePosition(ctx);
+  if (isDocRangeEnabled(ctx)) {
     m_ranges.reset(new Ranges);
-    calcDocRange().write(m_ranges->m_before);
+    calcDocRange(ctx).write(m_ranges->m_before);
   }
 
   // Execute the sequence of "cmds"
-  CmdSequence::onExecute();
+  CmdSequence::onExecute(ctx);
 }
 
-void CmdTransaction::onUndo()
+void CmdTransaction::onUndo(Context* ctx)
 {
-  CmdSequence::onUndo();
+  CmdSequence::onUndo(ctx);
 }
 
-void CmdTransaction::onRedo()
+void CmdTransaction::onRedo(Context* ctx)
 {
-  CmdSequence::onRedo();
+  CmdSequence::onRedo(ctx);
 }
 
 std::string CmdTransaction::onLabel() const
@@ -112,26 +112,26 @@ size_t CmdTransaction::onMemSize() const
   return size;
 }
 
-SpritePosition CmdTransaction::calcSpritePosition() const
+SpritePosition CmdTransaction::calcSpritePosition(Context* ctx) const
 {
   // This check was added to allow executing transactions on documents that are
   // not part of any context. For instance, when dragging and dropping a
   // document on the timeline, the dragged document doesn't have any context (
   // it is not associated with any editor).
-  if (!context())
+  if (!ctx)
     return SpritePosition();
-  Site site = context()->activeSite();
+  Site site = ctx->activeSite();
   return SpritePosition(site.layer(), site.frame());
 }
 
-bool CmdTransaction::isDocRangeEnabled() const
+bool CmdTransaction::isDocRangeEnabled(Context* ctx) const
 {
-  return (context() ? context()->range().enabled() : false);
+  return (ctx ? ctx->range().enabled() : false);
 }
 
-view::RealRange CmdTransaction::calcDocRange() const
+view::RealRange CmdTransaction::calcDocRange(Context* ctx) const
 {
-  return (context() ? context()->range() : view::RealRange());
+  return (ctx ? ctx->range() : view::RealRange());
 }
 
 } // namespace app

--- a/src/app/cmd_transaction.h
+++ b/src/app/cmd_transaction.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2023  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -32,7 +32,7 @@ public:
   CmdTransaction* moveToEmptyCopy();
 
   void setNewDocRange(const view::RealRange& range);
-  void updateSpritePositionAfter();
+  void updateSpritePositionAfter(Context* ctx);
 
   SpritePosition spritePositionBeforeExecute() const { return m_spritePositionBefore; }
   SpritePosition spritePositionAfterExecute() const { return m_spritePositionAfter; }
@@ -41,16 +41,16 @@ public:
   std::istream* documentRangeAfterExecute() const;
 
 protected:
-  void onExecute() override;
-  void onUndo() override;
-  void onRedo() override;
+  void onExecute(Context* ctx) override;
+  void onUndo(Context* ctx) override;
+  void onRedo(Context* ctx) override;
   std::string onLabel() const override;
   size_t onMemSize() const override;
 
 private:
-  SpritePosition calcSpritePosition() const;
-  bool isDocRangeEnabled() const;
-  view::RealRange calcDocRange() const;
+  SpritePosition calcSpritePosition(Context* ctx) const;
+  bool isDocRangeEnabled(Context* ctx) const;
+  view::RealRange calcDocRange(Context* ctx) const;
 
   struct Ranges {
     std::stringstream m_before;

--- a/src/app/commands/filters/filter_manager_impl.cpp
+++ b/src/app/commands/filters/filter_manager_impl.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2026  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -219,7 +219,8 @@ void FilterManagerImpl::apply()
     gfx::Rect output;
     if (algorithm::shrink_bounds2(m_src.get(), m_dst.get(), m_bounds, output)) {
       if (m_cel->layer()->isTilemap()) {
-        modify_tilemap_cel_region(*m_tx,
+        modify_tilemap_cel_region(m_writer->context(),
+                                  *m_tx,
                                   m_cel,
                                   nullptr,
                                   gfx::Region(output),

--- a/src/app/commands/move_tiles_command.cpp
+++ b/src/app/commands/move_tiles_command.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (c) 2019-2023  Igara Studio S.A.
+// Copyright (c) 2019-present  Igara Studio S.A.
 //
 // This program is distributed under the terms of
 // the End-User License Agreement for Aseprite.
@@ -64,9 +64,9 @@ protected:
     int currentEntry = picks.firstPick();
 
     if (m_copy)
-      copy_tiles_in_tileset(tx, tileset, picks, currentEntry, beforeIndex);
+      copy_tiles_in_tileset(ctx, tx, tileset, picks, currentEntry, beforeIndex);
     else
-      move_tiles_in_tileset(tx, tileset, picks, currentEntry, beforeIndex);
+      move_tiles_in_tileset(ctx, tx, tileset, picks, currentEntry, beforeIndex);
 
     tx.commit();
 

--- a/src/app/context.h
+++ b/src/app/context.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2023  Igara Studio S.A.
+// Copyright (C) 2018-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -22,6 +22,7 @@
 #include "obs/observable.h"
 #include "obs/signal.h"
 #include "os/surface.h"
+#include "undo/undo_context.h"
 #include "view/range.h"
 
 #include <memory>
@@ -107,7 +108,8 @@ private:
 };
 
 class Context : public obs::observable<ContextObserver>,
-                public DocsObserver {
+                public DocsObserver,
+                public undo::UndoContext {
 public:
   Context();
   virtual ~Context();

--- a/src/app/doc_undo.cpp
+++ b/src/app/doc_undo.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2022-2023  Igara Studio S.A.
+// Copyright (C) 2022-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -87,12 +87,12 @@ void DocUndo::add(CmdTransaction* cmd)
 
 bool DocUndo::canUndo() const
 {
-  return m_undoHistory.canUndo();
+  return m_undoHistory.canUndo(m_ctx);
 }
 
 bool DocUndo::canRedo() const
 {
-  return m_undoHistory.canRedo();
+  return m_undoHistory.canRedo(m_ctx);
 }
 
 void DocUndo::undo()
@@ -105,7 +105,7 @@ void DocUndo::undo()
     ASSERT(state);
     const Cmd* cmd = STATE_CMD(state);
     m_totalUndoSize -= cmd->memSize();
-    m_undoHistory.undo();
+    m_undoHistory.undo(m_ctx);
     m_totalUndoSize += cmd->memSize();
   }
   // This notification could execute a script that modifies the sprite
@@ -127,7 +127,7 @@ void DocUndo::redo()
     ASSERT(state);
     const Cmd* cmd = STATE_CMD(state);
     m_totalUndoSize -= cmd->memSize();
-    m_undoHistory.redo();
+    m_undoHistory.redo(m_ctx);
     m_totalUndoSize += cmd->memSize();
   }
   notify_observers(&DocUndoObserver::onCurrentUndoStateChange, this);
@@ -274,7 +274,7 @@ void DocUndo::moveToState(const undo::UndoState* state)
   ASSERT(!m_undoing);
   base::ScopedValue undoing(m_undoing, true);
 
-  m_undoHistory.moveTo(state);
+  m_undoHistory.moveTo(state, m_ctx);
 
   // After onCurrentUndoStateChange don't use the "state" argument, it
   // might be deleted because some script might have modified the

--- a/src/app/transaction.cpp
+++ b/src/app/transaction.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2018-2023  Igara Studio S.A.
+// Copyright (C) 2018-present  Igara Studio S.A.
 // Copyright (C) 2001-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -90,7 +90,7 @@ void Transaction::commit()
 
   m_doc->notifyBeforeCommitTransaction();
 
-  m_cmds->updateSpritePositionAfter();
+  m_cmds->updateSpritePositionAfter(m_ctx);
   const SpritePosition sprPos = m_cmds->spritePositionAfterExecute();
 
   m_undo->add(m_cmds);
@@ -130,7 +130,7 @@ void Transaction::rollback(CmdTransaction* newCmds)
   ASSERT(m_cmds);
   TX_TRACE("TX: Rollback <%s>\n", m_cmds->label().c_str());
 
-  m_cmds->undo();
+  m_cmds->undo(m_ctx);
 
   delete m_cmds;
   m_cmds = newCmds;

--- a/src/app/ui/color_bar.cpp
+++ b/src/app/ui/color_bar.cpp
@@ -1198,9 +1198,9 @@ void ColorBar::onTilesViewDragAndDrop(doc::Tileset* tileset,
     ContextWriter writer(ctx, 500);
     Tx tx(writer, Strings::color_bar_drag_and_drop_tiles(), ModifyDocument);
     if (isCopy)
-      copy_tiles_in_tileset(tx, tileset, picks, currentEntry, beforeIndex);
+      copy_tiles_in_tileset(ctx, tx, tileset, picks, currentEntry, beforeIndex);
     else
-      move_tiles_in_tileset(tx, tileset, picks, currentEntry, beforeIndex);
+      move_tiles_in_tileset(ctx, tx, tileset, picks, currentEntry, beforeIndex);
     tx.commit();
 
     m_scrollableTilesView.updateView();

--- a/src/app/ui/editor/moving_slice_state.cpp
+++ b/src/app/ui/editor/moving_slice_state.cpp
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2026  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2017-2018  David Capello
 //
 // This program is distributed under the terms of
@@ -487,7 +487,8 @@ gfx::Rect MovingSliceState::selectedSlicesBounds() const
 
 void MovingSliceState::clearSlices()
 {
-  ContextWriter writer(UIContext::instance(), 1000);
+  Context* ctx = UIContext::instance();
+  ContextWriter writer(ctx, 1000);
   if (writer.cel()) {
     std::vector<SliceKey> slicesKeys;
     slicesKeys.reserve(m_items.size());
@@ -496,7 +497,7 @@ void MovingSliceState::clearSlices()
     }
 
     CmdTransaction* cmds = m_tx;
-    cmds->executeAndAdd(new cmd::ClearSlices(m_site, m_selectedLayers, m_frame, slicesKeys));
+    cmds->executeAndAdd(ctx, new cmd::ClearSlices(m_site, m_selectedLayers, m_frame, slicesKeys));
   }
 }
 

--- a/src/app/ui/editor/pixels_movement.cpp
+++ b/src/app/ui/editor/pixels_movement.cpp
@@ -404,7 +404,11 @@ void PixelsMovement::cutMask()
     // Cut from all selected cels, not just the current one
     for (Cel* cel : m_selectedCels) {
       if (cel)
-        clear_mask_from_cel(m_tx, cel, m_site.tilemapMode(), m_site.tilesetMode());
+        clear_mask_from_cel(m_document->context(),
+                            m_tx,
+                            cel,
+                            m_site.tilemapMode(),
+                            m_site.tilesetMode());
     }
   }
 
@@ -1769,7 +1773,11 @@ void PixelsMovement::reproduceAllTransformationsWithInnerCmds()
   for (const InnerCmd& c : m_innerCmds) {
     switch (c.type) {
       case InnerCmd::Clear:
-        clear_mask_from_cel(m_tx, m_site.cel(), m_site.tilemapMode(), m_site.tilesetMode());
+        clear_mask_from_cel(m_document->context(),
+                            m_tx,
+                            m_site.cel(),
+                            m_site.tilemapMode(),
+                            m_site.tilesetMode());
         break;
       case InnerCmd::Flip: flipOriginalImage(c.data.flip.type); break;
       case InnerCmd::Shift:

--- a/src/app/ui/timeline/timeline.cpp
+++ b/src/app/ui/timeline/timeline.cpp
@@ -4260,7 +4260,7 @@ void Timeline::dropRange(DropOp op)
     // TODO improve this workaround
     Cmd* cmd = m_document->undoHistory()->lastExecutedCmd();
     if (auto cmdTx = dynamic_cast<CmdTransaction*>(cmd))
-      cmdTx->updateSpritePositionAfter();
+      cmdTx->updateSpritePositionAfter(UIContext::instance());
   }
   catch (const std::exception& ex) {
     Console::showException(ex);

--- a/src/app/util/cel_ops.cpp
+++ b/src/app/util/cel_ops.cpp
@@ -269,7 +269,8 @@ void create_region_with_differences(const Image* a,
   }
 }
 
-static void remove_unused_tiles_from_tileset(CmdSequence* cmds,
+static void remove_unused_tiles_from_tileset(Context* ctx,
+                                             CmdSequence* cmds,
                                              doc::Tileset* tileset,
                                              std::vector<size_t>& tilesHistogram,
                                              const std::vector<bool>& modifiedTileIndexes);
@@ -549,7 +550,7 @@ void draw_image_into_new_tilemap_cel(CmdSequence* cmds,
       auto addTile = new cmd::AddTile(tileset, tileImage);
 
       if (cmds)
-        cmds->executeAndAdd(addTile);
+        cmds->executeAndAdd(doc->context(), addTile);
       else {
         // TODO a little hacky
         addTile->execute(doc->context());
@@ -580,7 +581,8 @@ void draw_image_into_new_tilemap_cel(CmdSequence* cmds,
   dstCel->setPosition(grid.tileToCanvas(tilemapBounds.origin()));
 }
 
-void modify_tilemap_cel_region(CmdSequence* cmds,
+void modify_tilemap_cel_region(Context* ctx,
+                               CmdSequence* cmds,
                                doc::Cel* cel,
                                doc::Tileset* tileset,
                                const gfx::Region& region,
@@ -719,6 +721,7 @@ void modify_tilemap_cel_region(CmdSequence* cmds,
         // Common case: Re-utilize the same tile in Auto mode.
         tileIndex = ti;
         cmds->executeAndAdd(
+          ctx,
           new cmd::CopyTileRegion(existentTileImage.get(),
                                   tileImage.get(),
                                   gfx::Region(tileImage->bounds()), // TODO calculate better region
@@ -729,7 +732,7 @@ void modify_tilemap_cel_region(CmdSequence* cmds,
       }
       else {
         auto addTile = new cmd::AddTile(tileset, tileImage);
-        cmds->executeAndAdd(addTile);
+        cmds->executeAndAdd(ctx, addTile);
 
         tileIndex = addTile->tileIndex();
       }
@@ -764,18 +767,19 @@ void modify_tilemap_cel_region(CmdSequence* cmds,
     if (newTilemap->size() != cel->image()->size()) {
       gfx::Point newPos = grid.tileToCanvas(newTilemapBounds.origin());
       if (cel->position() != newPos) {
-        cmds->executeAndAdd(new cmd::SetCelPosition(cel, newPos));
+        cmds->executeAndAdd(ctx, new cmd::SetCelPosition(cel, newPos));
       }
-      cmds->executeAndAdd(new cmd::ReplaceImage(cel->sprite(), cel->imageRef(), newTilemap));
+      cmds->executeAndAdd(ctx, new cmd::ReplaceImage(cel->sprite(), cel->imageRef(), newTilemap));
     }
     else if (!tilePtsRgn.isEmpty()) {
       cmds->executeAndAdd(
+        ctx,
         new cmd::CopyRegion(cel->image(), newTilemap.get(), tilePtsRgn, gfx::Point(0, 0)));
     }
 
     // Remove unused tiles
     if (tilesetMode == TilesetMode::Auto) {
-      remove_unused_tiles_from_tileset(cmds, tileset, tilesHistogram, modifiedTileIndexes);
+      remove_unused_tiles_from_tileset(ctx, cmds, tileset, tilesHistogram, modifiedTileIndexes);
     }
 
     doc->notifyTilesetChanged(tileset);
@@ -887,7 +891,8 @@ void modify_tilemap_cel_region(CmdSequence* cmds,
       for (auto& mod : mods) {
         // TODO avoid creating several CopyTileRegion for the same tile,
         //      merge all mods for the same tile in some way
-        cmds->executeAndAdd(new cmd::CopyTileRegion(mod.tileDstImage.get(),
+        cmds->executeAndAdd(ctx,
+                            new cmd::CopyTileRegion(mod.tileDstImage.get(),
                                                     mod.tileImage.get(),
                                                     mod.tileRgn,
                                                     gfx::Point(0, 0),
@@ -905,7 +910,8 @@ void modify_tilemap_cel_region(CmdSequence* cmds,
 #endif
 }
 
-void clear_mask_from_cel(CmdSequence* cmds,
+void clear_mask_from_cel(Context* ctx,
+                         CmdSequence* cmds,
                          doc::Cel* cel,
                          const TilemapMode tilemapMode,
                          const TilesetMode tilesetMode)
@@ -920,7 +926,7 @@ void clear_mask_from_cel(CmdSequence* cmds,
     // Simple case (there is no visible selection, so we remove the
     // whole cel)
     if (!doc->isMaskVisible()) {
-      cmds->executeAndAdd(new cmd::ClearCel(cel));
+      cmds->executeAndAdd(ctx, new cmd::ClearCel(cel));
       return;
     }
 
@@ -928,6 +934,7 @@ void clear_mask_from_cel(CmdSequence* cmds,
     doc::Mask* mask = doc->mask();
 
     modify_tilemap_cel_region(
+      ctx,
       cmds,
       cel,
       nullptr,
@@ -941,11 +948,12 @@ void clear_mask_from_cel(CmdSequence* cmds,
       });
   }
   else {
-    cmds->executeAndAdd(new cmd::ClearMask(cel));
+    cmds->executeAndAdd(ctx, new cmd::ClearMask(cel));
   }
 }
 
-static void remove_unused_tiles_from_tileset(CmdSequence* cmds,
+static void remove_unused_tiles_from_tileset(Context* ctx,
+                                             CmdSequence* cmds,
                                              doc::Tileset* tileset,
                                              std::vector<size_t>& tilesHistogram,
                                              const std::vector<bool>& modifiedTileIndexes)
@@ -995,7 +1003,7 @@ static void remove_unused_tiles_from_tileset(CmdSequence* cmds,
               ti,
               (ti < tilesHistogram.size() ? tilesHistogram[ti] : 0));
     if (ti < tilesHistogram.size() && tilesHistogram[ti] == 0 && modifiedTileIndexes[ti]) {
-      cmds->executeAndAdd(new cmd::RemoveTile(tileset, tj));
+      cmds->executeAndAdd(ctx, new cmd::RemoveTile(tileset, tj));
       // Map to nothing, so the map can be invertible
       remap.notile(ti);
     }
@@ -1010,11 +1018,12 @@ static void remove_unused_tiles_from_tileset(CmdSequence* cmds,
       OPS_TRACE(" - remap tile[%d] -> %d\n", ti, remap[ti]);
     }
 #endif
-    cmds->executeAndAdd(new cmd::RemapTilemaps(tileset, remap));
+    cmds->executeAndAdd(ctx, new cmd::RemapTilemaps(tileset, remap));
   }
 }
 
-void move_tiles_in_tileset(CmdSequence* cmds,
+void move_tiles_in_tileset(Context* ctx,
+                           CmdSequence* cmds,
                            doc::Tileset* tileset,
                            doc::PalettePicks& picks,
                            int& currentEntry,
@@ -1035,11 +1044,11 @@ void move_tiles_in_tileset(CmdSequence* cmds,
   int n = beforeIndex - tileset->size();
   if (n > 0) {
     while (n-- > 0)
-      cmds->executeAndAdd(new cmd::AddTile(tileset, tileset->makeEmptyTile()));
+      cmds->executeAndAdd(ctx, new cmd::AddTile(tileset, tileset->makeEmptyTile()));
   }
 
   Remap remap = create_remap_to_move_picks(picks, beforeIndex);
-  cmds->executeAndAdd(new cmd::RemapTileset(tileset, remap));
+  cmds->executeAndAdd(ctx, new cmd::RemapTileset(tileset, remap));
 
   // New selection
   auto oldPicks = picks;
@@ -1048,7 +1057,8 @@ void move_tiles_in_tileset(CmdSequence* cmds,
   currentEntry = remap[currentEntry];
 }
 
-void copy_tiles_in_tileset(CmdSequence* cmds,
+void copy_tiles_in_tileset(Context* ctx,
+                           CmdSequence* cmds,
                            doc::Tileset* tileset,
                            doc::PalettePicks& picks,
                            int& currentEntry,
@@ -1095,10 +1105,10 @@ void copy_tiles_in_tileset(CmdSequence* cmds,
       // Fill the gap between the end of the tileset and the
       // "beforeIndex" with empty tiles
       while (tileset->size() < i)
-        cmds->executeAndAdd(new cmd::AddTile(tileset, tileset->makeEmptyTile()));
+        cmds->executeAndAdd(ctx, new cmd::AddTile(tileset, tileset->makeEmptyTile()));
       tileset->insert(i, newTiles[j], newDatas[j]);
       j++;
-      cmds->executeAndAdd(new cmd::AddTile(tileset, i));
+      cmds->executeAndAdd(ctx, new cmd::AddTile(tileset, i));
     }
   }
 }

--- a/src/app/util/cel_ops.h
+++ b/src/app/util/cel_ops.h
@@ -1,5 +1,5 @@
 // Aseprite
-// Copyright (C) 2019-2021  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2001-2016  David Capello
 //
 // This program is distributed under the terms of
@@ -31,6 +31,7 @@ class Tileset;
 
 namespace app {
 class CmdSequence;
+class Context;
 
 typedef std::function<doc::ImageRef(const doc::ImageRef& origTile,
                                     const gfx::Rect& tileBoundsInCanvas)>
@@ -62,7 +63,8 @@ void draw_image_into_new_tilemap_cel(CmdSequence* cmds,
                                      const gfx::Rect& canvasBounds,
                                      doc::ImageRef& newTilemap);
 
-void modify_tilemap_cel_region(CmdSequence* cmds,
+void modify_tilemap_cel_region(Context* ctx,
+                               CmdSequence* cmds,
                                doc::Cel* cel,
                                doc::Tileset* previewTileset, // Temporary tileset that can be used
                                                              // for preview
@@ -71,18 +73,21 @@ void modify_tilemap_cel_region(CmdSequence* cmds,
                                const GetTileImageFunc& getTileImage,
                                const gfx::Region& forceRegion = gfx::Region());
 
-void clear_mask_from_cel(CmdSequence* cmds,
+void clear_mask_from_cel(Context* ctx,
+                         CmdSequence* cmds,
                          doc::Cel* cel,
                          const TilemapMode tilemapMode,
                          const TilesetMode tilesetMode);
 
-void move_tiles_in_tileset(CmdSequence* cmds,
+void move_tiles_in_tileset(Context* ctx,
+                           CmdSequence* cmds,
                            doc::Tileset* tileset,
                            doc::PalettePicks& picks,
                            int& currentEntry,
                            int beforeIndex);
 
-void copy_tiles_in_tileset(CmdSequence* cmds,
+void copy_tiles_in_tileset(Context* ctx,
+                           CmdSequence* cmds,
                            doc::Tileset* tileset,
                            doc::PalettePicks& picks,
                            int& currentEntry,

--- a/src/app/util/clipboard.cpp
+++ b/src/app/util/clipboard.cpp
@@ -331,10 +331,12 @@ void Clipboard::clearMaskFromCels(Tx& tx,
                                   const CelList& cels,
                                   const bool deselectMask)
 {
+  Context* ctx = doc->context();
+
   for (Cel* cel : cels) {
     ObjectId celId = cel->id();
 
-    clear_mask_from_cel(tx, cel, site.tilemapMode(), site.tilesetMode());
+    clear_mask_from_cel(ctx, tx, cel, site.tilemapMode(), site.tilesetMode());
 
     // Get cel again just in case the cmd::ClearMask() called cmd::ClearCel()
     cel = doc::get<Cel>(celId);

--- a/src/app/util/expand_cel_canvas.cpp
+++ b/src/app/util/expand_cel_canvas.cpp
@@ -213,6 +213,9 @@ void ExpandCelCanvas::commit()
     return;
   }
 
+  Context* ctx = m_document->context();
+  ASSERT(ctx);
+
   // Was the cel created in the start of the tool-loop?
   if ((m_celCreated) ||
       // Was the cel without an image when the tool-loop started?
@@ -256,15 +259,15 @@ void ExpandCelCanvas::commit()
             m_cel->setPosition(newPosition);
           }
           else {
-            m_cmds->executeAndAdd(new cmd::SetCelImage(m_cel, newImage));
-            m_cmds->executeAndAdd(new cmd::SetCelPosition(m_cel, newPosition));
+            m_cmds->executeAndAdd(ctx, new cmd::SetCelImage(m_cel, newImage));
+            m_cmds->executeAndAdd(ctx, new cmd::SetCelPosition(m_cel, newPosition));
           }
         }
 
         // Add the cel again into the layer with a transaction.
         if (m_celCreated) {
           m_layer->removeCel(m_cel);
-          m_cmds->executeAndAdd(new cmd::AddCel(m_layer, m_cel));
+          m_cmds->executeAndAdd(ctx, new cmd::AddCel(m_layer, m_cel));
         }
       }
       else {
@@ -276,7 +279,7 @@ void ExpandCelCanvas::commit()
           m_cel = nullptr;
         }
         else {
-          m_cmds->executeAndAdd(new cmd::SetCelImage(m_cel, nullptr));
+          m_cmds->executeAndAdd(ctx, new cmd::SetCelImage(m_cel, nullptr));
         }
       }
     }
@@ -338,7 +341,8 @@ void ExpandCelCanvas::commit()
         // of relative to the m_cel).
         regionToPatch->offset(m_bounds.origin());
 
-        modify_tilemap_cel_region(m_cmds,
+        modify_tilemap_cel_region(ctx,
+                                  m_cmds,
                                   m_cel,
                                   nullptr,
                                   *regionToPatch,
@@ -363,7 +367,8 @@ void ExpandCelCanvas::commit()
                                          m_dstTileset->get(ti)->bounds(),
                                          diffRgn);
           if (!diffRgn.isEmpty()) {
-            m_cmds->executeAndAdd(new cmd::CopyTileRegion(srcTileset->get(ti).get(),
+            m_cmds->executeAndAdd(ctx,
+                                  new cmd::CopyTileRegion(srcTileset->get(ti).get(),
                                                           m_dstTileset->get(ti).get(),
                                                           diffRgn,
                                                           gfx::Point(0, 0),
@@ -382,6 +387,7 @@ void ExpandCelCanvas::commit()
         ASSERT(m_celImage.get() == m_cel->image());
 
         m_cmds->executeAndAdd(
+          ctx,
           new cmd::CopyRegion(m_cel->image(), m_dstImage.get(), *regionToPatch, m_bounds.origin()));
       }
       else if (m_tilemapMode == TilemapMode::Tiles) {
@@ -393,12 +399,14 @@ void ExpandCelCanvas::commit()
         EXP_TRACE(" - Tilemap bounds to patch", regionInCanvas.bounds());
 
         m_cmds->executeAndAdd(
+          ctx,
           new cmd::PatchCel(m_cel, m_dstImage.get(), regionInCanvas, m_grid.origin()));
       }
       else {
         ASSERT(m_celImage.get() == m_cel->image());
 
         m_cmds->executeAndAdd(
+          ctx,
           new cmd::PatchCel(m_cel, m_dstImage.get(), *regionToPatch, m_bounds.origin()));
       }
     }
@@ -658,6 +666,7 @@ void ExpandCelCanvas::validateDestTileset(const gfx::Region& rgn, const gfx::Reg
   if (m_dstTileset) {
     gfx::Region regionToPatch = rgn;
     modify_tilemap_cel_region(
+      m_document->context(),
       m_cmds,
       m_cel,
       m_dstTileset.get(),


### PR DESCRIPTION
This removes the `Cmd::m_ctx` member and `Cmd::context()` member function.