### PR TITLE
[lua] Add xFlip, yFlip and dFlip to ConvertLayer params

### DIFF
--- a/src/app/commands/convert_layer.cpp
+++ b/src/app/commands/convert_layer.cpp
@@ -63,6 +63,9 @@ void Param<ConvertLayerParam>::fromLua(lua_State* L, int index)
 
 struct ConvertLayerParams : public NewParams {
   Param<bool> ui{ this, true, "ui" };
+  Param<bool> xFlip{ this, false, "xFlip" };
+  Param<bool> yFlip{ this, false, "yFlip" };
+  Param<bool> dFlip{ this, false, "dFlip" };
   Param<ConvertLayerParam> to{ this, ConvertLayerParam::None, "to" };
 };
 
@@ -134,7 +137,9 @@ void ConvertLayerCommand::onExecute(Context* ctx)
   // Default options to convert a layer to a tilemap
   std::string tilesetName;
   int baseIndex = 1;
-  tile_flags matchFlags = 0;
+  tile_flags matchFlags = (params().xFlip() ? doc::tile_f_xflip : 0) |
+                          (params().yFlip() ? doc::tile_f_yflip : 0) |
+                          (params().dFlip() ? doc::tile_f_dflip : 0);
   Grid grid0 = site.grid();
   grid0.origin(gfx::Point(0, 0));
 

--- a/src/app/commands/convert_layer.cpp
+++ b/src/app/commands/convert_layer.cpp
@@ -150,6 +150,7 @@ void ConvertLayerCommand::onExecute(Context* ctx)
     tilesetInfo.allowNewTileset = true;
     tilesetInfo.allowExistentTileset = false;
     tilesetInfo.grid = grid0;
+    tilesetInfo.matchFlags = matchFlags;
 
     gen::TilesetSelectorWindow window;
     TilesetSelector tilesetSel(sprite, tilesetInfo);

--- a/src/app/commands/convert_layer.cpp
+++ b/src/app/commands/convert_layer.cpp
@@ -63,9 +63,7 @@ void Param<ConvertLayerParam>::fromLua(lua_State* L, int index)
 
 struct ConvertLayerParams : public NewParams {
   Param<bool> ui{ this, true, "ui" };
-  Param<bool> xFlip{ this, false, "xFlip" };
-  Param<bool> yFlip{ this, false, "yFlip" };
-  Param<bool> dFlip{ this, false, "dFlip" };
+  Param<int> allowedFlips{ this, 0, "allowedFlips" };
   Param<ConvertLayerParam> to{ this, ConvertLayerParam::None, "to" };
 };
 
@@ -137,9 +135,7 @@ void ConvertLayerCommand::onExecute(Context* ctx)
   // Default options to convert a layer to a tilemap
   std::string tilesetName;
   int baseIndex = 1;
-  tile_flags matchFlags = (params().xFlip() ? doc::tile_f_xflip : 0) |
-                          (params().yFlip() ? doc::tile_f_yflip : 0) |
-                          (params().dFlip() ? doc::tile_f_dflip : 0);
+  tile_flags matchFlags = params().allowedFlips();
   Grid grid0 = site.grid();
   grid0.origin(gfx::Point(0, 0));
 


### PR DESCRIPTION
Adds optional `xFlip`, `vFlip` and `dFlip` boolean params to the `ConvertLayer` command, matching the UI functionality when converting a layer to a tilemap. The values default to `false` when not provided, so match the existing behaviour and maintain backwards compatibility with existing scripts.

Usage (Lua):
```lua
app.command.ConvertLayer{ ui=false, to="tilemap", xFlip=true, yFlip=true, dFlip=true }
```

I declare that my contributions are not co-authored using a generative AI technology.

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing
