### PR TITLE
Update drawing positions before delayed movement commits

### DIFF
--- a/src/app/ui/editor/delayed_mouse_move.cpp
+++ b/src/app/ui/editor/delayed_mouse_move.cpp
@@ -123,6 +123,7 @@ bool DelayedMouseMove::updateSpritePos(const ui::MouseMessage* msg)
   // touch the viewport borders.
   const gfx::Point mousePos = m_editor->autoScroll(msg, AutoScroll::MouseDir);
   const gfx::PointF spritePos = m_editor->screenToEditorF(mousePos);
+  m_delegate->onUpdateMousePosition(m_editor, mousePos);
 
   // Avoid redrawing everything if the position in the canvas didn't
   // change.

--- a/src/app/ui/editor/delayed_mouse_move.cpp
+++ b/src/app/ui/editor/delayed_mouse_move.cpp
@@ -81,7 +81,7 @@ bool DelayedMouseMove::onMouseMove(const ui::MouseMessage* msg)
 
 void DelayedMouseMove::onMouseUp(const ui::MouseMessage* msg)
 {
-  if (updateSpritePos(msg))
+  if (updateSpritePos(msg) || m_timer.isRunning())
     commitMouseMove();
 }
 

--- a/src/app/ui/editor/delayed_mouse_move.h
+++ b/src/app/ui/editor/delayed_mouse_move.h
@@ -23,6 +23,8 @@ class Editor;
 class DelayedMouseMoveDelegate {
 public:
   virtual ~DelayedMouseMoveDelegate() {}
+  // Called after auto-scroll, before a movement can be committed.
+  virtual void onUpdateMousePosition(Editor* editor, const gfx::Point& mousePos) {}
   virtual void onCommitMouseMove(Editor* editor, const gfx::PointF& spritePos) = 0;
 };
 

--- a/src/app/ui/editor/drawing_state.cpp
+++ b/src/app/ui/editor/drawing_state.cpp
@@ -267,11 +267,7 @@ bool DrawingState::onMouseMove(Editor* editor, MouseMessage* msg)
   m_velocity.updateWithDisplayPoint(msg->position());
 
   // Update pointer with new mouse position
-  m_lastPointer = tools::Pointer(gfx::Point(m_delayedMouseMove.spritePos()),
-                                 m_velocity.velocity(),
-                                 button_from_msg(msg),
-                                 msg->pointerType(),
-                                 msg->pressure());
+  m_lastPointer = pointer_from_msg(editor, msg, m_velocity.velocity());
 
   // Use DelayedMouseMove for tools like line, rectangle, etc. (that
   // use the only the last mouse position) to filter out rapid mouse
@@ -280,14 +276,18 @@ bool DrawingState::onMouseMove(Editor* editor, MouseMessage* msg)
   return true;
 }
 
+void DrawingState::onUpdateMousePosition(Editor* editor, const gfx::Point& mousePos)
+{
+  m_lastPointer = tools::Pointer(editor->screenToEditor(mousePos),
+                                 m_lastPointer.velocity(),
+                                 m_lastPointer.button(),
+                                 m_lastPointer.type(),
+                                 m_lastPointer.pressure());
+}
+
 void DrawingState::onCommitMouseMove(Editor* editor, const gfx::PointF& spritePos)
 {
   if (m_toolLoop && m_toolLoopManager && !m_toolLoopManager->isCanceled()) {
-    m_lastPointer = tools::Pointer(gfx::Point(spritePos),
-                                   m_lastPointer.velocity(),
-                                   m_lastPointer.button(),
-                                   m_lastPointer.type(),
-                                   m_lastPointer.pressure());
     handleMouseMovement();
   }
 }

--- a/src/app/ui/editor/drawing_state.cpp
+++ b/src/app/ui/editor/drawing_state.cpp
@@ -283,6 +283,11 @@ bool DrawingState::onMouseMove(Editor* editor, MouseMessage* msg)
 void DrawingState::onCommitMouseMove(Editor* editor, const gfx::PointF& spritePos)
 {
   if (m_toolLoop && m_toolLoopManager && !m_toolLoopManager->isCanceled()) {
+    m_lastPointer = tools::Pointer(gfx::Point(spritePos),
+                                   m_lastPointer.velocity(),
+                                   m_lastPointer.button(),
+                                   m_lastPointer.type(),
+                                   m_lastPointer.pressure());
     handleMouseMovement();
   }
 }

--- a/src/app/ui/editor/drawing_state.h
+++ b/src/app/ui/editor/drawing_state.h
@@ -77,6 +77,7 @@ private:
   void destroyLoop(Editor* editor);
 
   // DelayedMouseMoveDelegate impl
+  void onUpdateMousePosition(Editor* editor, const gfx::Point& mousePos) override;
   void onCommitMouseMove(Editor* editor, const gfx::PointF& spritePos) override;
 
   Editor* m_editor;


### PR DESCRIPTION
Related to #6028. This PR is closed; the [debugging findings and test results](https://github.com/aseprite/aseprite/issues/6028#issuecomment-5593229236) are recorded in the issue.

On Windows, automated Pencil drags could leave just the starting pixel, and Rectangular Marquee could produce a 1 x 1 selection. With this patch, the same gestures produced a connected 301-pixel line and a 301 x 151 selection.

The patch updates DrawingState's pointer after auto-scroll returns the adjusted mouse position, before a delayed movement can commit. It uses the existing integer `screenToEditor` conversion and preserves the pointer metadata. Mouse-up also flushes a pending movement when the release position hasn't changed. The diff is four source files, +15/-6.

The first version updated the pointer at commit time, which could overwrite a newer scroll position. The revision removes that overwrite. A controlled test reproduced the regression in the first patch and verified the revised behavior. Negative-coordinate checks also confirmed consistent commit/release conversion. Details are in the issue.

Tested on locally built v1.3.18.3 sources with MSVC x64 and Skia:

- Build/link, repository formatting checks and `git diff --check` passed.
- Native GUI checks covered Pencil, Marquee, pixel/cel/text movement, undo/redo, cancellation after release, and Line/Rectangle edge auto-scroll. Saved PNGs were checked for pixel counts and preservation.
- A local probe passed 16 checks, including 84 coordinate/zoom/pixel-ratio combinations. It uses production methods with substitute editor/timer scheduling, so it isn't the upstream test suite.

I also ran additional manual checks, without a per-case log. A full current-main build and exhaustive hardware/GUI coverage haven't been verified.

The investigation and patch were developed with Codex assistance.
